### PR TITLE
Add API call statistics tracking to database

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -214,6 +214,22 @@ func (db *DB) initSchema() error {
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		completed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
+
+	CREATE TABLE IF NOT EXISTS APICallStats (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		pr_list INTEGER NOT NULL DEFAULT 0,
+		pr_specific INTEGER NOT NULL DEFAULT 0,
+		comments INTEGER NOT NULL DEFAULT 0,
+		issue_comments INTEGER NOT NULL DEFAULT 0,
+		ci_status INTEGER NOT NULL DEFAULT 0,
+		diff INTEGER NOT NULL DEFAULT 0,
+		reviews INTEGER NOT NULL DEFAULT 0,
+		combined_status INTEGER NOT NULL DEFAULT 0,
+		check_runs INTEGER NOT NULL DEFAULT 0,
+		commits INTEGER NOT NULL DEFAULT 0,
+		total INTEGER NOT NULL DEFAULT 0
+	);
 	`
 
 	_, err := db.conn.Exec(schema)
@@ -1159,6 +1175,18 @@ func (db *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
 
 func (db *DB) QueryRow(query string, args ...interface{}) *sql.Row {
 	return db.conn.QueryRow(query, args...)
+}
+
+// LogAPICallStats persists per-type GitHub API call counts for a completed workflow cycle.
+func (db *DB) LogAPICallStats(prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits int64) error {
+	total := prList + prSpecific + comments + issueComments + ciStatus + diff + reviews + combinedStatus + checkRuns + commits
+	_, err := db.conn.Exec(
+		`INSERT INTO APICallStats
+			(pr_list, pr_specific, comments, issue_comments, ci_status, diff, reviews, combined_status, check_runs, commits, total)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits, total,
+	)
+	return err
 }
 
 // LogWorkflowCycle records a completed workflow cycle in the DB.

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -476,6 +476,21 @@ func (ms ManagerService) RunOnce(log *slog.Logger, file_change_wg *sync.WaitGrou
 		log.Info("Completed RunOnce Waitgroup")
 	}
 	apiCalls.log(log)
+	db := config.C().DB
+	if err := db.LogAPICallStats(
+		apiCalls.PRList.Load(),
+		apiCalls.PRSpecific.Load(),
+		apiCalls.Comments.Load(),
+		apiCalls.IssueComments.Load(),
+		apiCalls.CIStatus.Load(),
+		apiCalls.Diff.Load(),
+		apiCalls.Reviews.Load(),
+		apiCalls.CombinedStatus.Load(),
+		apiCalls.CheckRuns.Load(),
+		apiCalls.Commits.Load(),
+	); err != nil {
+		log.Error("Failed to save API call stats to database", "error", err)
+	}
 }
 
 func (ms *ManagerService) Run(log *slog.Logger) {


### PR DESCRIPTION
## Summary

This change adds persistent tracking of GitHub API call counts by type for each completed workflow cycle. A new `APICallStats` table stores granular metrics on API usage patterns, enabling better monitoring and optimization of API consumption.

### Changes

- Add `APICallStats` table to database schema with per-type API call counters (PR list, PR specific, comments, issue comments, CI status, diff, reviews, combined status, check runs, commits) and a total count
- Implement `LogAPICallStats()` method in database layer to persist API call statistics after each workflow cycle
- Integrate API stats logging into `RunOnce()` workflow manager to automatically record metrics at the end of each cycle

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_013ueoavwW6ww9WTsKK5xqdS