### PR TITLE
Filter out BODY details from rendered org items

### DIFF
--- a/server/renderer.go
+++ b/server/renderer.go
@@ -376,7 +376,11 @@ func (r *OrgRenderer) buildItemLines(item *database.Item, indentLevel int) []str
 	}
 
 	lines := []string{titleLine + "\n"}
-	lines = append(lines, details...)
+	for _, d := range details {
+		if !strings.HasPrefix(d, "*** BODY") {
+			lines = append(lines, d)
+		}
+	}
 
 	return lines
 }


### PR DESCRIPTION
## Summary

Modify the item rendering logic to exclude details that start with "*** BODY" when building org-formatted output lines. This prevents duplicate or unwanted body content from appearing in the rendered item representation.

### Changes

- Updated `buildItemLines()` in `renderer.go` to filter out details with "*** BODY" prefix
- Changed from directly appending all details to iterating and conditionally appending only non-BODY details

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_01FWAPYUW4JPnXBPFwsp2vGo