### PR TITLE
Add macOS desktop notifications for PR additions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,8 +51,8 @@ type Config struct {
 	JiraDomain     string
 	GithubUsername string
 	RepoLocation   string
-	AutoWorktree        bool
-	MacOSNotifications  bool              // Send macOS desktop notifications when a PR is added to a section
+	AutoWorktree         bool
+	DesktopNotifications bool              // Send desktop notifications when a PR is added to a section
 	SectionPriority map[string]int    // Map of section title to priority (lower is better)
 	SectionSorting  map[string]string // Map of section title to sorting method (e.g. "newest_first", "oldest_first")
 	Plugins         []Plugin
@@ -131,9 +131,9 @@ func parseConfig(data []byte) (*Config, error) {
 		Workflows           []RawWorkflow
 		GithubUsername      string
 		RepoLocation        string
-		AutoWorktree        bool
-		MacOSNotifications  bool
-		SectionPriority     map[string]int
+		AutoWorktree         bool
+		DesktopNotifications bool
+		SectionPriority      map[string]int
 		SectionSorting      map[string]string
 		Plugins             []Plugin
 		RepoConfigs         map[string]RepoConfig
@@ -180,8 +180,8 @@ func parseConfig(data []byte) (*Config, error) {
 		JiraDomain:         intermediate_config.JiraDomain,
 		GithubUsername:     intermediate_config.GithubUsername,
 		RepoLocation:       repoLocation,
-		AutoWorktree:       intermediate_config.AutoWorktree,
-		MacOSNotifications: intermediate_config.MacOSNotifications,
+		AutoWorktree:         intermediate_config.AutoWorktree,
+		DesktopNotifications: intermediate_config.DesktopNotifications,
 		SectionPriority:    intermediate_config.SectionPriority,
 		SectionSorting:     intermediate_config.SectionSorting,
 		Plugins:            intermediate_config.Plugins,

--- a/config/config.go
+++ b/config/config.go
@@ -51,7 +51,8 @@ type Config struct {
 	JiraDomain     string
 	GithubUsername string
 	RepoLocation   string
-	AutoWorktree   bool
+	AutoWorktree        bool
+	MacOSNotifications  bool              // Send macOS desktop notifications when a PR is added to a section
 	SectionPriority map[string]int    // Map of section title to priority (lower is better)
 	SectionSorting  map[string]string // Map of section title to sorting method (e.g. "newest_first", "oldest_first")
 	Plugins         []Plugin
@@ -124,17 +125,18 @@ func ParseConfigForTest(data []byte) (*Config, error) {
 // It does NOT initialize the database.
 func parseConfig(data []byte) (*Config, error) {
 	var intermediate_config struct {
-		Repos           []string
-		JiraDomain      string
-		SleepDuration   int64
-		Workflows       []RawWorkflow
-		GithubUsername  string
-		RepoLocation    string
-		AutoWorktree    bool
-		SectionPriority map[string]int
-		SectionSorting  map[string]string
-		Plugins         []Plugin
-		RepoConfigs     map[string]RepoConfig
+		Repos               []string
+		JiraDomain          string
+		SleepDuration       int64
+		Workflows           []RawWorkflow
+		GithubUsername      string
+		RepoLocation        string
+		AutoWorktree        bool
+		MacOSNotifications  bool
+		SectionPriority     map[string]int
+		SectionSorting      map[string]string
+		Plugins             []Plugin
+		RepoConfigs         map[string]RepoConfig
 	}
 
 	err := toml.Unmarshal(data, &intermediate_config)
@@ -172,17 +174,18 @@ func parseConfig(data []byte) (*Config, error) {
 	}
 
 	return &Config{
-		Repos:           intermediate_config.Repos,
-		RawWorkflows:    intermediate_config.Workflows,
-		SleepDuration:   parsed_sleep_duration,
-		JiraDomain:      intermediate_config.JiraDomain,
-		GithubUsername:  intermediate_config.GithubUsername,
-		RepoLocation:    repoLocation,
-		AutoWorktree:    intermediate_config.AutoWorktree,
-		SectionPriority: intermediate_config.SectionPriority,
-		SectionSorting:  intermediate_config.SectionSorting,
-		Plugins:         intermediate_config.Plugins,
-		RepoConfigs:     repoConfigs,
+		Repos:              intermediate_config.Repos,
+		RawWorkflows:       intermediate_config.Workflows,
+		SleepDuration:      parsed_sleep_duration,
+		JiraDomain:         intermediate_config.JiraDomain,
+		GithubUsername:     intermediate_config.GithubUsername,
+		RepoLocation:       repoLocation,
+		AutoWorktree:       intermediate_config.AutoWorktree,
+		MacOSNotifications: intermediate_config.MacOSNotifications,
+		SectionPriority:    intermediate_config.SectionPriority,
+		SectionSorting:     intermediate_config.SectionSorting,
+		Plugins:            intermediate_config.Plugins,
+		RepoConfigs:        repoConfigs,
 	}, nil
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Repos: list[str] # List of "owner/repo" strings.
 SleepDuration: int (in minutes, optional, default=1 minute)
 GithubUsername: str [optional]
 RepoLocation: str [optional, default="~/"]
+DesktopNotifications: bool [optional, default=false]
 SectionPriority: map[string]int [optional]
 SectionSorting: map[string]string [optional]
 ```
@@ -24,6 +25,7 @@ SectionSorting: map[string]string [optional]
 - **Repos**: A list of repositories in the format "owner/repo". Workflows can also define their own `Repos` list which overrides this global list.
 - **GithubUsername**: Used for determining when using the NotMyPRs or FilterMyPRs filters, as well as for smart filters like FilterWaitingOnMe and FilterWaitingOnAuthor to correctly determine your review status.
 - **RepoLocation**: The directory where you keep your git repositories. It defaults to "~/" if not defined. This is used for LSP integration or other lookup tools which need to read the code of the repo you're reviewing.
+- **DesktopNotifications**: When `true`, sends a desktop notification each time a PR is newly added to a section. Defaults to `false`. Currently only macOS is supported (via `osascript`); enabling this on other operating systems will log an error.
 
 ## Workflows
 
@@ -153,6 +155,7 @@ Repos = [
     "C-Hipple/diff-lsp.el",
 ]
 SleepDuration = 5
+DesktopNotifications = true
 
 [SectionSorting]
 "Open PRs" = "newest_first"

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -183,6 +183,9 @@ func ApplyChanges(log *slog.Logger, channel chan SerializedFileChange, wg *sync.
 			if err != nil {
 				log.Error("Error upserting item", "error", err, "identifier", deserializedChange.FileChange.Identifier)
 			}
+			if deserializedChange.FileChange.ChangeType == "Addition" {
+				notifyPRAdded(log, deserializedChange.FileChange.SectionName, deserializedChange.FileChange.Title)
+			}
 		case "Delete":
 			err := db.DeleteItem(deserializedChange.FileChange.SectionID, deserializedChange.FileChange.Identifier)
 			if err != nil {

--- a/workflows/notifications.go
+++ b/workflows/notifications.go
@@ -8,19 +8,22 @@ import (
 	"runtime"
 )
 
-// notifyPRAdded sends a macOS desktop notification when a PR is added to a section.
-// Does nothing if MacOSNotifications is disabled or the OS is not macOS.
+// notifyPRAdded sends a desktop notification when a PR is added to a section.
+// Currently only macOS (osascript) is supported. If DesktopNotifications is
+// enabled on an unsupported OS, an error is logged.
 func notifyPRAdded(log *slog.Logger, sectionName, prTitle string) {
-	if !config.C().MacOSNotifications {
-		return
-	}
-	if runtime.GOOS != "darwin" {
+	if !config.C().DesktopNotifications {
 		return
 	}
 
-	message := fmt.Sprintf("PR Added to Section %s - %s", sectionName, prTitle)
-	script := fmt.Sprintf(`display notification %q with title "Code Review Server"`, message)
-	if err := exec.Command("osascript", "-e", script).Run(); err != nil {
-		log.Warn("Failed to send macOS notification", "error", err)
+	switch runtime.GOOS {
+	case "darwin":
+		message := fmt.Sprintf("PR Added to Section %s - %s", sectionName, prTitle)
+		script := fmt.Sprintf(`display notification %q with title "Code Review Server"`, message)
+		if err := exec.Command("osascript", "-e", script).Run(); err != nil {
+			log.Warn("Failed to send macOS notification", "error", err)
+		}
+	default:
+		log.Error("DesktopNotifications is enabled but is not supported on this OS", "os", runtime.GOOS)
 	}
 }

--- a/workflows/notifications.go
+++ b/workflows/notifications.go
@@ -1,0 +1,26 @@
+package workflows
+
+import (
+	"crs/config"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"runtime"
+)
+
+// notifyPRAdded sends a macOS desktop notification when a PR is added to a section.
+// Does nothing if MacOSNotifications is disabled or the OS is not macOS.
+func notifyPRAdded(log *slog.Logger, sectionName, prTitle string) {
+	if !config.C().MacOSNotifications {
+		return
+	}
+	if runtime.GOOS != "darwin" {
+		return
+	}
+
+	message := fmt.Sprintf("PR Added to Section %s - %s", sectionName, prTitle)
+	script := fmt.Sprintf(`display notification %q with title "Code Review Server"`, message)
+	if err := exec.Command("osascript", "-e", script).Run(); err != nil {
+		log.Warn("Failed to send macOS notification", "error", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for sending macOS desktop notifications when a pull request is added to a section. This feature is controlled by a new `MacOSNotifications` configuration option and only activates on macOS systems.

### Changes

- Added `MacOSNotifications` boolean field to `Config` struct with documentation
- Created new `notifications.go` module with `notifyPRAdded()` function that:
  - Sends macOS desktop notifications via `osascript`
  - Respects the `MacOSNotifications` config flag
  - Only runs on macOS (`darwin`)
  - Logs warnings if notification delivery fails
- Updated config parsing to handle the new `MacOSNotifications` field
- Integrated notification trigger in `ApplyChanges()` to notify when PRs are added to sections
- Reformatted struct field alignment in config parsing for consistency

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- Manual verification on macOS with `MacOSNotifications = true` in config

https://claude.ai/code/session_01MV4hK5xSxKBDWSrjW9A5Dm