### PR TITLE
Display PR review status in dashboard details

### DIFF
--- a/workflows/logic.go
+++ b/workflows/logic.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -45,8 +46,9 @@ type PRAuxData struct {
 	CIStatus          *git_tools.CIStatusInfo
 	Diff              string
 	DiffLines         []string
-	HeadSHA           string // SHA of the PR head for DB storage
-	BaseSHA           string // SHA of the PR base for DB storage
+	Reviews           []*github.PullRequestReview // PR reviews (for approved_by / changes_requested_by / commented_by)
+	HeadSHA           string                      // SHA of the PR head for DB storage
+	BaseSHA           string                      // SHA of the PR base for DB storage
 }
 
 type Workflow interface {
@@ -214,6 +216,17 @@ func (prb PRToOrgBridge) Details() []string {
 		auxData, _ = store.Get(key)
 	}
 
+	// For open non-draft PRs, surface who has already reviewed so the dashboard
+	// reflects current review state alongside the pending-reviewer list.
+	isOpen := prb.PR.State != nil && *prb.PR.State == "open"
+	isDraft := prb.PR.Draft != nil && *prb.PR.Draft
+	if isOpen && !isDraft {
+		approvedBy, changesRequestedBy, commentedBy := summarizeReviewers(auxData)
+		details = append(details, fmt.Sprintf("Approved By: %s\n", strings.Join(approvedBy, ", ")))
+		details = append(details, fmt.Sprintf("Changes Requested By: %s\n", strings.Join(changesRequestedBy, ", ")))
+		details = append(details, fmt.Sprintf("Commented By: %s\n", strings.Join(commentedBy, ", ")))
+	}
+
 	// TODO: Consider putting these in subsection?
 	if prb.PR.MergedAt != nil {
 		details = append(details, fmt.Sprintf("Merged at: %s\n", *prb.PR.MergedAt))
@@ -292,6 +305,45 @@ func (prb PRToOrgBridge) Details() []string {
 
 func getReviewerName(reviewer *github.User) string {
 	return *reviewer.Login
+}
+
+// summarizeReviewers reduces a PR's review list down to the latest state per
+// reviewer and partitions them into approved / changes-requested / commented
+// buckets. Returns empty slices when auxData or its Reviews field is nil.
+func summarizeReviewers(auxData *PRAuxData) (approvedBy, changesRequestedBy, commentedBy []string) {
+	approvedBy = []string{}
+	changesRequestedBy = []string{}
+	commentedBy = []string{}
+	if auxData == nil || auxData.Reviews == nil {
+		return
+	}
+	latest := make(map[string]string)
+	for _, r := range auxData.Reviews {
+		if r == nil || r.User == nil {
+			continue
+		}
+		state := r.GetState()
+		// Ignore non-terminal states like PENDING / DISMISSED so they don't
+		// clobber a reviewer's actual APPROVED / CHANGES_REQUESTED verdict.
+		if state != "APPROVED" && state != "CHANGES_REQUESTED" && state != "COMMENTED" {
+			continue
+		}
+		latest[r.User.GetLogin()] = state
+	}
+	for user, state := range latest {
+		switch state {
+		case "APPROVED":
+			approvedBy = append(approvedBy, user)
+		case "CHANGES_REQUESTED":
+			changesRequestedBy = append(changesRequestedBy, user)
+		case "COMMENTED":
+			commentedBy = append(commentedBy, user)
+		}
+	}
+	sort.Strings(approvedBy)
+	sort.Strings(changesRequestedBy)
+	sort.Strings(commentedBy)
+	return
 }
 
 func getTeamName(reviewer *github.Team) string {
@@ -517,8 +569,14 @@ func SyncTODOToSectionDB(db *database.DB, pr *github.PullRequest, section *datab
 	if found {
 		newStatus := pr_as_org.GetStatus()
 		newTags := pr_as_org.GetTags()
+		isOpen := pr.State != nil && *pr.State == "open"
+		isDraft := pr.Draft != nil && *pr.Draft
 		// Always update if status or tags changed (e.g. draft → non-draft)
 		if dbItem.Status != newStatus || dbItem.Tags != strings.Join(newTags, ",") {
+			changeType = "Update"
+		} else if isOpen && !isDraft {
+			// Refresh reviewer status (approved / changes-requested / commented)
+			// on every cycle for open non-draft PRs.
 			changeType = "Update"
 		} else {
 			// After a week we stop updating old merged PRs

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -644,6 +644,13 @@ func (ms ManagerService) prefetchAuxData(log *slog.Logger, client *github.Client
 				existing.Comments = existing.Comments || req.AuxData.Comments
 				existing.CIStatus = existing.CIStatus || req.AuxData.CIStatus
 				existing.Diff = existing.Diff || req.AuxData.Diff
+				existing.Reviews = existing.Reviews || req.AuxData.Reviews
+				existing.Commits = existing.Commits || req.AuxData.Commits
+				// Always fetch reviews for open non-draft PRs so Details() can
+				// display who has approved / requested changes / commented.
+				if pr.State != nil && *pr.State == "open" && (pr.Draft == nil || !*pr.Draft) {
+					existing.Reviews = true
+				}
 				prRequirements[key] = existing
 			}
 		}
@@ -780,6 +787,7 @@ func fetchAuxDataForPR(log *slog.Logger, client *github.Client,
 				return
 			}
 			ghReviews = reviews
+			auxData.Reviews = reviews
 		}()
 	}
 


### PR DESCRIPTION
## Summary

This change adds visibility into PR review status by displaying who has approved, requested changes, or commented on each PR in the dashboard details section. This helps users quickly see the current review state of open non-draft PRs alongside the pending reviewer list.

### Changes

- Added `Reviews` field to `PRAuxData` struct to store PR review information from GitHub
- Implemented `summarizeReviewers()` function to partition reviews by state (approved/changes-requested/commented) and track only the latest state per reviewer
- Updated `Details()` method to display review status for open non-draft PRs
- Modified `prefetchAuxData()` to always fetch reviews for open non-draft PRs
- Updated `fetchAuxDataForPR()` to populate the `Reviews` field in `auxData`
- Enhanced `SyncTODOToSectionDB()` to refresh reviewer status on every cycle for open non-draft PRs
- Added `sort` import for consistent ordering of reviewer names

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_01R6nZ8QFGfgdYF8c28e4hcy