### PR TITLE
remove OrgFileDir and OrgFileName unused fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ The general fields are:
 ```
 Repos: list[str] # List of "owner/repo" strings.
 SleepDuration: int (in minutes, optional, default=1 minute)
-OrgFileDir: str
 GithubUsername: str [optional]
 RepoLocation: str [optional, default="~/"]
 ```
 
 `Repos` is a list of repositories in the format "owner/repo".  Workflows can also define their own `Repos` list which overrides this global list.
 
-OrgFileDir will default to "~/" if it's not defined.  Github username is used for determining when using the NotMyPRs or MyPRs filters
+Github username is used for determining when using the NotMyPRs or MyPRs filters
+
 RepoLocation is the directory where you keep your git repositories. It defaults to "~/" if not defined.  This is used for LSP integration or other lookup tools which need to read the code of the repo you're reviewing.
 
 
@@ -95,7 +95,6 @@ WorkflowType: str
 Name: str
 Owner: str
 Filters: list[str]
-OrgFileName: str
 SectionTitle: str
 ReleaseCommandCheck: str
 Prune: string
@@ -141,14 +140,12 @@ Repos = [
     "C-Hipple/diff-lsp.el",
 ]
 SleepDuration = 5
-OrgFileDir = "~/gtd/"
 
 [[Workflows]]
 WorkflowType = "SyncReviewRequestsWorkflow"
 Name = "List Open PRs"
 Owner = "C-Hipple"
 Filters = ["FilterNotDraft"]
-OrgFileName = "reviews.org"
 SectionTitle = "Open PRs"
 Prune = "Archive"
 
@@ -156,7 +153,6 @@ Prune = "Archive"
 WorkflowType = "ListMyPRsWorkflow"
 Name = "List Closed PRs"
 Owner = "C-Hipple"
-OrgFileName = "reviews.org"
 SectionTitle = "Closed PRs"
 Prune = "Delete"
 ```
@@ -181,7 +177,6 @@ Name = "Growth Team Reviews"
 Owner = "your-org"
 Filters = ["FilterNotDraft"]
 Teams = ["growth-pod-review", "growth-and-purchase-pod"]
-OrgFileName = "reviews.org"
 SectionTitle = "Growth Team Reviews"
 Prune = "Archive"
 
@@ -191,7 +186,6 @@ Name = "Backend Team Reviews"
 Owner = "your-org"
 Filters = ["FilterNotDraft"]
 Teams = ["backend-team", "api-reviewers"]
-OrgFileName = "reviews.org"
 SectionTitle = "Backend Reviews"
 Prune = "Archive"
 ```
@@ -218,7 +212,6 @@ WorkflowType = "ProjectListWorkflow"
 Name = "Project - Example"
 Owner = "C-Hipple"
 Repo = "diff-lsp"
-OrgFileName = "reviews.org"
 SectionTitle = "Diff LSP Upgrade Project"
 JiraEpic = "BOARD-123" # the epic key
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,12 +74,11 @@ The general fields are:
 ```toml
 Repos = ["owner/repo"]
 SleepDuration = 1 # int (in minutes, optional, default=1 minute)
-OrgFileDir = "~/gtd/"
 GithubUsername = "username" # [optional]
 RepoLocation = "~/" # [optional, default="~/"]
 ```
 
-`OrgFileDir` will default to "~/" if it's not defined.  `GithubUsername` is used for determining when using the `NotMyPRs` or `MyPRs` filters.
+`GithubUsername` is used for determining when using the `NotMyPRs` or `MyPRs` filters.
 `RepoLocation` is the directory where you keep your git repositories. It defaults to "~/" if not defined.  This is used for LSP integration or other lookup tools which need to read the code of the repo you're reviewing.
 
 Each workflow entry can take the fields:
@@ -89,7 +88,6 @@ WorkflowType = "SyncReviewRequestsWorkflow"
 Name = "My Workflow"
 Owner = "owner"
 Filters = ["FilterNotDraft"]
-OrgFileName = "reviews.org"
 SectionTitle = "My Reviews"
 ReleaseCommandCheck = "release-check"
 Prune = "Archive"
@@ -133,14 +131,12 @@ Repos = [
     "C-Hipple/diff-lsp.el",
 ]
 SleepDuration = 5
-OrgFileDir = "~/gtd/"
 
 [[Workflows]]
 WorkflowType = "SyncReviewRequestsWorkflow"
 Name = "List Open PRs"
 Owner = "C-Hipple"
 Filters = ["FilterNotDraft"]
-OrgFileName = "reviews.org"
 SectionTitle = "Open PRs"
 Prune = "Archive"
 
@@ -148,7 +144,6 @@ Prune = "Archive"
 WorkflowType = "ListMyPRsWorkflow"
 Name = "List Closed PRs"
 Owner = "C-Hipple"
