### PR TITLE
Add per-workflow desktop notification override

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ type RawWorkflow struct {
 	GithubUsername      string
 	IncludeDiff         bool
 	Teams               []string // Teams to filter PRs by when using FilterTeamRequested
+	// DesktopNotifications overrides the global DesktopNotifications setting
+	// for this workflow only. If nil, the global setting is used.
+	DesktopNotifications *bool
 }
 
 // RepoConfig holds per-repository configuration settings.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,9 +40,12 @@ Filters: list[str]
 SectionTitle: str
 IncludeDiff: bool
 Teams: list[str]
+DesktopNotifications: bool [optional]
 ```
 
 The `GithubUsername` can be set at the top level of the config file. If a workflow does not have a `GithubUsername` set, it will inherit the top-level setting. This is useful for setting a default user for all workflows.
+
+`DesktopNotifications` on a workflow overrides the top-level `DesktopNotifications` setting for that workflow only. Omit it to inherit the global value; set it to `true` or `false` to force notifications on or off for this workflow. This lets you keep notifications globally off but opt in on a specific workflow (e.g. review requests) — or vice versa.
 
 ### Workflow Types
 

--- a/workflows/builders.go
+++ b/workflows/builders.go
@@ -44,13 +44,14 @@ func BuildSingleRepoReviewWorkflow(raw *config.RawWorkflow, repos *[]string) (Wo
 		return nil, err
 	}
 	wf := SyncReviewRequestsWorkflow{
-		Name:         raw.Name,
-		Owner:        raw.Owner,
-		Repos:        []string{raw.Repo},
-		Filters:      filters,
-		SectionTitle: raw.SectionTitle,
-		IncludeDiff:  raw.IncludeDiff,
-		AuxDataReq:   computeAuxRequirements(raw.Filters, raw.IncludeDiff),
+		Name:                 raw.Name,
+		Owner:                raw.Owner,
+		Repos:                []string{raw.Repo},
+		Filters:              filters,
+		SectionTitle:         raw.SectionTitle,
+		IncludeDiff:          raw.IncludeDiff,
+		AuxDataReq:           computeAuxRequirements(raw.Filters, raw.IncludeDiff),
+		DesktopNotifications: raw.DesktopNotifications,
 	}
 	return wf, nil
 }
@@ -66,14 +67,15 @@ func BuildSyncReviewRequestWorkflow(raw *config.RawWorkflow, repos *[]string) (W
 		return nil, err
 	}
 	wf := SyncReviewRequestsWorkflow{
-		Name:         raw.Name,
-		Owner:        raw.Owner,
-		Repos:        workflowRepos,
-		Filters:      filters,
-		PRState:      raw.PRState,
-		SectionTitle: raw.SectionTitle,
-		IncludeDiff:  raw.IncludeDiff,
-		AuxDataReq:   computeAuxRequirements(raw.Filters, raw.IncludeDiff),
+		Name:                 raw.Name,
+		Owner:                raw.Owner,
+		Repos:                workflowRepos,
+		Filters:              filters,
+		PRState:              raw.PRState,
+		SectionTitle:         raw.SectionTitle,
+		IncludeDiff:          raw.IncludeDiff,
+		AuxDataReq:           computeAuxRequirements(raw.Filters, raw.IncludeDiff),
+		DesktopNotifications: raw.DesktopNotifications,
 	}
 	return wf, nil
 }
@@ -93,14 +95,15 @@ func BuildListMyPRsWorkflow(raw *config.RawWorkflow, repos *[]string) (Workflow,
 	// Prepend it so user-supplied filters further narrow the result.
 	filters = append([]git_tools.PRFilter{git_tools.FilterMyPRs}, filters...)
 	wf := SyncReviewRequestsWorkflow{
-		Name:         raw.Name,
-		Owner:        raw.Owner,
-		Repos:        workflowRepos,
-		Filters:      filters,
-		PRState:      raw.PRState,
-		SectionTitle: raw.SectionTitle,
-		IncludeDiff:  raw.IncludeDiff,
-		AuxDataReq:   computeAuxRequirements(raw.Filters, raw.IncludeDiff),
+		Name:                 raw.Name,
+		Owner:                raw.Owner,
+		Repos:                workflowRepos,
+		Filters:              filters,
+		PRState:              raw.PRState,
+		SectionTitle:         raw.SectionTitle,
+		IncludeDiff:          raw.IncludeDiff,
+		AuxDataReq:           computeAuxRequirements(raw.Filters, raw.IncludeDiff),
+		DesktopNotifications: raw.DesktopNotifications,
 	}
 	return wf, nil
 }
@@ -111,14 +114,15 @@ func BuildProjectListWorkflow(raw *config.RawWorkflow, jiraDomain string) (Workf
 		return nil, err
 	}
 	wf := ProjectListWorkflow{
-		Name:         raw.Name,
-		Owner:        raw.Owner,
-		Repo:         raw.Repo,
-		JiraDomain:   jiraDomain,
-		JiraEpic:     raw.JiraEpic,
-		Filters:      filters,
-		SectionTitle: raw.SectionTitle,
-		IncludeDiff:  raw.IncludeDiff,
+		Name:                 raw.Name,
+		Owner:                raw.Owner,
+		Repo:                 raw.Repo,
+		JiraDomain:           jiraDomain,
+		JiraEpic:             raw.JiraEpic,
+		Filters:              filters,
+		SectionTitle:         raw.SectionTitle,
+		IncludeDiff:          raw.IncludeDiff,
+		DesktopNotifications: raw.DesktopNotifications,
 	}
 	return wf, nil
 }

--- a/workflows/logic.go
+++ b/workflows/logic.go
@@ -66,6 +66,10 @@ type FileChanges struct {
 	SectionID   int64
 	SectionName string
 	TTL         int64
+	// NotifyOnAdd is the effective desktop-notification decision for the
+	// workflow that produced this change. When true and ChangeType is
+	// "Addition", a desktop notification will be sent.
+	NotifyOnAdd bool
 }
 
 type SerializedFileChange struct {
@@ -400,7 +404,7 @@ func formatComments(comments []*github.PullRequestComment) (int, []string) {
 	return len(comments), str_comments
 }
 
-func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel chan FileChanges, db *database.DB, section *database.Section, change_wg *sync.WaitGroup, includeDiff bool) RunResult {
+func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel chan FileChanges, db *database.DB, section *database.Section, change_wg *sync.WaitGroup, includeDiff bool, notifyOnAdd bool) RunResult {
 	result := RunResult{}
 
 	pr_identifiers := []string{}
@@ -412,6 +416,7 @@ func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel c
 		pr_identifiers = append(pr_identifiers, bridge.Identifier())
 		fc := SyncTODOToSectionDB(db, pr, section, includeDiff)
 		fc.TTL = ttl
+		fc.NotifyOnAdd = notifyOnAdd
 		changes = append(changes, fc)
 	}
 

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -183,7 +183,7 @@ func ApplyChanges(log *slog.Logger, channel chan SerializedFileChange, wg *sync.
 			if err != nil {
 				log.Error("Error upserting item", "error", err, "identifier", deserializedChange.FileChange.Identifier)
 			}
-			if deserializedChange.FileChange.ChangeType == "Addition" {
+			if deserializedChange.FileChange.ChangeType == "Addition" && deserializedChange.FileChange.NotifyOnAdd {
 				notifyPRAdded(log, deserializedChange.FileChange.SectionName, deserializedChange.FileChange.Title)
 			}
 		case "Delete":

--- a/workflows/notifications.go
+++ b/workflows/notifications.go
@@ -1,7 +1,6 @@
 package workflows
 
 import (
-	"crs/config"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -9,13 +8,9 @@ import (
 )
 
 // notifyPRAdded sends a desktop notification when a PR is added to a section.
-// Currently only macOS (osascript) is supported. If DesktopNotifications is
-// enabled on an unsupported OS, an error is logged.
+// Currently only macOS (osascript) is supported. The caller is responsible for
+// deciding whether notifications should fire (global or per-workflow override).
 func notifyPRAdded(log *slog.Logger, sectionName, prTitle string) {
-	if !config.C().DesktopNotifications {
-		return
-	}
-
 	switch runtime.GOOS {
 	case "darwin":
 		message := fmt.Sprintf("PR Added to Section %s - %s", sectionName, prTitle)

--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -52,6 +52,10 @@ type SyncReviewRequestsWorkflow struct {
 
 	// org output info
 	SectionTitle string
+
+	// DesktopNotifications overrides the global setting for this workflow.
+	// nil means inherit the global config.
+	DesktopNotifications *bool
 }
 
 func (w SyncReviewRequestsWorkflow) GetPRRequirements() []PRRequirement {
@@ -88,10 +92,19 @@ func (w SyncReviewRequestsWorkflow) Run(log *slog.Logger, prs []*github.PullRequ
 
 	beforeCount, _ := db.GetItemCount()
 	log.Info("Starting workflow", "items_before", beforeCount)
-	result := ProcessPRsDB(log, prs, c, db, section, file_change_wg, w.IncludeDiff)
+	result := ProcessPRsDB(log, prs, c, db, section, file_change_wg, w.IncludeDiff, w.ShouldNotify())
 	afterCount, _ := db.GetItemCount()
 	log.Info("Finished workflow", "items_after", afterCount)
 	return result, nil
+}
+
+// ShouldNotify resolves the effective desktop-notification setting for this
+// workflow: the per-workflow override if set, otherwise the global config.
+func (w SyncReviewRequestsWorkflow) ShouldNotify() bool {
+	if w.DesktopNotifications != nil {
+		return *w.DesktopNotifications
+	}
+	return config.C().DesktopNotifications
 }
 
 func (w SyncReviewRequestsWorkflow) GetName() string {
@@ -111,6 +124,19 @@ type ProjectListWorkflow struct {
 	JiraDomain   string
 	JiraEpic     string
 	IncludeDiff  bool
+
+	// DesktopNotifications overrides the global setting for this workflow.
+	// nil means inherit the global config.
+	DesktopNotifications *bool
+}
+
+// ShouldNotify resolves the effective desktop-notification setting for this
+// workflow: the per-workflow override if set, otherwise the global config.
+func (w ProjectListWorkflow) ShouldNotify() bool {
+	if w.DesktopNotifications != nil {
+		return *w.DesktopNotifications
+	}
+	return config.C().DesktopNotifications
 }
 
 func (w ProjectListWorkflow) GetName() string {
@@ -147,7 +173,7 @@ func (w ProjectListWorkflow) Run(log *slog.Logger, prs []*github.PullRequest, c 
 
 	beforeCount, _ := db.GetItemCount()
 	log.Info("Starting workflow", "items_before", beforeCount)
-	result := ProcessPRsDB(log, prs, c, db, section, file_change_wg, w.IncludeDiff)
+	result := ProcessPRsDB(log, prs, c, db, section, file_change_wg, w.IncludeDiff, w.ShouldNotify())
 	afterCount, _ := db.GetItemCount()
 	log.Info("Finished workflow", "items_after", afterCount)
 	return result, nil


### PR DESCRIPTION
## Summary

Add support for per-workflow desktop notification settings that override the global configuration. This allows users to enable notifications for specific workflows (e.g., review requests) while keeping them globally disabled, or vice versa.

### Changes

- Add `DesktopNotifications` optional field to `RawWorkflow` config struct to allow per-workflow overrides
- Add `DesktopNotifications` field to `SyncReviewRequestsWorkflow` and `ProjectListWorkflow` types
- Implement `ShouldNotify()` method on both workflow types to resolve effective notification setting (per-workflow override takes precedence over global config)
- Update workflow builders to populate `DesktopNotifications` from config
- Pass notification decision through `ProcessPRsDB` and store in `FileChanges` struct as `NotifyOnAdd`
- Update `ApplyChanges` to check both change type and `NotifyOnAdd` flag before sending desktop notifications
- Remove global config check from `notifyPRAdded` function (caller now responsible for decision)
- Update documentation to explain the per-workflow override behavior

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_015qDu1p3GaA8kA4MAkYF8rJ