### PR TITLE
Bind O/o to hunk context expansion in Emacs client

### DIFF
--- a/client.el/client.el
+++ b/client.el/client.el
@@ -657,7 +657,8 @@ Re-renders the buffer with or without comments based on the toggle state."
   "f" #'crs-set-review-feedback
   "RET" #'crs-visit-file
   "<return>" #'crs-visit-file
-  "O" #'crs-show-outdated-comments
+  "O" #'crs-expand-hunk-before
+  "o" #'crs-expand-hunk-after
   "q" #'quit-window
   "]" #'crs-next-pr
   "[" #'crs-prev-pr
@@ -729,7 +730,8 @@ Re-renders the buffer with or without comments based on the toggle state."
     "H" #'crs-toggle-comments
     "f" #'crs-set-review-feedback
     "RET" #'crs-visit-file
-    "O" #'crs-show-outdated-comments
+    "O" #'crs-expand-hunk-before
+    "o" #'crs-expand-hunk-after
     "q" #'quit-window
     "]" #'crs-next-pr
     "[" #'crs-prev-pr
@@ -754,7 +756,8 @@ Re-renders the buffer with or without comments based on the toggle state."
     "H" #'crs-toggle-comments
     "f" #'crs-set-review-feedback
     "RET" #'crs-visit-file
-    "O" #'crs-show-outdated-comments
+    "O" #'crs-expand-hunk-before
+    "o" #'crs-expand-hunk-after
     "q" #'quit-window
     "]" #'crs-next-pr
     "[" #'crs-prev-pr


### PR DESCRIPTION
## Summary
- Bind `O` → `crs-expand-hunk-before` and `o` → `crs-expand-hunk-after` in code review buffers, shadowing evil-mode's default `evil-open-above`/`evil-open-below` so reviewers can expand hunk context with familiar vim-style keys.
- Applied to all three keymaps: `my-code-review-mode-map`, evil `'normal` state, and evil `'visual` state.
- Removes the previous `O` → `crs-show-outdated-comments` binding (function is still reachable via `M-x`). The existing `<`/`>` bindings for the same expand commands remain as alternatives.

## Test plan
- [ ] Open a PR in the Emacs client and press `O` on a hunk — verify context expands upward.
- [ ] Press `o` on a hunk — verify context expands downward.
- [ ] Confirm evil-mode's `evil-open-above`/`evil-open-below` no longer fire in the code review buffer.
- [ ] Confirm `<`/`>` still work as alternative bindings.

https://claude.ai/code/session_01BuS1q7Eo7Qxa3J1jkqs44V