### PR TITLE
Change pprof server port from 6060 to 6061

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,8 +86,8 @@ func main() {
 
 	if *serverFlag {
 		go func() {
-			slog.Info("Starting pprof server", "addr", "localhost:6060")
-			if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			slog.Info("Starting pprof server", "addr", "localhost:6061")
+			if err := http.ListenAndServe("localhost:6061", nil); err != nil {
 				slog.Error("pprof server exited", "error", err)
 			}
 		}()


### PR DESCRIPTION
## Summary

Updates the pprof profiling server to listen on port 6061 instead of the default 6060. This avoids potential port conflicts with other services that may use the standard pprof port.

### Changes

- Changed pprof server listen address from `localhost:6060` to `localhost:6061`
- Updated corresponding log message to reflect the new port

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_011ZbPkCKQAK6wBoETjbs1Au