### PR TITLE
Add copy URL button to review metadata section

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -30,6 +30,37 @@ import LspPopover from './LspPopover';
 import CodeViewerModal from './CodeViewerModal';
 
 // Strip HTML comments from text (e.g., <!-- comment -->)
+function CopyUrlButton({ url }: { url: string }) {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(url).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        });
+    };
+
+    return (
+        <button
+            onClick={handleCopy}
+            style={{
+                background: 'transparent',
+                color: copied ? 'var(--accent)' : 'var(--text-secondary)',
+                border: '1px solid var(--border)',
+                padding: '8px 16px',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+                fontSize: '13px',
+            }}
+        >
+            <span>{copied ? '✓' : '⎘'}</span> {copied ? 'Copied!' : 'Copy URL'}
+        </button>
+    );
+}
+
 const stripHtmlComments = (text: string): string => {
     return text.replace(/<!--[\s\S]*?-->/g, '');
 };
@@ -2144,26 +2175,29 @@ export default function Review({
                                     {metadata.title}
                                 </h1>
                             </div>
-                            <a
-                                href={metadata.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                style={{
-                                    background: 'transparent',
-                                    color: 'var(--text-secondary)',
-                                    border: '1px solid var(--border)',
-                                    padding: '8px 16px',
-                                    borderRadius: '6px',
-                                    cursor: 'pointer',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: '6px',
-                                    textDecoration: 'none',
-                                    fontSize: '13px',
-                                }}
-                            >
-                                <span>↗</span> GitHub
-                            </a>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                                <a
+                                    href={metadata.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    style={{
+                                        background: 'transparent',
+                                        color: 'var(--text-secondary)',
+                                        border: '1px solid var(--border)',
+                                        padding: '8px 16px',
+                                        borderRadius: '6px',
+                                        cursor: 'pointer',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: '6px',
+                                        textDecoration: 'none',
+                                        fontSize: '13px',
+                                    }}
+                                >
+                                    <span>↗</span> GitHub
+                                </a>
+                                <CopyUrlButton url={metadata.url} />
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary

Added a new "Copy URL" button next to the GitHub link in the review metadata section, allowing users to easily copy the review URL to their clipboard without navigating away.

### Changes

- Created new `CopyUrlButton` component that copies a URL to clipboard and displays visual feedback (checkmark and "Copied!" text for 2 seconds)
- Added the copy button below the existing GitHub link in the review metadata header
- Wrapped both buttons in a flex container for proper layout alignment

## Test Plan

- [ ] Verify the "Copy URL" button appears next to the GitHub link in the review metadata section
- [ ] Verify clicking the button copies the URL to clipboard
- [ ] Verify the button shows a checkmark and "Copied!" text for 2 seconds after clicking
- [ ] Verify the button styling matches the GitHub link button

https://claude.ai/code/session_01RfHNGtVqEma9Udrzfwvuf4