### PR TITLE
workflows: track per-workflow ownership of section items

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -31,6 +31,7 @@ type Item struct {
 	Tags        string // Comma-separated tags
 	TTL         int64
 	CreatedAt   time.Time
+	Workflows   string // JSON array of workflow names that maintain this item
 }
 
 type LocalComment struct {
@@ -100,6 +101,7 @@ func (db *DB) initSchema() error {
 		details_json TEXT NOT NULL,
 		tags TEXT DEFAULT '',
 		ttl INTEGER DEFAULT 0,
+		workflows TEXT NOT NULL DEFAULT '[]',
 		UNIQUE(section_id, identifier),
 		FOREIGN KEY(section_id) REFERENCES sections(id) ON DELETE CASCADE
 	);
@@ -328,6 +330,15 @@ func (db *DB) initSchema() error {
 		}
 	}
 
+	// Migration: Add workflows column to items if it doesn't exist
+	err = db.conn.QueryRow("SELECT COUNT(*) FROM pragma_table_info('items') WHERE name='workflows'").Scan(&count)
+	if err == nil && count == 0 {
+		_, err = db.conn.Exec("ALTER TABLE items ADD COLUMN workflows TEXT NOT NULL DEFAULT '[]'")
+		if err != nil {
+			slog.Warn("Error adding workflows column to items", "error", err)
+		}
+	}
+
 	return nil
 }
 