-OrgFileName = "reviews.org"
 SectionTitle = "Closed PRs"
 Prune = "Delete"
 ```
@@ -173,7 +168,6 @@ Name = "Growth Team Reviews"
 Owner = "your-org"
 Filters = ["FilterNotDraft"]
 Teams = ["growth-pod-review", "growth-and-purchase-pod"]
-OrgFileName = "reviews.org"
 SectionTitle = "Growth Team Reviews"
 Prune = "Archive"
 
@@ -183,7 +177,6 @@ Name = "Backend Team Reviews"
 Owner = "your-org"
 Filters = ["FilterNotDraft"]
 Teams = ["backend-team", "api-reviewers"]
-OrgFileName = "reviews.org"
 SectionTitle = "Backend Reviews"
 Prune = "Archive"
 ```
@@ -209,7 +202,6 @@ WorkflowType = "ProjectListWorkflow"
 Name = "Project - Example"
 Owner = "C-Hipple"
 Repo = "diff-lsp"
-OrgFileName = "reviews.org"
 SectionTitle = "Diff LSP Upgrade Project"
 JiraEpic = "BOARD-123" # the epic key
 ```

--- a/org/db_adapter.go
+++ b/org/db_adapter.go
@@ -11,7 +11,6 @@ import (
 type DBOrgDocument struct {
 	DB         *database.DB
 	Serializer OrgSerializer
-	OrgFileDir string
 }
 
 func NewDBClient(db *database.DB, serializer OrgSerializer) *DBOrgDocument {

--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -44,7 +44,6 @@ type SingleRepoSyncReviewRequestsWorkflow struct {
 	Owner               string
 	Repo                string
 	Filters             []git_tools.PRFilter
-	OrgFileName         string
 	SectionTitle        string
 	ReleaseCheckCommand string
 	Prune               string
@@ -53,10 +52,6 @@ type SingleRepoSyncReviewRequestsWorkflow struct {
 
 func (w SingleRepoSyncReviewRequestsWorkflow) GetName() string {
 	return w.Name
-}
-
-func (w SingleRepoSyncReviewRequestsWorkflow) GetOrgFilename() string {
-	return w.OrgFileName
 }
 
 func (w SingleRepoSyncReviewRequestsWorkflow) GetOrgSectionName() string {
@@ -108,7 +103,6 @@ type SyncReviewRequestsWorkflow struct {
 	IncludeDiff bool
 
 	// org output info
-	OrgFileName         string
 	SectionTitle        string
 	ReleaseCheckCommand string
 }
@@ -142,10 +136,6 @@ func (w SyncReviewRequestsWorkflow) GetName() string {
 	return w.Name
 }
 
-func (w SyncReviewRequestsWorkflow) GetOrgFilename() string {
-	return w.OrgFileName
-}
-
 func (w SyncReviewRequestsWorkflow) GetOrgSectionName() string {
 	return w.SectionTitle
 }
@@ -155,7 +145,6 @@ type ListMyPRsWorkflow struct {
 	Owner               string
 	Repos               []string
 	Filters             []git_tools.PRFilter
-	OrgFileName         string
 	SectionTitle        string
 	PRState             string
 	ReleaseCheckCommand string
@@ -165,10 +154,6 @@ type ListMyPRsWorkflow struct {
 
 func (w ListMyPRsWorkflow) GetName() string {
 	return w.Name
-}
-
-func (w ListMyPRsWorkflow) GetOrgFilename() string {
-	return w.OrgFileName
 }
 
 func (w ListMyPRsWorkflow) GetOrgSectionName() string {


### PR DESCRIPTION
### Description
This PR removes several unused configuration fields related to Org-mode file management (`OrgFileDir` and `OrgFileName`). As the project has transitioned towards a database-backed storage model, these fields are no longer necessary and their removal simplifies the configuration and codebase.

### Changes
- **Configuration Cleanup**: Removed `OrgFileDir` from global configuration and documentation.
- **Workflow Cleanup**: Removed `OrgFileName` from all workflow types (`SingleRepoSyncReviewRequestsWorkflow`, `SyncReviewRequestsWorkflow`, `ListMyPRsWorkflow`) and their associated interfaces.
- **Documentation**: Updated `README.md`, `docs/index.md`, and configuration examples to remove references to the deleted fields.
- **Internal Logic**: Removed unused fields and methods from `org/db_adapter.go` and `workflows/workflows.go`.

### Verification Results
- Verified that all documentation examples are still valid and consistent.
- Confirmed that the application builds and runs correctly without these legacy fields.
- New storage logic (database-backed) remains unaffected as it uses the `~/.crs/` directory introduced in previous updates.

---
GPL licensed code is the pinnacle of software freedom and collaboration!