### PR TITLE
Preserve newlines in HTML PR body descriptions

### DIFF
--- a/client.el/client.el
+++ b/client.el/client.el
@@ -65,11 +65,12 @@ Set to nil to disable the timeout."
 
 (defun crs--ensure-html (text)
   "Return TEXT as HTML suitable for shr rendering.
-If TEXT already looks like HTML (starts with a tag), return it unchanged.
+If TEXT already looks like HTML (starts with a tag), bare newlines are
+replaced with <br> elements so shr preserves the visual line structure.
 Otherwise convert plain text/Markdown line breaks to HTML paragraphs and
 br elements so that shr preserves the visual line structure."
   (if (string-match-p "\\`[[:space:]]*<" text)
-      text
+      (replace-regexp-in-string "\n" "<br>" text)
     (let* ((escaped (replace-regexp-in-string "&" "&amp;" text))
            (escaped (replace-regexp-in-string "<" "&lt;" escaped))
            (escaped (replace-regexp-in-string ">" "&gt;" escaped))


### PR DESCRIPTION
When a PR body starts with an HTML-like character (e.g., <!-- comment -->, <details>, <kbd>) crs--ensure-html was returning the text unchanged, causing shr to treat bare newlines as HTML whitespace and collapse them into spaces.

Fix by replacing bare \n with <br> in the "already HTML" path so shr renders them as actual line breaks.

https://claude.ai/code/session_01M2Byip6E7CaiK9XnoQ9aZb

## Summary

<!-- What does this change and why? -->

### Changes

<!-- Bullet-point the notable changes. -->

-
-

## Test Plan

<!-- Check off what you've verified. Add manual steps if needed. -->

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
