### PR TITLE
Waiting on Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Each workflow can use the available filters:
 *   `FilterCIFailing` - Only include PRs with failing CI/Actions
 *   `FilterStale` - PRs with no activity for more than 3 days
 *   `FilterNotStale` - PRs with activity within the last 3 days
+*   `FilterWaitingOnMe` - PRs where you are a requested reviewer and need to act
+*   `FilterWaitingOnAuthor` - PRs where you were the last to act and are waiting on the author
 
 ### Team-Based Filtering
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,8 @@ Each workflow can use the available filters:
 *   `FilterCIFailing` - Only include PRs with failing CI/Actions
 *   `FilterStale` - PRs with no activity for more than 3 days
 *   `FilterNotStale` - PRs with activity within the last 3 days
+*   `FilterWaitingOnMe` - PRs where you are a requested reviewer and need to act
+*   `FilterWaitingOnAuthor` - PRs where you were the last to act and are waiting on the author
 
 ### Team-Based Filtering
 

--- a/workflows/builders.go
+++ b/workflows/builders.go
@@ -106,6 +106,8 @@ var filter_func_map = map[string]func(prs []*github.PullRequest) []*github.PullR
 	"FilterCIFailing":         git_tools.FilterCIFailing,
 	"FilterStale":             git_tools.FilterStale,
 	"FilterNotStale":          git_tools.FilterNotStale,
+	"FilterWaitingOnMe":       git_tools.FilterWaitingOnMe,
+	"FilterWaitingOnAuthor":    git_tools.FilterWaitingOnAuthor,
 }
 
 func BuildFiltersList(raw *config.RawWorkflow) []git_tools.PRFilter {


### PR DESCRIPTION
### Description
This PR introduces advanced "waiting status" filters that help users identify pull requests requiring their immediate attention and those that are pending action from the author. It implements a sophisticated interaction tracking system to determine the state of a PR relative to the current user.

### Changes
- **New Filters**:
    - `FilterWaitingOnMe`: Includes PRs where you are a requested reviewer (individually or via team) and you haven't acted since the latest update (new commit, comment, or review from others).
    - `FilterWaitingOnAuthor`: Includes PRs where you were the last person to take action and are waiting for the author to respond or push new changes.
- **Interaction Tracking**: Added `GetInteractionState` to aggregate timestamps for reviews, review comments, issue comments, and commits for a given PR.
- **Team Integration**: Added `GetMyTeams` to automatically fetch and cache the user's GitHub team memberships, enabling team-based "Waiting on Me" logic.
- **Caching**: Utilizes the `GlobalCache` for interaction states and team lists to ensure high performance and minimize API rate limiting.
- **Documentation**: Updated `README.md` and `docs/index.md` with descriptions of the new filters.

### Verification Results
- Verified that `FilterWaitingOnMe` correctly identifies PRs where the user is a reviewer and has not yet responded to the latest changes.
- Verified that team-based review requests are correctly handled.
- Confirmed that `FilterWaitingOnAuthor` correctly identifies PRs pending author action.
- Cache effectiveness confirmed via repeated sync runs.

---
Software freedom is the cornerstone of digital autonomy, and the GPL ensures that this power remains in the hands of the community!