### PR TITLE
Align renderer sorting with GetAllReviews handler

### DIFF
--- a/server/renderer.go
+++ b/server/renderer.go
@@ -141,9 +141,61 @@ func (r *OrgRenderer) RenderAndGetItems() (string, []ReviewItem, error) {
 		// Get items for this section
 		items := itemsBySection[section.ID]
 
-		// Apply per-section sorting if configured
+		// Parse review items up-front so we can sort items and content the
+		// same way the GetAllReviews handler sorts the items reply.
+		parsed := make([]ReviewItem, len(items))
+		for i, item := range items {
+			parsed[i] = r.parseItemToReviewItem(item, section.SectionName, section.Priority)
+		}
+
 		if sortMethod, ok := sectionSorting[section.SectionName]; ok {
-			sortItems(items, sortMethod)
+			// Per-section sort override: keep items and parsed entries aligned.
+			indices := make([]int, len(items))
+			for i := range indices {
+				indices[i] = i
+			}
+			switch sortMethod {
+			case SortNewestFirst:
+				sort.SliceStable(indices, func(a, b int) bool {
+					return items[indices[a]].CreatedAt.After(items[indices[b]].CreatedAt)
+				})
+			case SortOldestFirst:
+				sort.SliceStable(indices, func(a, b int) bool {
+					return items[indices[a]].CreatedAt.Before(items[indices[b]].CreatedAt)
+				})
+			}
+			sortedItems := make([]*database.Item, len(items))
+			sortedParsed := make([]ReviewItem, len(parsed))
+			for i, idx := range indices {
+				sortedItems[i] = items[idx]
+				sortedParsed[i] = parsed[idx]
+			}
+			items = sortedItems
+			parsed = sortedParsed
+		} else {
+			// Default: same order as GetAllReviews — status, then repo, then number.
+			indices := make([]int, len(items))
+			for i := range indices {
+				indices[i] = i
+			}
+			sort.SliceStable(indices, func(a, b int) bool {
+				si, sj := prStatusOrder(parsed[indices[a]]), prStatusOrder(parsed[indices[b]])
+				if si != sj {
+					return si < sj
+				}
+				if parsed[indices[a]].Repo != parsed[indices[b]].Repo {
+					return parsed[indices[a]].Repo < parsed[indices[b]].Repo
+				}
+				return parsed[indices[a]].Number < parsed[indices[b]].Number
+			})
+			sortedItems := make([]*database.Item, len(items))
+			sortedParsed := make([]ReviewItem, len(parsed))
+			for i, idx := range indices {
+				sortedItems[i] = items[idx]
+				sortedParsed[i] = parsed[idx]
+			}
+			items = sortedItems
+			parsed = sortedParsed
 		}
 
 		// Build section header
@@ -152,7 +204,7 @@ func (r *OrgRenderer) RenderAndGetItems() (string, []ReviewItem, error) {
 		content.WriteString("\n")
 
 		// Build items
-		for _, item := range items {
+		for i, item := range items {
 			// String representation
 			itemLines := r.buildItemLines(item, 2)
 			for _, line := range itemLines {
@@ -163,8 +215,7 @@ func (r *OrgRenderer) RenderAndGetItems() (string, []ReviewItem, error) {
 			}
 
 			// Structured representation
-			reviewItem := r.parseItemToReviewItem(item, section.SectionName, section.Priority)
-			reviewItems = append(reviewItems, reviewItem)
+			reviewItems = append(reviewItems, parsed[i])
 		}
 		// Add blank line between sections
 		content.WriteString("\n")

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -141,19 +141,18 @@ func (r *OrgRenderer) RenderAndGetItems() (string, []ReviewItem, error) {
 		// Get items for this section
 		items := itemsBySection[section.ID]
 
-		// Parse review items up-front so we can sort items and content the
-		// same way the GetAllReviews handler sorts the items reply.
+		// Parse review items up-front so content and the items reply share a
+		// single ordering.
 		parsed := make([]ReviewItem, len(items))
 		for i, item := range items {
 			parsed[i] = r.parseItemToReviewItem(item, section.SectionName, section.Priority)
 		}
 
+		indices := make([]int, len(items))
+		for i := range indices {
+			indices[i] = i
+		}
 		if sortMethod, ok := sectionSorting[section.SectionName]; ok {
-			// Per-section sort override: keep items and parsed entries aligned.
-			indices := make([]int, len(items))
-			for i := range indices {
-				indices[i] = i
-			}
 			switch sortMethod {
 			case SortNewestFirst:
 				sort.SliceStable(indices, func(a, b int) bool {
@@ -164,39 +163,19 @@ func (r *OrgRenderer) RenderAndGetItems() (string, []ReviewItem, error) {
 					return items[indices[a]].CreatedAt.Before(items[indices[b]].CreatedAt)
 				})
 			}
-			sortedItems := make([]*database.Item, len(items))
-			sortedParsed := make([]ReviewItem, len(parsed))
-			for i, idx := range indices {
-				sortedItems[i] = items[idx]
-				sortedParsed[i] = parsed[idx]
-			}
-			items = sortedItems
-			parsed = sortedParsed
 		} else {
-			// Default: same order as GetAllReviews — status, then repo, then number.
-			indices := make([]int, len(items))
-			for i := range indices {
-				indices[i] = i
-			}
 			sort.SliceStable(indices, func(a, b int) bool {
-				si, sj := prStatusOrder(parsed[indices[a]]), prStatusOrder(parsed[indices[b]])
-				if si != sj {
-					return si < sj
-				}
-				if parsed[indices[a]].Repo != parsed[indices[b]].Repo {
-					return parsed[indices[a]].Repo < parsed[indices[b]].Repo
-				}
-				return parsed[indices[a]].Number < parsed[indices[b]].Number
+				return reviewItemLess(parsed[indices[a]], parsed[indices[b]])
 			})
-			sortedItems := make([]*database.Item, len(items))
-			sortedParsed := make([]ReviewItem, len(parsed))
-			for i, idx := range indices {
-				sortedItems[i] = items[idx]
-				sortedParsed[i] = parsed[idx]
-			}
-			items = sortedItems
-			parsed = sortedParsed
 		}
+		sortedItems := make([]*database.Item, len(items))
+		sortedParsed := make([]ReviewItem, len(parsed))
+		for i, idx := range indices {
+			sortedItems[i] = items[idx]
+			sortedParsed[i] = parsed[idx]
+		}
+		items = sortedItems
+		parsed = sortedParsed
 
 		// Build section header
 		sectionHeader := r.buildSectionHeader(section, items)

--- a/server/server.go
+++ b/server/server.go
@@ -98,6 +98,30 @@ func prStatusOrder(item ReviewItem) int {
 	}
 }
 
+// reviewItemLess is the canonical ordering used for review items across the
+// RPC surface: primary key is status, then most-recently-created first, with
+// repo and PR number as tie-breakers.
+func reviewItemLess(a, b ReviewItem) bool {
+	si, sj := prStatusOrder(a), prStatusOrder(b)
+	if si != sj {
+		return si < sj
+	}
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.After(b.CreatedAt)
+	}
+	if a.Repo != b.Repo {
+		return a.Repo < b.Repo
+	}
+	return a.Number < b.Number
+}
+
+// sortReviewItems sorts items in-place using reviewItemLess.
+func sortReviewItems(items []ReviewItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return reviewItemLess(items[i], items[j])
+	})
+}
+
 func (h *RPCHandler) GetAllReviews(args *GetReviewsArgs, reply *GetReviewsReply) error {
 	if err := config.Reload(); err != nil {
 		h.Log.Error("Error reloading config", "error", err)
@@ -113,19 +137,7 @@ func (h *RPCHandler) GetAllReviews(args *GetReviewsArgs, reply *GetReviewsReply)
 	if items == nil {
 		reply.Items = []ReviewItem{}
 	} else {
-		sort.SliceStable(items, func(i, j int) bool {
-			si, sj := prStatusOrder(items[i]), prStatusOrder(items[j])
-			if si != sj {
-				return si < sj
-			}
-			if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
-				return items[i].CreatedAt.After(items[j].CreatedAt)
-			}
-			if items[i].Repo != items[j].Repo {
-				return items[i].Repo < items[j].Repo
-			}
-			return items[i].Number < items[j].Number
-		})
+		sortReviewItems(items)
 		reply.Items = items
 	}
 	return nil
@@ -224,19 +236,7 @@ func (h *RPCHandler) GetAdjacentPR(args *GetAdjacentPRArgs, reply *GetAdjacentPR
 	}
 
 	// Sort the same way as GetAllReviews
-	sort.SliceStable(items, func(i, j int) bool {
-		si, sj := prStatusOrder(items[i]), prStatusOrder(items[j])
-		if si != sj {
-			return si < sj
-		}
-		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
-			return items[i].CreatedAt.After(items[j].CreatedAt)
-		}
-		if items[i].Repo != items[j].Repo {
-			return items[i].Repo < items[j].Repo
-		}
-		return items[i].Number < items[j].Number
-	})
+	sortReviewItems(items)
 
 	// Find the current PR in the sorted list
 	currentIdx := -1


### PR DESCRIPTION
## Summary

Refactor the item sorting logic in `RenderAndGetItems()` to parse review items up-front and apply the same sorting strategy as the `GetAllReviews` handler. This ensures consistent ordering between the rendered output and the structured review items returned by the API.

### Changes

- Parse all items to `ReviewItem` structs before sorting, rather than parsing them individually during iteration
- Implement index-based sorting to keep items and parsed entries aligned during reordering
- Add default sorting behavior (by status, then repo, then number) when no per-section sort override is configured, matching the `GetAllReviews` handler's logic
- Replace direct item iteration with index-based access to use pre-parsed review items

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_019YMuhHrFTkmvWV13E8oS69