### PR TITLE
Parallelize PR processing in ProcessPRsDB

### DIFF
--- a/workflows/logic.go
+++ b/workflows/logic.go
@@ -403,15 +403,27 @@ func formatComments(comments []*github.PullRequestComment) (int, []string) {
 func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel chan FileChanges, db *database.DB, section *database.Section, change_wg *sync.WaitGroup, includeDiff bool) RunResult {
 	result := RunResult{}
 
-	pr_identifiers := []string{}
-	changes := []FileChanges{}
 	ttl := time.Now().Add(2 * time.Hour).Unix()
 
-	for _, pr := range prs {
-		bridge := PRToOrgBridge{PR: pr, IncludeDiff: includeDiff}
-		pr_identifiers = append(pr_identifiers, bridge.Identifier())
-		fc := SyncTODOToSectionDB(db, pr, section, includeDiff)
-		fc.TTL = ttl
+	// Build FileChanges for each PR in parallel; each goroutine writes to its
+	// own index so no mutex is needed.
+	prChanges := make([]FileChanges, len(prs))
+	var buildWg sync.WaitGroup
+	for i, pr := range prs {
+		buildWg.Add(1)
+		go func(i int, pr *github.PullRequest) {
+			defer buildWg.Done()
+			fc := SyncTODOToSectionDB(db, pr, section, includeDiff)
+			fc.TTL = ttl
+			prChanges[i] = fc
+		}(i, pr)
+	}
+	buildWg.Wait()
+
+	pr_identifiers := make([]string, 0, len(prs))
+	changes := make([]FileChanges, 0, len(prs))
+	for _, fc := range prChanges {
+		pr_identifiers = append(pr_identifiers, fc.Identifier)
 		changes = append(changes, fc)
 	}
 


### PR DESCRIPTION
## Summary

Refactor `ProcessPRsDB` to build `FileChanges` for each PR in parallel using goroutines, improving performance when processing multiple pull requests. Each goroutine writes to its own array index, eliminating the need for synchronization primitives.

### Changes

- Parallelize `SyncTODOToSectionDB` calls across all PRs using a wait group
- Pre-allocate `prChanges` slice with capacity for all PRs to avoid contention
- Extract PR identifiers from the resulting `FileChanges` objects instead of building them separately
- Use pre-allocated slices with capacity hints for `pr_identifiers` and `changes`

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_013wgySd2yqGRXniX48xTr7x