### PR TITLE
dev: improvement cache hit on GetPR

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 
 	if *testFlag {
-		content, err := server.GetFullPRResponse("C-Hipple", "gtdbot", 9, false)
+		content, err := server.GetFullPRResponse("C-Hipple", "gtdbot", 9, false, nil)
 		if err != nil {
 			slog.Error("Error getting PR response", "error", err)
 			os.Exit(1)

--- a/server/server.go
+++ b/server/server.go
@@ -149,9 +149,8 @@ func (h *RPCHandler) fetchPRAndRunPlugins(owner, repo string, number int, skipCa
 	go RunPlugins(owner, repo, number, sha, details.Diff, commentsJSON, string(metadataJSON))
 
 	// Get the full formatted response for the UI.
-	// Since GetPRDetails already refreshed the cache if skipCache was true,
-	// we use false here to avoid redundant API calls.
-	content, _ := GetFullPRResponse(owner, repo, number, false)
+	// We pass the already fetched details to avoid redundant API calls.
+	content, _ := GetFullPRResponse(owner, repo, number, false, details)
 
 	return details, content, nil
 }


### PR DESCRIPTION
## PR Description for #17: Optimize GetFullPRResponse and Reduce API Calls

### Summary
This PR optimizes the `GetFullPRResponse` function to significantly reduce redundant GitHub API calls when rendering a pull request. By passing the already-fetched `PRDetails` object to the renderer, we avoid re-fetching metadata, comments, reviews, CI status, and the diff.

### Changes
*   **Consolidated Data Fetching**: Added a `CommitJSON` struct and a `Commits` field to the `PRDetails` struct, moving commit fetching into `GetPRDetails`.
*   **Refactored `GetFullPRResponse`**: Updated the function signature to accept `*PRDetails`. It now utilizes fields from this structure (Metadata, Reviews, Comments, Commits, Diff, and CI status) to build the response string.
*   **Improved Performance**: Eliminated multiple redundant API calls per PR view by reusing data for:
    *   PR Metadata (Title, Author, Refs, State, etc.)
    *   Requested Reviewers and Teams
    *   Completed Reviews and their states
    *   Unified Issue and PR Comments
    *   CI Status and failure details
    *   The PR Diff itself
*   **Infrastructure Improvements**: Added a `JSONPRComment` adapter to bridge `CommentJSON` data with existing comment-tree building logic in the renderer.
*   **Call Site Updates**: Updated `server.go` and `main.go` to support the new function signature.

### Verification
*   Verified that the project builds successfully (`go build .`).
*   Ensured `GetFullPRResponse` maintains a fallback mechanism to fetch data manually if `PRDetails` is passed as `nil` (preserving compatibility with one-off or test callers).