### PR TITLE
Support multiple repos in ProjectListWorkflow

### DIFF
--- a/jira/jira.go
+++ b/jira/jira.go
@@ -43,9 +43,9 @@ func getAuth() (string, string) {
 	return jiraEmail, token
 }
 
-// / Get all of the PRs #s for a repo under a JIRA epic
-func GetProjectPRKeys(domain string, epicKey string, repo_name string) []int {
-	// fmt.Printf("Searching for project shas for project: `%s`\n", epicKey)
+// GetProjectPRKeys returns the PR numbers for every target repo under a JIRA epic,
+// keyed by the repo short name (e.g. "code-review-server").
+func GetProjectPRKeys(domain string, epicKey string, repo_names []string) map[string][]int {
 	if !strings.HasSuffix(domain, "/") {
 		domain += "/"
 	}
@@ -60,7 +60,7 @@ func GetProjectPRKeys(domain string, epicKey string, repo_name string) []int {
 	req, err := http.NewRequest("GET", searchURL, nil)
 	if err != nil {
 		slog.Error("Error creating request", "error", err)
-		return []int{}
+		return map[string][]int{}
 	}
 	req.URL.RawQuery = params.Encode()
 
@@ -71,7 +71,7 @@ func GetProjectPRKeys(domain string, epicKey string, repo_name string) []int {
 	resp, err := client.Do(req)
 	if err != nil {
 		slog.Error("Error making request", "error", err)
-		return []int{}
+		return map[string][]int{}
 	}
 	defer resp.Body.Close()
 
@@ -81,31 +81,36 @@ func GetProjectPRKeys(domain string, epicKey string, repo_name string) []int {
 		body := make([]byte, 1024)
 		n, _ := resp.Body.Read(body) // We ignore the error here.
 		slog.Error("JIRA response body", "content", string(body[:n]))
-		return []int{}
+		return map[string][]int{}
 	}
 
 	var data JiraSearchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		slog.Error("Error decoding JSON", "error", err)
-		return []int{}
+		return map[string][]int{}
 	}
 
-	return processIssues(domain, data, repo_name)
+	return processIssues(domain, data, repo_names)
 
 }
 
-func processIssues(domain string, data JiraSearchResponse, target_repo string) []int {
-	// this function right now only works for a single repo.
-	// Returns a list of the PR numbers.
+type issuePR struct {
+	repo string
+	num  int
+}
 
-	var (
-		PRNumbers []int
-		mu        sync.Mutex
-		wg        sync.WaitGroup
-	)
+func processIssues(domain string, data JiraSearchResponse, target_repos []string) map[string][]int {
+	// Returns a map of repo short name -> list of PR numbers for that repo.
 
-	errChan := make(chan error, len(data.Issues))   // Buffered channel for errors
-	resultsChan := make(chan int, len(data.Issues)) // Buffered channel for merge SHAs
+	targets := make(map[string]struct{}, len(target_repos))
+	for _, r := range target_repos {
+		targets[r] = struct{}{}
+	}
+
+	var wg sync.WaitGroup
+
+	errChan := make(chan error, len(data.Issues))
+	resultsChan := make(chan issuePR, len(data.Issues))
 
 	for _, issue := range data.Issues {
 		wg.Add(1)
@@ -128,19 +133,19 @@ func processIssues(domain string, data JiraSearchResponse, target_repo string) [
 				return
 			}
 
-			// fmt.Println("checking the url: " + pr.URL)
-			prNumber := strings.Split(pr.URL, "/")
-			repo := prNumber[len(prNumber)-3]
-			if repo != target_repo {
+			urlParts := strings.Split(pr.URL, "/")
+			repo := urlParts[len(urlParts)-3]
+			if _, ok := targets[repo]; !ok {
 				errChan <- fmt.Errorf("Issue PR is for a separate repo: %s", repo)
 				return
 			}
-			prNum := prNumber[len(prNumber)-1]
+			prNum := urlParts[len(urlParts)-1]
 			num, err := strconv.Atoi(prNum)
 			if err != nil {
 				errChan <- fmt.Errorf("Failed to convert prNum %s to int", prNum)
+				return
 			}
-			resultsChan <- num
+			resultsChan <- issuePR{repo: repo, num: num}
 		}(issue)
 	}
 
@@ -148,19 +153,11 @@ func processIssues(domain string, data JiraSearchResponse, target_repo string) [
 	close(errChan)
 	close(resultsChan)
 
-	// Collect errors
-	// for err := range errChan {
-	//	fmt.Println(err)
-	// }
-
-	// Collect merge SHAs
-	for PRNumber := range resultsChan {
-		mu.Lock()
-		PRNumbers = append(PRNumbers, PRNumber)
-		mu.Unlock()
+	out := make(map[string][]int)
+	for r := range resultsChan {
+		out[r.repo] = append(out[r.repo], r.num)
 	}
-
-	return PRNumbers
+	return out
 }
 
 func getPRLinkForIssue(domain string, issueID string) (*JiraPullRequestIdentifier, error) {

--- a/workflows/builders.go
+++ b/workflows/builders.go
@@ -23,7 +23,7 @@ func MatchWorkflows(workflow_maps []config.RawWorkflow, repos *[]string, jiraDom
 		case "ListMyPRsWorkflow":
 			wf, err = BuildListMyPRsWorkflow(&raw_workflow, repos)
 		case "ProjectListWorkflow":
-			wf, err = BuildProjectListWorkflow(&raw_workflow, jiraDomain)
+			wf, err = BuildProjectListWorkflow(&raw_workflow, repos, jiraDomain)
 		default:
 			slog.Warn("Skipping workflow with unknown WorkflowType", "name", raw_workflow.Name, "type", raw_workflow.WorkflowType)
 			continue
@@ -108,15 +108,22 @@ func BuildListMyPRsWorkflow(raw *config.RawWorkflow, repos *[]string) (Workflow,
 	return wf, nil
 }
 
-func BuildProjectListWorkflow(raw *config.RawWorkflow, jiraDomain string) (Workflow, error) {
+func BuildProjectListWorkflow(raw *config.RawWorkflow, repos *[]string, jiraDomain string) (Workflow, error) {
+	workflowRepos := *repos
+	if len(raw.Repos) > 0 {
+		workflowRepos = raw.Repos
+	} else if raw.Owner != "" && raw.Repo != "" {
+		// Backward compat for configs using singular Owner/Repo.
+		workflowRepos = []string{fmt.Sprintf("%s/%s", raw.Owner, raw.Repo)}
+	}
+
 	filters, err := BuildFiltersList(raw)
 	if err != nil {
 		return nil, err
 	}
 	wf := ProjectListWorkflow{
 		Name:                 raw.Name,
-		Owner:                raw.Owner,
-		Repo:                 raw.Repo,
+		Repos:                workflowRepos,
 		JiraDomain:           jiraDomain,
 		JiraEpic:             raw.JiraEpic,
 		Filters:              filters,

--- a/workflows/requirements_test.go
+++ b/workflows/requirements_test.go
@@ -66,8 +66,7 @@ func TestGetPRRequirements(t *testing.T) {
 		{
 			name: "ProjectListWorkflow",
 			workflow: ProjectListWorkflow{
-				Owner:      "owner",
-				Repo:       "repo",
+				Repos:      []string{"owner/repo"},
 				JiraEpic:   "EPIC-123",
 				JiraDomain: "domain.atlassian.net",
 			},

--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -127,8 +127,7 @@ func (w SyncReviewRequestsWorkflow) GetOrgSectionName() string {
 
 type ProjectListWorkflow struct {
 	Name         string
-	Owner        string
-	Repo         string
+	Repos        []string
 	Filters      []git_tools.PRFilter
 	SectionTitle string
 	JiraDomain   string
@@ -173,17 +172,50 @@ func (w ProjectListWorkflow) Run(log *slog.Logger, prs []*github.PullRequest, c 
 		// I used to let just define []int for PR #s in config, could easily bring that back
 		return RunResult{}, errors.New("ProjectList requires Jira Epic")
 	}
-	projectPRs := jira.GetProjectPRKeys(w.JiraDomain, w.JiraEpic, w.Repo)
-
-	prs, err = git_tools.GetSpecificPRs(client, w.Owner, w.Repo, projectPRs)
-	if err != nil {
-		log.Error("Error getting specific PRs", "error", err)
-		return RunResult{}, err
+	if len(w.Repos) == 0 {
+		return RunResult{}, errors.New("ProjectList requires at least one repo")
 	}
+
+	// Resolve each configured "owner/repo" to its short name so the JIRA filter
+	// (which only sees the repo short name in PR URLs) can match and we can map
+	// results back to the correct owner when fetching from GitHub.
+	type repoRef struct{ owner, repo string }
+	shortToRef := make(map[string]repoRef, len(w.Repos))
+	shortRepos := make([]string, 0, len(w.Repos))
+	for _, entry := range w.Repos {
+		owner, repo, err := git_tools.ParseRepoName(entry)
+		if err != nil {
+			log.Error("Skipping invalid repo entry", "entry", entry, "error", err)
+			continue
+		}
+		shortToRef[repo] = repoRef{owner: owner, repo: repo}
+		shortRepos = append(shortRepos, repo)
+	}
+	if len(shortRepos) == 0 {
+		return RunResult{}, errors.New("ProjectList has no valid repos")
+	}
+
+	prsByRepo := jira.GetProjectPRKeys(w.JiraDomain, w.JiraEpic, shortRepos)
+
+	var allPRs []*github.PullRequest
+	for short, nums := range prsByRepo {
+		if len(nums) == 0 {
+			continue
+		}
+		ref := shortToRef[short]
+		repoPRs, err := git_tools.GetSpecificPRs(client, ref.owner, ref.repo, nums)
+		if err != nil {
+			log.Error("Error getting specific PRs", "owner", ref.owner, "repo", ref.repo, "error", err)
+			continue
+		}
+		allPRs = append(allPRs, repoPRs...)
+	}
+
+	allPRs = git_tools.ApplyPRFilters(allPRs, w.Filters)
 
 	beforeCount, _ := db.GetItemCount()
 	log.Info("Starting workflow", "items_before", beforeCount)
-	result := ProcessPRsDB(log, prs, c, db, section, file_change_wg, w.IncludeDiff, w.ShouldNotify())
+	result := ProcessPRsDB(log, allPRs, c, db, section, file_change_wg, w.IncludeDiff, w.ShouldNotify())
 	afterCount, _ := db.GetItemCount()
 	log.Info("Finished workflow", "items_after", afterCount)
 	return result, nil


### PR DESCRIPTION
## Summary

Refactor `ProjectListWorkflow` to support multiple repositories instead of a single repo. This allows a single workflow to aggregate PRs from multiple repos that are linked to the same JIRA epic.

### Changes

- **jira.go**: 
  - Changed `GetProjectPRKeys()` to accept `repo_names []string` instead of `repo_name string`
  - Changed return type from `[]int` to `map[string][]int` to map repo short names to their PR numbers
  - Updated `processIssues()` to handle multiple target repos and return results keyed by repo
  - Added `issuePR` struct to track both repo and PR number during concurrent processing

- **workflows.go**:
  - Changed `ProjectListWorkflow` struct to use `Repos []string` instead of separate `Owner` and `Repo` fields
  - Updated `Run()` method to:
    - Parse multiple "owner/repo" entries from config
    - Map repo short names back to their owner/repo pairs for GitHub API calls
    - Fetch PRs from each repo separately and aggregate results
    - Apply filters to the combined PR list

- **workflows/builders.go**:
  - Updated `BuildProjectListWorkflow()` to accept `repos` parameter
  - Added backward compatibility for configs using the old singular `Owner`/`Repo` fields
  - Prioritizes `Repos` array if present, falls back to `Owner`/`Repo` format

- **workflows/requirements_test.go**:
  - Updated test to use new `Repos` field format

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_01Bpp1BrMK4zSekcs8KDLovz