@@ -523,6 +534,13 @@ func (db *DB) GetAllSections() ([]*Section, error) {
 }
 
 func (db *DB) UpsertItem(sectionID int64, identifier, status, title string, details []string, tags []string, ttl int64) (*Item, error) {
+	return db.UpsertItemWithWorkflow(sectionID, identifier, status, title, details, tags, ttl, "")
+}
+
+// UpsertItemWithWorkflow upserts an item and merges workflowName into the
+// item's `workflows` ownership list. Pass an empty string to leave ownership
+// unchanged (compatibility with callers that don't track workflow ownership).
+func (db *DB) UpsertItemWithWorkflow(sectionID int64, identifier, status, title string, details []string, tags []string, ttl int64, workflowName string) (*Item, error) {
 	detailsJSON, err := json.Marshal(details)
 	if err != nil {
 		return nil, err
@@ -537,28 +555,51 @@ func (db *DB) UpsertItem(sectionID int64, identifier, status, title string, deta
 		tagsStr = string(tagsBytes)
 	}
 
-	result, err := db.conn.Exec(
-		`INSERT INTO items (section_id, identifier, status, title, details_json, tags, ttl)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Read current workflows list (if any) so we can merge in workflowName.
+	var existingWorkflowsJSON string
+	err = tx.QueryRow(
+		"SELECT workflows FROM items WHERE section_id = ? AND identifier = ?",
+		sectionID, identifier,
+	).Scan(&existingWorkflowsJSON)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+
+	workflows := decodeWorkflowList(existingWorkflowsJSON)
+	if workflowName != "" && !containsString(workflows, workflowName) {
+		workflows = append(workflows, workflowName)
+	}
+	workflowsJSON, err := json.Marshal(workflows)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := tx.Exec(
+		`INSERT INTO items (section_id, identifier, status, title, details_json, tags, ttl, workflows)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(section_id, identifier) DO UPDATE SET
 			status = excluded.status,
 			title = excluded.title,
 			details_json = excluded.details_json,
 			tags = excluded.tags,
-			ttl = excluded.ttl`,
-		sectionID, identifier, status, title, string(detailsJSON), tagsStr, ttl,
+			ttl = excluded.ttl,
+			workflows = excluded.workflows`,
+		sectionID, identifier, status, title, string(detailsJSON), tagsStr, ttl, string(workflowsJSON),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	// Try to get the last inserted ID.
-	// In SQLite with ON CONFLICT DO UPDATE, LastInsertId() might be 0 if no row was inserted.
 	id, err := result.LastInsertId()
 	if err != nil || id == 0 {
-		// Get the existing ID
 		var existingID int64
-		err := db.conn.QueryRow(
+		err := tx.QueryRow(
 			"SELECT id FROM items WHERE section_id = ? AND identifier = ?",
 			sectionID, identifier,
 		).Scan(&existingID)
@@ -566,6 +607,10 @@ func (db *DB) UpsertItem(sectionID int64, identifier, status, title string, deta
 			return nil, err
 		}
 		id = existingID
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
 	}
 
 	item := &Item{
@@ -577,17 +622,92 @@ func (db *DB) UpsertItem(sectionID int64, identifier, status, title string, deta
 		DetailsJSON: string(detailsJSON),
 		Tags:        tagsStr,
 		TTL:         ttl,
+		Workflows:   string(workflowsJSON),
 	}
 
 	return item, nil
 }
 
+// RemoveWorkflowFromItem removes workflowName from the item's ownership list.
+// The row is left in place even if the list becomes empty; PruneOrphanedItems
+// is responsible for deleting items that no workflow maintains.
+func (db *DB) RemoveWorkflowFromItem(sectionID int64, identifier, workflowName string) error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var workflowsJSON string
+	err = tx.QueryRow(
+		"SELECT workflows FROM items WHERE section_id = ? AND identifier = ?",
+		sectionID, identifier,
+	).Scan(&workflowsJSON)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	workflows := decodeWorkflowList(workflowsJSON)
+	updated := workflows[:0]
+	for _, w := range workflows {
+		if w != workflowName {
+			updated = append(updated, w)
+		}
+	}
+	encoded, err := json.Marshal(updated)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		"UPDATE items SET workflows = ? WHERE section_id = ? AND identifier = ?",
+		string(encoded), sectionID, identifier,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// PruneOrphanedItems deletes every item whose workflow ownership list is
+// empty. Returns the number of rows deleted.
+func (db *DB) PruneOrphanedItems() (int64, error) {
+	res, err := db.conn.Exec(
+		`DELETE FROM items WHERE workflows = '' OR workflows = '[]' OR workflows IS NULL`,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func decodeWorkflowList(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
 func (db *DB) GetItem(sectionID int64, identifier string) (*Item, error) {
 	var item Item
 	err := db.conn.QueryRow(
-		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl FROM items WHERE section_id = ? AND identifier = ?",
+		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl, COALESCE(workflows, '[]') FROM items WHERE section_id = ? AND identifier = ?",
 		sectionID, identifier,
-	).Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL)
+	).Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL, &item.Workflows)
 
 	if err != nil {
 		return nil, err
@@ -597,7 +717,7 @@ func (db *DB) GetItem(sectionID int64, identifier string) (*Item, error) {
 
 func (db *DB) GetItemsBySection(sectionID int64) ([]*Item, error) {
 	rows, err := db.conn.Query(
-		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl, COALESCE(created_at, CURRENT_TIMESTAMP) FROM items WHERE section_id = ? ORDER BY id",
+		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl, COALESCE(created_at, CURRENT_TIMESTAMP), COALESCE(workflows, '[]') FROM items WHERE section_id = ? ORDER BY id",
 		sectionID,
 	)
 	if err != nil {
@@ -609,7 +729,7 @@ func (db *DB) GetItemsBySection(sectionID int64) ([]*Item, error) {
 	for rows.Next() {
 		var item Item
 		var createdAtStr string
-		if err := rows.Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL, &createdAtStr); err != nil {
+		if err := rows.Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL, &createdAtStr, &item.Workflows); err != nil {
 			return nil, err
 		}
 		item.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAtStr)
@@ -620,7 +740,7 @@ func (db *DB) GetItemsBySection(sectionID int64) ([]*Item, error) {
 
 func (db *DB) GetAllItems() ([]*Item, error) {
 	rows, err := db.conn.Query(
-		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl, COALESCE(created_at, CURRENT_TIMESTAMP) FROM items ORDER BY section_id, id",
+		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl, COALESCE(created_at, CURRENT_TIMESTAMP), COALESCE(workflows, '[]') FROM items ORDER BY section_id, id",
 	)
 	if err != nil {
 		return nil, err
@@ -631,7 +751,7 @@ func (db *DB) GetAllItems() ([]*Item, error) {
 	for rows.Next() {
 		var item Item
 		var createdAtStr string
-		if err := rows.Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL, &createdAtStr); err != nil {
+		if err := rows.Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL, &createdAtStr, &item.Workflows); err != nil {
 			return nil, err
 		}
 		item.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAtStr)
@@ -643,7 +763,7 @@ func (db *DB) GetAllItems() ([]*Item, error) {
 func (db *DB) GetExpiredItems(sectionID int64) ([]*Item, error) {
 	now := time.Now().Unix()
 	rows, err := db.conn.Query(
-		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl FROM items WHERE section_id = ? AND ttl > 0 AND ttl < ?",
+		"SELECT id, section_id, identifier, status, title, details_json, tags, ttl, COALESCE(workflows, '[]') FROM items WHERE section_id = ? AND ttl > 0 AND ttl < ?",
 		sectionID, now,
 	)
 	if err != nil {
@@ -654,7 +774,7 @@ func (db *DB) GetExpiredItems(sectionID int64) ([]*Item, error) {
 	var items []*Item
 	for rows.Next() {
 		var item Item
-		if err := rows.Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL); err != nil {
+		if err := rows.Scan(&item.ID, &item.SectionID, &item.Identifier, &item.Status, &item.Title, &item.DetailsJSON, &item.Tags, &item.TTL, &item.Workflows); err != nil {
 			return nil, err
 		}
 		items = append(items, &item)
@@ -1060,6 +1180,11 @@ func (item *Item) GetDetails() ([]string, error) {
 		return nil, err
 	}
 	return details, nil
+}
+
+// GetWorkflows returns the list of workflow names that maintain this item.
+func (item *Item) GetWorkflows() []string {
+	return decodeWorkflowList(item.Workflows)
 }
 
 func (item *Item) GetTags() ([]string, error) {

--- a/workflows/logic.go
+++ b/workflows/logic.go
@@ -57,15 +57,16 @@ type Workflow interface {
 }
 
 type FileChanges struct {
-	ChangeType  string
-	Identifier  string
-	Status      string
-	Title       string
-	Details     []string
-	Tags        []string
-	SectionID   int64
-	SectionName string
-	TTL         int64
+	ChangeType   string
+	Identifier   string
+	Status       string
+	Title        string
+	Details      []string
+	Tags         []string
+	SectionID    int64
+	SectionName  string
+	TTL          int64
+	WorkflowName string
 }
 
 type SerializedFileChange struct {
@@ -400,7 +401,7 @@ func formatComments(comments []*github.PullRequestComment) (int, []string) {
 	return len(comments), str_comments
 }
 
-func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel chan FileChanges, db *database.DB, section *database.Section, change_wg *sync.WaitGroup, includeDiff bool) RunResult {
+func ProcessPRsDB(log *slog.Logger, workflowName string, prs []*github.PullRequest, changes_channel chan FileChanges, db *database.DB, section *database.Section, change_wg *sync.WaitGroup, includeDiff bool) RunResult {
 	result := RunResult{}
 
 	ttl := time.Now().Add(2 * time.Hour).Unix()
@@ -413,7 +414,7 @@ func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel c
 		buildWg.Add(1)
 		go func(i int, pr *github.PullRequest) {
 			defer buildWg.Done()
-			fc := SyncTODOToSectionDB(db, pr, section, includeDiff)
+			fc := SyncTODOToSectionDB(db, workflowName, pr, section, includeDiff)
 			fc.TTL = ttl
 			prChanges[i] = fc
 		}(i, pr)
@@ -435,29 +436,35 @@ func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel c
 			for _, item := range items {
 				if slices.Contains(pr_identifiers, item.Identifier) {
 					continue
-				} else {
-					var details []string
-					json.Unmarshal([]byte(item.DetailsJSON), &details)
-					var tags []string
-					json.Unmarshal([]byte(item.Tags), &tags)
-
-					fileChange := FileChanges{
-						ChangeType:  "Delete",
-						Identifier:  item.Identifier,
-						Status:      item.Status,
-						Title:       item.Title,
-						Details:     details,
-						Tags:        tags,
-						SectionID:   section.ID,
-						SectionName: section.SectionName,
-						TTL:         0,
-					}
-					changes = append(changes, fileChange)
 				}
+				// Only release ownership for items this workflow actually
+				// claims. Items maintained by other workflows are left alone
+				// here; cycle-end pruning removes anything with no owners.
+				if !slices.Contains(item.GetWorkflows(), workflowName) {
+					continue
+				}
+				var details []string
+				json.Unmarshal([]byte(item.DetailsJSON), &details)
+				var tags []string
+				json.Unmarshal([]byte(item.Tags), &tags)
+
+				fileChange := FileChanges{
+					ChangeType:   "Delete",
+					Identifier:   item.Identifier,
+					Status:       item.Status,
+					Title:        item.Title,
+					Details:      details,
+					Tags:         tags,
+					SectionID:    section.ID,
+					SectionName:  section.SectionName,
+					TTL:          0,
+					WorkflowName: workflowName,
+				}
+				changes = append(changes, fileChange)
 			}
 		}
 	}
-	
+
 	// Cleanup expired items
 	expiredItems, err := db.GetExpiredItems(section.ID)
 	if err == nil {
@@ -469,26 +476,31 @@ func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel c
 					break
 				}
 			}
-			
-			if !isBeingProcessed {
-				var details []string
-				json.Unmarshal([]byte(item.DetailsJSON), &details)
-				var tags []string
-				json.Unmarshal([]byte(item.Tags), &tags)
 
-				fileChange := FileChanges{
-					ChangeType:  "Delete",
-					Identifier:  item.Identifier,
-					Status:      item.Status,
-					Title:       item.Title,
-					Details:     details,
-					Tags:        tags,
-					SectionID:   section.ID,
-					SectionName: section.SectionName,
-					TTL:         0,
-				}
-				changes = append(changes, fileChange)
+			if isBeingProcessed {
+				continue
 			}
+			if !slices.Contains(item.GetWorkflows(), workflowName) {
+				continue
+			}
+			var details []string
+			json.Unmarshal([]byte(item.DetailsJSON), &details)
+			var tags []string
+			json.Unmarshal([]byte(item.Tags), &tags)
+
+			fileChange := FileChanges{
+				ChangeType:   "Delete",
+				Identifier:   item.Identifier,
+				Status:       item.Status,
+				Title:        item.Title,
+				Details:      details,
+				Tags:         tags,
+				SectionID:    section.ID,
+				SectionName:  section.SectionName,
+				TTL:          0,
+				WorkflowName: workflowName,
+			}
+			changes = append(changes, fileChange)
 		}
 	} else {
 		log.Error("Error getting expired items", "error", err)
@@ -501,12 +513,12 @@ func ProcessPRsDB(log *slog.Logger, prs []*github.PullRequest, changes_channel c
 	return result
 }
 
-func SyncTODOToSectionDB(db *database.DB, pr *github.PullRequest, section *database.Section, includeDiff bool) FileChanges {
+func SyncTODOToSectionDB(db *database.DB, workflowName string, pr *github.PullRequest, section *database.Section, includeDiff bool) FileChanges {
 	pr_as_org := PRToOrgBridge{PR: pr, IncludeDiff: includeDiff}
-	
+
 	identifier := pr_as_org.Identifier()
 	dbItem, err := db.GetItem(section.ID, identifier)
-	
+
 	found := err == nil && dbItem != nil
 	changeType := "Addition"
 	if found {
@@ -514,6 +526,10 @@ func SyncTODOToSectionDB(db *database.DB, pr *github.PullRequest, section *datab
 		newTags := pr_as_org.GetTags()
 		// Always update if status or tags changed (e.g. draft → non-draft)
 		if dbItem.Status != newStatus || dbItem.Tags != strings.Join(newTags, ",") {
+			changeType = "Update"
+		} else if workflowName != "" && !slices.Contains(dbItem.GetWorkflows(), workflowName) {
+			// Item exists but this workflow doesn't yet claim it; we need an
+			// upsert so the workflow gets added to the ownership list.
 			changeType = "Update"
 		} else {
 			// After a week we stop updating old merged PRs
@@ -525,17 +541,18 @@ func SyncTODOToSectionDB(db *database.DB, pr *github.PullRequest, section *datab
 			}
 		}
 	}
-	
+
 	return FileChanges{
-		ChangeType:  changeType,
-		Identifier:  identifier,
-		Status:      pr_as_org.GetStatus(),
-		Title:       pr_as_org.Title(),
-		Details:     pr_as_org.Details(),
-		Tags:        pr_as_org.GetTags(),
-		SectionID:   section.ID,
-		SectionName: section.SectionName,
-		TTL:         0, // Set by caller
+		ChangeType:   changeType,
+		Identifier:   identifier,
+		Status:       pr_as_org.GetStatus(),
+		Title:        pr_as_org.Title(),
+		Details:      pr_as_org.Details(),
+		Tags:         pr_as_org.GetTags(),
+		SectionID:    section.ID,
+		SectionName:  section.SectionName,
+		TTL:          0, // Set by caller
+		WorkflowName: workflowName,
 	}
 }
 

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -81,9 +81,14 @@ type ManagerService struct {
 }
 
 func deduplicateChanges(log *slog.Logger, changes []SerializedFileChange) []SerializedFileChange {
+	// Dedup is per (identifier, workflow): a single workflow may emit at most
+	// one canonical change per item per cycle, but different workflows that
+	// touch the same item must each contribute (e.g. one Update from workflow
+	// A and one Delete from workflow B both need to land so ownership is
+	// tracked correctly).
 	changesByIdentifier := make(map[string][]SerializedFileChange)
 	for _, change := range changes {
-		identifier := change.FileChange.Identifier
+		identifier := change.FileChange.Identifier + "\x00" + change.FileChange.WorkflowName
 		changesByIdentifier[identifier] = append(changesByIdentifier[identifier], change)
 	}
 
@@ -171,7 +176,7 @@ func ApplyChanges(log *slog.Logger, channel chan SerializedFileChange, wg *sync.
 
 		switch deserializedChange.FileChange.ChangeType {
 		case "Addition", "Update":
-			_, err := db.UpsertItem(
+			_, err := db.UpsertItemWithWorkflow(
 				deserializedChange.FileChange.SectionID,
 				deserializedChange.FileChange.Identifier,
 				deserializedChange.FileChange.Status,
@@ -179,6 +184,7 @@ func ApplyChanges(log *slog.Logger, channel chan SerializedFileChange, wg *sync.
 				deserializedChange.FileChange.Details,
 				deserializedChange.FileChange.Tags,
 				deserializedChange.FileChange.TTL,
+				deserializedChange.FileChange.WorkflowName,
 			)
 			if err != nil {
 				log.Error("Error upserting item", "error", err, "identifier", deserializedChange.FileChange.Identifier)
@@ -187,9 +193,16 @@ func ApplyChanges(log *slog.Logger, channel chan SerializedFileChange, wg *sync.
 				notifyPRAdded(log, deserializedChange.FileChange.SectionName, deserializedChange.FileChange.Title)
 			}
 		case "Delete":
-			err := db.DeleteItem(deserializedChange.FileChange.SectionID, deserializedChange.FileChange.Identifier)
+			// "Delete" now means "this workflow no longer claims this item".
+			// The row stays in place; PruneOrphanedItems removes anything
+			// left with no remaining owners after the cycle completes.
+			err := db.RemoveWorkflowFromItem(
+				deserializedChange.FileChange.SectionID,
+				deserializedChange.FileChange.Identifier,
+				deserializedChange.FileChange.WorkflowName,
+			)
 			if err != nil {
-				log.Error("Error deleting item", "error", err, "identifier", deserializedChange.FileChange.Identifier)
+				log.Error("Error releasing workflow ownership", "error", err, "identifier", deserializedChange.FileChange.Identifier, "workflow", deserializedChange.FileChange.WorkflowName)
 			}
 		}
 		changeCount++
@@ -516,6 +529,7 @@ func (ms *ManagerService) Run(log *slog.Logger) {
 		if waitTimeout(&listener_wg, 240*time.Second) {
 			log.Error("Listener waitgroup timed out waiting for changes to be applied")
 		}
+		pruneOrphanedItems(log)
 	} else {
 		cycle_count := 0
 		for {
@@ -564,6 +578,8 @@ func (ms *ManagerService) Run(log *slog.Logger) {
 				log.Error("Cycle waitgroup timed out waiting for changes to be applied")
 			}
 
+			pruneOrphanedItems(log)
+
 			// Log cycle completion so the throttle check works on next server start.
 			if err := db.LogWorkflowCycle(); err != nil {
 				log.Error("Failed to log workflow cycle completion", "error", err)
@@ -574,6 +590,20 @@ func (ms *ManagerService) Run(log *slog.Logger) {
 		}
 	}
 	log.Info("Exiting Service")
+}
+
+// pruneOrphanedItems deletes any items that are no longer claimed by any
+// workflow. Run after every cycle once all per-workflow ownership updates have
+// been applied.
+func pruneOrphanedItems(log *slog.Logger) {
+	deleted, err := config.C().DB.PruneOrphanedItems()
+	if err != nil {
+		log.Error("Failed to prune orphaned items", "error", err)
+		return
+	}
+	if deleted > 0 {
+		log.Info("Pruned orphaned items", "count", deleted)
+	}
 }
 
 func (ms *ManagerService) Initialize() {

--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -98,7 +98,7 @@ func (w SyncReviewRequestsWorkflow) Run(log *slog.Logger, prs []*github.PullRequ
 
 	beforeCount, _ := db.GetItemCount()
 	log.Info("Starting workflow", "items_before", beforeCount)
-	result := ProcessPRsDB(log, prs, c, db, section, file_change_wg, w.IncludeDiff)
+	result := ProcessPRsDB(log, w.Name, prs, c, db, section, file_change_wg, w.IncludeDiff)
 	afterCount, _ := db.GetItemCount()
 	log.Info("Finished workflow", "items_after", afterCount)
 	return result, nil
@@ -157,7 +157,7 @@ func (w ProjectListWorkflow) Run(log *slog.Logger, prs []*github.PullRequest, c 
 
 	beforeCount, _ := db.GetItemCount()
 	log.Info("Starting workflow", "items_before", beforeCount)
-	result := ProcessPRsDB(log, prs, c, db, section, file_change_wg, w.IncludeDiff)
+	result := ProcessPRsDB(log, w.Name, prs, c, db, section, file_change_wg, w.IncludeDiff)
 	afterCount, _ := db.GetItemCount()
 	log.Info("Finished workflow", "items_after", afterCount)
 	return result, nil


### PR DESCRIPTION
Previously, two workflows pointing at the same section would prune each
other's PRs: each workflow's ProcessPRsDB compared the section's items
against its own current PR list and deleted everything missing from
that list, ignoring whether another workflow was actively maintaining
the item.

Add a `workflows` JSON-array column on items recording which workflows
maintain each row. Upserts merge the running workflow's name into the
list; "Delete" changes now release the workflow's claim instead of
deleting the row outright. After every cycle we prune any item whose
ownership list is empty.

https://claude.ai/code/session_016t2mJfC5jEqVe7bYEb3iCD