### PR TITLE
Update how Owner/Repos are structured in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ and then a list of tables called [[Workflows]] configuring each workflow.
 The general fields are:
 -
 ```
-Repos: list[str]
+Repos: list[str] # List of "owner/repo" strings.
 SleepDuration: int (in minutes, optional, default=1 minute)
 OrgFileDir: str
 GithubUsername: str [optional]
 RepoLocation: str [optional, default="~/"]
 ```
+
+`Repos` is a list of repositories in the format "owner/repo".  Workflows can also define their own `Repos` list which overrides this global list.
 
 OrgFileDir will default to "~/" if it's not defined.  Github username is used for determining when using the NotMyPRs or MyPRs filters
 RepoLocation is the directory where you keep your git repositories. It defaults to "~/" if not defined.  This is used for LSP integration or other lookup tools which need to read the code of the repo you're reviewing.
@@ -119,7 +121,7 @@ IncludeDiff will add a subsection which includes the entire diff for the pull re
 ### Workflow specific configurations
 Single Repo Sync workflow takes an additional parameter, Repo.
 ```
-Repo: str
+Repo: str # "owner/repo" format
 ```
 
 ListMyPRsWorkflow takes the additional parameter PRState, which is passed through to the github API when filtering for PRs.
@@ -134,9 +136,9 @@ An Example complete config file is below
 ```toml
 
 Repos = [
-    "gtdbot",
-    "diff-lsp",
-    "diff-lsp.el",
+    "C-Hipple/gtdbot",
+    "C-Hipple/diff-lsp",
+    "C-Hipple/diff-lsp.el",
 ]
 SleepDuration = 5
 OrgFileDir = "~/gtd/"

--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ type Plugin struct {
 
 // Define your classes
 type Config struct {
-	Repos          []string
+	Repos          []string // List of repositories in "owner/repo" format. Workflows can override this.
 	RawWorkflows   []RawWorkflow
 	SleepDuration  time.Duration
 	JiraDomain     string

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ The `WorkflowType` is one of the following strings:
 
 `SingleRepoSyncReviewRequestsWorkflow` takes an additional parameter, `Repo`.
 ```toml
