### PR TITLE
Handle dismissed reviews in FilterMyReviewRequested

### DIFF
--- a/git_tools/git_tools.go
+++ b/git_tools/git_tools.go
@@ -213,19 +213,6 @@ func MakeTeamFilters(teams []string) func([]*github.PullRequest) []*github.PullR
 	}
 }
 
-func FilterMyReviewRequested(prs []*github.PullRequest) []*github.PullRequest {
-	filtered := []*github.PullRequest{}
-	for _, pr := range prs {
-		for _, reviewer := range pr.RequestedReviewers {
-			if strings.EqualFold(*reviewer.Login, config.C().GithubUsername) {
-				filtered = append(filtered, pr)
-				break
-			}
-		}
-	}
-	return filtered
-}
-
 // githubSemaphore limits concurrent in-flight GitHub API requests to 50
 // to avoid hitting GitHub's secondary rate limits.
 var githubSemaphore = make(chan struct{}, 50)

--- a/workflows/builders.go
+++ b/workflows/builders.go
@@ -156,7 +156,7 @@ func computeAuxRequirements(filterNames []string, includeDiff bool) AuxDataRequi
 }
 
 var filter_func_map = map[string]func(prs []*github.PullRequest) []*github.PullRequest{
-	"FilterMyReviewRequested": git_tools.FilterMyReviewRequested,
+	"FilterMyReviewRequested": filterMyReviewRequested,
 	"FilterNotDraft":          git_tools.FilterNotDraft,
 	"FilterIsDraft":           git_tools.FilterIsDraft,
 	"FilterNotMyPRs":          git_tools.FilterNotMyPRs,

--- a/workflows/filters.go
+++ b/workflows/filters.go
@@ -1,0 +1,89 @@
+package workflows
+
+import (
+	"crs/config"
+	"strings"
+
+	"github.com/google/go-github/v48/github"
+)
+
+// filterMyReviewRequested matches PRs where the configured user owes a review.
+// A user owes a review when either:
+//  1. They are in pr.RequestedReviewers (a normal pending request), OR
+//  2. Their latest review on the PR has state DISMISSED. CODEOWNERS stale-review
+//     auto-dismissal removes the user's prior approval but does NOT add them
+//     back to RequestedReviewers, so case 1 alone misses these PRs.
+func filterMyReviewRequested(prs []*github.PullRequest) []*github.PullRequest {
+	myLogin := config.C().GithubUsername
+	store := GetCurrentAuxDataStore()
+	filtered := []*github.PullRequest{}
+	for _, pr := range prs {
+		if pr == nil {
+			continue
+		}
+		if userInRequestedReviewers(pr, myLogin) {
+			filtered = append(filtered, pr)
+			continue
+		}
+		if store == nil {
+			continue
+		}
+		key, ok := prKey(pr)
+		if !ok {
+			continue
+		}
+		aux, ok := store.Get(key)
+		if !ok || aux == nil {
+			continue
+		}
+		if latestUserReviewIsDismissed(aux.Reviews, myLogin) {
+			filtered = append(filtered, pr)
+		}
+	}
+	return filtered
+}
+
+func userInRequestedReviewers(pr *github.PullRequest, login string) bool {
+	for _, reviewer := range pr.RequestedReviewers {
+		if reviewer == nil || reviewer.Login == nil {
+			continue
+		}
+		if strings.EqualFold(*reviewer.Login, login) {
+			return true
+		}
+	}
+	return false
+}
+
+func prKey(pr *github.PullRequest) (PRKey, bool) {
+	if pr.Base == nil || pr.Base.Repo == nil ||
+		pr.Base.Repo.Owner == nil || pr.Base.Repo.Owner.Login == nil ||
+		pr.Base.Repo.Name == nil || pr.Number == nil {
+		return PRKey{}, false
+	}
+	return PRKey{
+		Owner:  *pr.Base.Repo.Owner.Login,
+		Repo:   *pr.Base.Repo.Name,
+		Number: *pr.Number,
+	}, true
+}
+
+// latestUserReviewIsDismissed reports whether the most recent review submitted
+// by login has state DISMISSED. Returns false if the user has not reviewed the
+// PR or if their latest review is APPROVED / CHANGES_REQUESTED / COMMENTED
+// (i.e. they have already weighed in since any prior dismissal).
+func latestUserReviewIsDismissed(reviews []*github.PullRequestReview, login string) bool {
+	var latest *github.PullRequestReview
+	for _, r := range reviews {
+		if r == nil || r.User == nil || r.User.Login == nil || r.SubmittedAt == nil {
+			continue
+		}
+		if !strings.EqualFold(*r.User.Login, login) {
+			continue
+		}
+		if latest == nil || r.SubmittedAt.After(*latest.SubmittedAt) {
+			latest = r
+		}
+	}
+	return latest != nil && latest.GetState() == "DISMISSED"
+}

--- a/workflows/filters_test.go
+++ b/workflows/filters_test.go
@@ -1,0 +1,207 @@
+package workflows
+
+import (
+	"crs/config"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v48/github"
+)
+
+func TestLatestUserReviewIsDismissed(t *testing.T) {
+	me := "myself"
+	other := "someone-else"
+
+	t0 := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	mkReview := func(login, state string, at time.Time) *github.PullRequestReview {
+		l, s := login, state
+		t := at
+		return &github.PullRequestReview{
+			User:        &github.User{Login: &l},
+			State:       &s,
+			SubmittedAt: &t,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		reviews []*github.PullRequestReview
+		want    bool
+	}{
+		{
+			name:    "no reviews",
+			reviews: nil,
+			want:    false,
+		},
+		{
+			name: "user has only an APPROVED review",
+			reviews: []*github.PullRequestReview{
+				mkReview(me, "APPROVED", t0),
+			},
+			want: false,
+		},
+		{
+			name: "user's only review is DISMISSED",
+			reviews: []*github.PullRequestReview{
+				mkReview(me, "DISMISSED", t0),
+			},
+			want: true,
+		},
+		{
+			name: "user APPROVED then was DISMISSED (latest is DISMISSED)",
+			reviews: []*github.PullRequestReview{
+				mkReview(me, "APPROVED", t0),
+				mkReview(me, "DISMISSED", t0.Add(time.Hour)),
+			},
+			want: true,
+		},
+		{
+			name: "user DISMISSED then APPROVED again (latest is APPROVED)",
+			reviews: []*github.PullRequestReview{
+				mkReview(me, "DISMISSED", t0),
+				mkReview(me, "APPROVED", t0.Add(time.Hour)),
+			},
+			want: false,
+		},
+		{
+			name: "only other user has a DISMISSED review",
+			reviews: []*github.PullRequestReview{
+				mkReview(other, "DISMISSED", t0),
+			},
+			want: false,
+		},
+		{
+			name: "case-insensitive login match",
+			reviews: []*github.PullRequestReview{
+				mkReview("MYSELF", "DISMISSED", t0),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := latestUserReviewIsDismissed(tt.reviews, me)
+			if got != tt.want {
+				t.Errorf("latestUserReviewIsDismissed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterMyReviewRequested(t *testing.T) {
+	me := "myself"
+	cfg := config.C()
+	cfg.GithubUsername = me
+	config.SetC(cfg)
+
+	owner := "owner"
+	repo := "repo"
+
+	mkPR := func(number int, reviewers ...string) *github.PullRequest {
+		n := number
+		o, r := owner, repo
+		users := []*github.User{}
+		for _, login := range reviewers {
+			l := login
+			users = append(users, &github.User{Login: &l})
+		}
+		return &github.PullRequest{
+			Number: &n,
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Owner: &github.User{Login: &o},
+					Name:  &r,
+				},
+			},
+			RequestedReviewers: users,
+		}
+	}
+
+	t0 := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	mkReview := func(login, state string, at time.Time) *github.PullRequestReview {
+		l, s := login, state
+		ts := at
+		return &github.PullRequestReview{
+			User:        &github.User{Login: &l},
+			State:       &s,
+			SubmittedAt: &ts,
+		}
+	}
+
+	// PR 1: user is in RequestedReviewers (normal pending request).
+	pr1 := mkPR(1, me)
+	// PR 2: user not in RequestedReviewers, but their latest review was DISMISSED.
+	pr2 := mkPR(2, "someone-else")
+	// PR 3: user not in RequestedReviewers and latest review is APPROVED → exclude.
+	pr3 := mkPR(3, "someone-else")
+	// PR 4: user has no history at all → exclude.
+	pr4 := mkPR(4, "someone-else")
+
+	store := NewAuxDataStore()
+	store.Set(PRKey{Owner: owner, Repo: repo, Number: 2}, &PRAuxData{
+		Reviews: []*github.PullRequestReview{
+			mkReview(me, "APPROVED", t0),
+			mkReview(me, "DISMISSED", t0.Add(time.Hour)),
+		},
+	})
+	store.Set(PRKey{Owner: owner, Repo: repo, Number: 3}, &PRAuxData{
+		Reviews: []*github.PullRequestReview{
+			mkReview(me, "DISMISSED", t0),
+			mkReview(me, "APPROVED", t0.Add(time.Hour)),
+		},
+	})
+	store.Set(PRKey{Owner: owner, Repo: repo, Number: 4}, &PRAuxData{})
+	SetCurrentAuxDataStore(store)
+	defer SetCurrentAuxDataStore(nil)
+
+	got := filterMyReviewRequested([]*github.PullRequest{pr1, pr2, pr3, pr4})
+
+	wantNumbers := map[int]bool{1: true, 2: true}
+	if len(got) != len(wantNumbers) {
+		t.Fatalf("filterMyReviewRequested returned %d PRs, want %d", len(got), len(wantNumbers))
+	}
+	for _, pr := range got {
+		if !wantNumbers[*pr.Number] {
+			t.Errorf("filterMyReviewRequested unexpectedly included PR #%d", *pr.Number)
+		}
+	}
+}
+
+func TestFilterMyReviewRequestedNoAuxStore(t *testing.T) {
+	me := "myself"
+	cfg := config.C()
+	cfg.GithubUsername = me
+	config.SetC(cfg)
+
+	SetCurrentAuxDataStore(nil)
+
+	owner, repo := "owner", "repo"
+	n1, n2 := 1, 2
+	pr1 := &github.PullRequest{
+		Number: &n1,
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				Owner: &github.User{Login: &owner},
+				Name:  &repo,
+			},
+		},
+		RequestedReviewers: []*github.User{{Login: &me}},
+	}
+	otherLogin := "other"
+	pr2 := &github.PullRequest{
+		Number: &n2,
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				Owner: &github.User{Login: &owner},
+				Name:  &repo,
+			},
+		},
+		RequestedReviewers: []*github.User{{Login: &otherLogin}},
+	}
+
+	got := filterMyReviewRequested([]*github.PullRequest{pr1, pr2})
+	if len(got) != 1 || *got[0].Number != 1 {
+		t.Errorf("expected only PR #1 with no aux store, got %d PRs", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

Enhance the review request filter to detect when a user's review has been dismissed by CODEOWNERS auto-dismissal. Previously, the filter only checked if a user was in `RequestedReviewers`, missing cases where a prior approval was dismissed but the user was not re-added to the request list.

### Changes

- Move `FilterMyReviewRequested` from `git_tools` to `workflows` package and enhance it to check both:
  1. User is in `pr.RequestedReviewers` (normal pending request)
  2. User's latest review state is `DISMISSED` (auto-dismissed by CODEOWNERS)
- Add `latestUserReviewIsDismissed()` helper to find the most recent review by a user and check if it was dismissed
- Add `userInRequestedReviewers()` helper for case-insensitive login matching
- Add `prKey()` helper to safely extract PR owner/repo/number for auxiliary data lookup
- Update filter function map in `builders.go` to reference the new location
- Add comprehensive unit tests covering edge cases: no reviews, multiple reviews, dismissal followed by re-approval, case-insensitive matching, and behavior when auxiliary data store is unavailable

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (new tests in `workflows/filters_test.go` cover all code paths)

https://claude.ai/code/session_01Su5EiAq7FDPo3mgMsrQUXN