### PR TITLE
Handle closed channel panic in workflow result processing

### DIFF
--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -30,7 +30,17 @@ func (rr *RunResult) Process(output *FileChanges, c chan FileChanges, wg *sync.W
 			rr.Deleted += 1
 		}
 		wg.Add(1)
-		c <- *output
+		func() {
+			defer func() {
+				if recover() != nil {
+					// Channel closed (workflow goroutine outlived its cycle due to
+					// the 240 s timeout in RunOnce). Undo the wg.Add so the
+					// WaitGroup can still reach zero.
+					wg.Done()
+				}
+			}()
+			c <- *output
+		}()
 	} else {
 		rr.Skipped += 1
 	}


### PR DESCRIPTION
## Summary

Wraps the channel send operation in `RunResult.Process()` with panic recovery to gracefully handle cases where the channel has been closed by the workflow goroutine. This prevents the application from crashing when a workflow goroutine outlives its cycle due to the 240-second timeout in `RunOnce()`.

### Changes

- Wrapped `c <- *output` in an anonymous function with defer/recover to catch panic from sending on a closed channel
- When a panic is caught (indicating the channel was closed), calls `wg.Done()` to properly decrement the WaitGroup counter that was incremented by the preceding `wg.Add(1)`
- Ensures the WaitGroup can still reach zero even when the receiving goroutine has already exited

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_01QaZyALsbfJXpD2wRvHJ6SW