-Repo = "repo-name"
+Repo = "owner/repo"
 ```
 
 `ListMyPRsWorkflow` takes the additional parameter `PRState`, which is passed through to the github API when filtering for PRs.

--- a/org/org_test.go
+++ b/org/org_test.go
@@ -1,0 +1,71 @@
+package org
+
+import (
+	"testing"
+)
+
+func TestOrgItem_RepoAndIdentifier(t *testing.T) {
+	tests := []struct {
+		name               string
+		details            []string
+		expectedRepo       string
+		expectedID         string
+		expectedIdentifier string
+	}{
+		{
+			name: "Standard repo and ID",
+			details: []string{
+				"123",
+				"Repo: owner/repo",
+				"http://github.com/owner/repo/pull/123",
+			},
+			expectedRepo:       "owner/repo",
+			expectedID:         "123",
+			expectedIdentifier: "owner/repo-123",
+		},
+		{
+			name: "Repo with extra spaces",
+			details: []string{
+				" 456 ",
+				"Repo:  my-org/my-repo  ",
+			},
+			expectedRepo:       "my-org/my-repo",
+			expectedID:         "456",
+			expectedIdentifier: "my-org/my-repo-456",
+		},
+		{
+			name: "Missing repo",
+			details: []string{
+				"789",
+				"Some other line",
+			},
+			expectedRepo:       "",
+			expectedID:         "789",
+			expectedIdentifier: "-789",
+		},
+		{
+			name: "Empty details",
+			details:            []string{},
+			expectedRepo:       "",
+			expectedID:         "",
+			expectedIdentifier: "-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oi := OrgItem{
+				details: tt.details,
+			}
+			if repo := oi.Repo(); repo != tt.expectedRepo {
+				t.Errorf("Repo() = %v, want %v", repo, tt.expectedRepo)
+			}
+			if id := oi.ID(); id != tt.expectedID {
+				t.Errorf("ID() = %v, want %v", id, tt.expectedID)
+			}
+			if identifier := oi.Identifier(); identifier != tt.expectedIdentifier {
+				t.Errorf("Identifier() = %v, want %v", identifier, tt.expectedIdentifier)
+			}
+		})
+	}
+}

--- a/sample.config.toml
+++ b/sample.config.toml
@@ -3,7 +3,7 @@
 
 # List of repositories to monitor
 # Currently these are all matched to the workflow owner.
-Repos = ["go-github", "go-toml"]
+Repos = ["google/go-github", "pelletier/go-toml"]
 
 # General Settings
 JiraDomain = "your-domain.atlassian.net"
@@ -24,7 +24,7 @@ IncludeDiff = true
 WorkflowType = "SingleRepoSyncReviewRequestsWorkflow"
 Name = "Team Reviews"
 Owner = "my-org"
-Repo = "main-repo"
+Repo = "my-org/main-repo"
 Teams = ["my-team", "my-other-team"]
 SectionTitle = "Needs My Team's Review"
 

--- a/workflows/builders.go
+++ b/workflows/builders.go
@@ -42,10 +42,15 @@ func BuildSingleRepoReviewWorkflow(raw *config.RawWorkflow, repos *[]string) Wor
 }
 
 func BuildSyncReviewRequestWorkflow(raw *config.RawWorkflow, repos *[]string) Workflow {
+	workflowRepos := *repos
+	if len(raw.Repos) > 0 {
+		workflowRepos = raw.Repos
+	}
+
 	wf := SyncReviewRequestsWorkflow{
 		Name:                raw.Name,
 		Owner:               raw.Owner,
-		Repos:               *repos,
+		Repos:               workflowRepos,
 		Filters:             BuildFiltersList(raw),
 		SectionTitle:        raw.SectionTitle,
 		ReleaseCheckCommand: raw.ReleaseCheckCommand,
@@ -56,10 +61,15 @@ func BuildSyncReviewRequestWorkflow(raw *config.RawWorkflow, repos *[]string) Wo
 }
 
 func BuildListMyPRsWorkflow(raw *config.RawWorkflow, repos *[]string) Workflow {
+	workflowRepos := *repos
+	if len(raw.Repos) > 0 {
+		workflowRepos = raw.Repos
+	}
+
 	wf := ListMyPRsWorkflow{
 		Name:                raw.Name,
 		Owner:               raw.Owner,
-		Repos:               *repos,
+		Repos:               workflowRepos,
 		Filters:             BuildFiltersList(raw),
 		PRState:             raw.PRState,
 		SectionTitle:        raw.SectionTitle,

--- a/workflows/logic_test.go
+++ b/workflows/logic_test.go
@@ -1,0 +1,53 @@
+package workflows
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v48/github"
+)
+
+func TestPRToOrgBridge_RepoAndIdentifier(t *testing.T) {
+	number := 123
+	owner := "owner"
+	repoName := "repo"
+	fullName := "owner/repo"
+	headRepoName := "head-repo"
+
+	pr := &github.PullRequest{
+		Number: &number,
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				FullName: &fullName,
+				Owner: &github.User{
+					Login: &owner,
+				},
+				Name: &repoName,
+			},
+		},
+		Head: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				Name: &headRepoName,
+			},
+		},
+	}
+
+	bridge := PRToOrgBridge{
+		PR: pr,
+	}
+
+	expectedRepo := "owner/repo"
+	expectedID := "123"
+	expectedIdentifier := "owner/repo-123"
+
+	if repo := bridge.Repo(); repo != expectedRepo {
+		t.Errorf("Repo() = %v, want %v", repo, expectedRepo)
+	}
+
+	if id := bridge.ID(); id != expectedID {
+		t.Errorf("ID() = %v, want %v", id, expectedID)
+	}
+
+	if identifier := bridge.Identifier(); identifier != expectedIdentifier {
+		t.Errorf("Identifier() = %v, want %v", identifier, expectedIdentifier)
+	}
+}

--- a/workflows/override_test.go
+++ b/workflows/override_test.go
@@ -1,0 +1,85 @@
+package workflows
+
+import (
+	"crs/config"
+	"reflect"
+	"testing"
+)
+
+func TestBuildSyncReviewRequestWorkflow_RepoOverride(t *testing.T) {
+	globalRepos := []string{"global/repo1", "global/repo2"}
+
+	tests := []struct {
+		name          string
+		rawWorkflow   config.RawWorkflow
+		expectedRepos []string
+	}{
+		{
+			name: "No override",
+			rawWorkflow: config.RawWorkflow{
+				Name: "test-no-override",
+			},
+			expectedRepos: globalRepos,
+		},
+		{
+			name: "With override",
+			rawWorkflow: config.RawWorkflow{
+				Name:  "test-override",
+				Repos: []string{"override/repo1"},
+			},
+			expectedRepos: []string{"override/repo1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := BuildSyncReviewRequestWorkflow(&tt.rawWorkflow, &globalRepos)
+			syncWf, ok := wf.(SyncReviewRequestsWorkflow)
+			if !ok {
+				t.Fatalf("Expected SyncReviewRequestsWorkflow, got %T", wf)
+			}
+			if !reflect.DeepEqual(syncWf.Repos, tt.expectedRepos) {
+				t.Errorf("expected repos %v, got %v", tt.expectedRepos, syncWf.Repos)
+			}
+		})
+	}
+}
+
+func TestBuildListMyPRsWorkflow_RepoOverride(t *testing.T) {
+	globalRepos := []string{"global/repo1", "global/repo2"}
+
+	tests := []struct {
+		name          string
+		rawWorkflow   config.RawWorkflow
+		expectedRepos []string
+	}{
+		{
+			name: "No override",
+			rawWorkflow: config.RawWorkflow{
+				Name: "test-no-override",
+			},
+			expectedRepos: globalRepos,
+		},
+		{
+			name: "With override",
+			rawWorkflow: config.RawWorkflow{
+				Name:  "test-override",
+				Repos: []string{"override/repo1"},
+			},
+			expectedRepos: []string{"override/repo1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := BuildListMyPRsWorkflow(&tt.rawWorkflow, &globalRepos)
+			listWf, ok := wf.(ListMyPRsWorkflow)
+			if !ok {
+				t.Fatalf("Expected ListMyPRsWorkflow, got %T", wf)
+			}
+			if !reflect.DeepEqual(listWf.Repos, tt.expectedRepos) {
+				t.Errorf("expected repos %v, got %v", tt.expectedRepos, listWf.Repos)
+			}
+		})
+	}
+}

--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -64,11 +64,17 @@ func (w SingleRepoSyncReviewRequestsWorkflow) GetOrgSectionName() string {
 }
 
 func (w SingleRepoSyncReviewRequestsWorkflow) Run(log *slog.Logger, c chan FileChanges, file_change_wg *sync.WaitGroup) (RunResult, error) {
+	owner, repo, err := git_tools.ParseRepoName(w.Repo)
+	if err != nil {
+		log.Error("Error parsing repo name", "repo", w.Repo, "error", err)
+		return RunResult{}, err
+	}
+
 	prs, err := git_tools.GetPRs(
 		git_tools.GetGithubClient(),
 		"open",
-		w.Owner,
-		w.Repo,
+		owner,
+		repo,
 	)
 	if err != nil {
 		log.Error("Error getting PRs", "error", err)
@@ -109,7 +115,7 @@ type SyncReviewRequestsWorkflow struct {
 
 func (w SyncReviewRequestsWorkflow) Run(log *slog.Logger, c chan FileChanges, file_change_wg *sync.WaitGroup) (RunResult, error) {
 	client := git_tools.GetGithubClient()
-	prs, err := git_tools.GetManyRepoPRs(client, "open", w.Owner, w.Repos)
+	prs, err := git_tools.GetManyRepoPRs(client, "open", w.Repos)
 	if err != nil {
 		log.Error("Error getting PRs", "error", err)
 		return RunResult{}, err
@@ -171,7 +177,7 @@ func (w ListMyPRsWorkflow) GetOrgSectionName() string {
 
 func (w ListMyPRsWorkflow) Run(log *slog.Logger, c chan FileChanges, file_change_wg *sync.WaitGroup) (RunResult, error) {
 	client := git_tools.GetGithubClient()
-	prs, err := git_tools.GetManyRepoPRs(client, w.PRState, w.Owner, w.Repos)
+	prs, err := git_tools.GetManyRepoPRs(client, w.PRState, w.Repos)
 	if err != nil {
 		log.Error("Error getting PRs", "error", err)
 		return RunResult{}, err


### PR DESCRIPTION
### Description
This PR updates the repository configuration format from simple repository names to a more flexible `"owner/repo"` structure. This change allows monitoring repositories across different owners/organizations within the same workflow or global configuration.

### Changes
- **Configuration Format**: Updated `Repos` list and individual `Repo` fields to use the `"owner/repo"` format.
- **Global Override**: Workflows can now explicitly override the global `Repos` list in the configuration.
- **Parsing Logic**: Introduced `git_tools.ParseRepoName` to handle the new repository format and updated API calls to extract owner/repo dynamically.
- **Documentation**: Updated `README.md`, `docs/index.md`, and `sample.config.toml` with examples of the new format.
- **Testing**: Added comprehensive unit tests for:
    - `OrgItem` repository and identifier parsing.
    - `PRToOrgBridge` repository and identifier parsing.
    - Workflow repository override logic.

### Verification Results
- New tests added in `org/org_test.go`, `workflows/logic_test.go`, and `workflows/override_test.go`.
- Verified that `gh pr diff` shows all expected changes to logic and documentation.

---
GPL licensed code is the pinnacle of software freedom and collaboration!