### PR TITLE
feat: Allow filtering in workflows on CI Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Each workflow can use the available filters:
 *   `FilterIsDraft` - Only include draft PRs
 *   `FilterNotMyPRs` - Exclude PRs authored by you
 *   `FilterMyPRs` - Only include PRs authored by you
+*   `FilterCIPassing` - Only include PRs with passing CI/Actions
+*   `FilterCIFailing` - Only include PRs with failing CI/Actions
 
 ### Team-Based Filtering
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,8 @@ Each workflow can use the available filters:
 *   `FilterIsDraft` - Only include draft PRs
 *   `FilterNotMyPRs` - Exclude PRs authored by you
 *   `FilterMyPRs` - Only include PRs authored by you
+*   `FilterCIPassing` - Only include PRs with passing CI/Actions
+*   `FilterCIFailing` - Only include PRs with failing CI/Actions
 
 ### Team-Based Filtering
 

--- a/workflows/builders.go
+++ b/workflows/builders.go
@@ -102,6 +102,8 @@ var filter_func_map = map[string]func(prs []*github.PullRequest) []*github.PullR
 	"FilterIsDraft":           git_tools.FilterIsDraft,
 	"FilterNotMyPRs":          git_tools.FilterNotMyPRs,
 	"FilterMyPRs":             git_tools.FilterMyPRs,
+	"FilterCIPassing":         git_tools.FilterCIPassing,
+	"FilterCIFailing":         git_tools.FilterCIFailing,
 }
 
 func BuildFiltersList(raw *config.RawWorkflow) []git_tools.PRFilter {


### PR DESCRIPTION
### Description
This PR introduces the ability to filter pull requests based on their CI/GitHub Actions status. It also includes a significant refactor of CI status retrieval logic, moving it to `git_tools` and implementing a caching mechanism to improve performance and reduce API calls.

### Changes
- **New Filters**: Added `FilterCIPassing` and `FilterCIFailing` to allow workflows to include or exclude PRs based on whether their checks are passing.
- **CI Status Refactor**: Moved CI status retrieval and processing from `workflows/logic.go` to `git_tools/git_tools.go` for better modularity.
- **Caching Mechanism**: Implemented a thread-safe `DataCache` in `git_tools` to cache CI status results for 5 minutes, significantly reducing the number of GitHub Actions API calls during sync.
- **Improved Logic**: Refined the `GetCIStatus` logic to handle branch name parsing correctly and provide a clearer `OverallStatus` (`DONE`, `WAITING`, `TODO`).
- **Documentation**: Updated `README.md` and `docs/index.md` to include information about the new CI status filters.

### Verification Results
- Verified that `FilterCIPassing` correctly includes PRs with all checks passing (`DONE`).
- Verified that `FilterCIFailing` correctly includes PRs with at least one failing check (`TODO`).
- Confirmed that CI status information is still correctly displayed in the output with the new refactored logic.
- Observed reduced API latency on subsequent runs due to the new caching layer.

---
GPL licensed code is the pinnacle of software freedom and collaboration!