### PR TITLE
Sort test files last in review diff display

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -1133,8 +1133,35 @@ export default function Review({
         }
     };
 
+    const isTestFile = (filename: string): boolean =>
+        /\.(test|spec)\.[jt]sx?$/.test(filename) ||
+        /_test\.[jt]sx?$/.test(filename) ||
+        /_test\.go$/.test(filename) ||
+        /\/__tests__\//.test(filename);
+
+    const sortParsedLinesTestsLast = (lines: ParsedLine[]): ParsedLine[] => {
+        const groups: ParsedLine[][] = [];
+        let currentGroup: ParsedLine[] = [];
+        for (const line of lines) {
+            if (line.lineType === 'file-header') {
+                if (currentGroup.length > 0) groups.push(currentGroup);
+                currentGroup = [line];
+            } else {
+                currentGroup.push(line);
+            }
+        }
+        if (currentGroup.length > 0) groups.push(currentGroup);
+        groups.sort((a, b) => {
+            const aIsTest = a[0].file ? isTestFile(a[0].file) : false;
+            const bIsTest = b[0].file ? isTestFile(b[0].file) : false;
+            if (aIsTest === bIsTest) return 0;
+            return aIsTest ? 1 : -1;
+        });
+        return groups.flat();
+    };
+
     const renderDiff = (filterFile?: string) => {
-        const lines = parseDiff();
+        const lines = sortParsedLinesTestsLast(parseDiff());
         if (lines.length === 0) return null;
 
         let currentFile: string | null = null;


### PR DESCRIPTION
## Summary

Reorder parsed diff lines to display test files after non-test files in the review component. This improves readability by grouping implementation changes together before test changes.

### Changes

- Added `isTestFile()` helper to detect test files by common naming patterns (`.test.`, `.spec.`, `_test.`, `__tests__/`)
- Added `sortParsedLinesTestsLast()` function to group diff lines by file and sort groups so test files appear last
- Updated `renderDiff()` to apply the new sorting before rendering

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] Manual verification: Review a PR with both implementation and test file changes; test files should appear after implementation files in the diff display

https://claude.ai/code/session_01LrUX3hwdz1FDgwDsuTtUNB