### PR TITLE
Display worktree path in client metadata output

### DIFF
--- a/client.el/client.el
+++ b/client.el/client.el
@@ -904,6 +904,7 @@ SHOW-FULL-COMMENTS determines whether to show full content or indicators."
           (commented (cdr (assq 'commented_by metadata))) ;; array
           (ci-status (cdr (assq 'ci_status metadata)))
           (ci-failures (cdr (assq 'ci_failures metadata))) ;; array
+          (worktree (cdr (assq 'worktree_path metadata)))
           (body (cdr (assq 'body metadata)))
           (sb ""))
 
@@ -911,6 +912,8 @@ SHOW-FULL-COMMENTS determines whether to show full content or indicators."
       (setq sb (concat sb (format "Author: \t@%s\n" author)))
       (setq sb (concat sb (format "Title: \t%s\n" title)))
       (setq sb (concat sb (format "Refs:  %s ... %s\n" base head)))
+      (when (and worktree (not (string-empty-p worktree)))
+        (setq sb (concat sb (format "Worktree: \t%s\n" worktree))))
       (setq sb (concat sb (format "URL:   %s\n" url)))
       (setq sb (concat sb (format "State: \t%s\n" state)))
       (setq sb (concat sb (format "Draft: \t%s\n" (if (eq draft t) "True" "False"))))


### PR DESCRIPTION
## Summary

Add support for displaying the worktree path in the client metadata output when available. This allows users to see the associated worktree path for a given item in the formatted metadata display.

### Changes

- Extract `worktree_path` from metadata
- Display worktree path in formatted output when present and non-empty
- Conditionally render the worktree line only when the value exists

## Test Plan

N/A - This is a straightforward display enhancement that adds a new metadata field to the output formatting. The change follows the existing pattern for optional metadata fields.

https://claude.ai/code/session_01NkbHPntEVhPnP7uVe6BFo3