### PR TITLE
Add ability to re-execute deferred plugins

### DIFF
--- a/bun_client/frontend/src/api.ts
+++ b/bun_client/frontend/src/api.ts
@@ -22,6 +22,7 @@ const SPECIALIZED_ENDPOINTS: Record<string, string> = {
     'RPCHandler.GetAllReviews': '/api/reviews',
     'RPCHandler.ListPlugins': '/api/list-plugins',
     'RPCHandler.GetPluginOutput': '/api/get-plugin-output',
+    'RPCHandler.RerunPlugins': '/api/rerun-plugins',
     'RPCHandler.GetHunkContext': '/api/get-hunk-context',
 };
 

--- a/bun_client/frontend/src/components/PluginOutput.tsx
+++ b/bun_client/frontend/src/components/PluginOutput.tsx
@@ -30,6 +30,7 @@ export default function PluginOutput({
 }: PluginOutputProps) {
     const [loading, setLoading] = useState(false);
     const [pluginOutput, setPluginOutput] = useState<Record<string, PluginResult>>({});
+    const [executingPlugins, setExecutingPlugins] = useState<Set<string>>(new Set());
 
     useEffect(() => {
         loadPluginOutput();
@@ -62,6 +63,29 @@ export default function PluginOutput({
             setPluginOutput({});
         } finally {
             setLoading(false);
+        }
+    };
+
+    const executePlugin = async (pluginName: string) => {
+        setExecutingPlugins((prev: Set<string>) => new Set(prev).add(pluginName));
+        try {
+            await rpcCall('RPCHandler.RerunPlugins', [
+                {
+                    Owner: owner,
+                    Repo: repo,
+                    Number: number,
+                    Plugins: [pluginName],
+                },
+            ]);
+            await loadPluginOutput();
+        } catch (e) {
+            console.error('Failed to execute plugin:', e);
+        } finally {
+            setExecutingPlugins((prev: Set<string>) => {
+                const next = new Set(prev);
+                next.delete(pluginName);
+                return next;
+            });
         }
     };
 
@@ -143,10 +167,21 @@ export default function PluginOutput({
                                                 fontWeight: 600,
                                                 fontSize: '15px',
                                                 fontFamily: 'var(--font-mono)',
+                                                flex: 1,
                                             }}
                                         >
                                             {pluginName}
                                         </span>
+                                        {plugin.status.toLowerCase() === 'deferred' && (
+                                            <Button
+                                                onClick={() => executePlugin(pluginName)}
+                                                loading={executingPlugins.has(pluginName)}
+                                                variant="secondary"
+                                                size="sm"
+                                            >
+                                                Execute
+                                            </Button>
+                                        )}
                                     </div>
                                     <div
                                         style={{

--- a/bun_client/server.ts
+++ b/bun_client/server.ts
@@ -337,6 +337,11 @@ Bun.serve<{
             return handleRpc('RPCHandler.GetPluginOutput', [body]);
         }
 
+        if (url.pathname === '/api/rerun-plugins' && req.method === 'POST') {
+            const body = await req.json();
+            return handleRpc('RPCHandler.RerunPlugins', [body]);
+        }
+
         if (url.pathname === '/api/check-lsp' && req.method === 'GET') {
             return new Response(JSON.stringify({ available: !!DIFF_LSP_PATH }), {
                 headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

Adds UI and backend support for re-executing plugins that have a "deferred" status. Users can now click an "Execute" button on deferred plugins to trigger them on-demand, rather than waiting for the next scheduled workflow run.

### Changes

- **Frontend (`PluginOutput.tsx`)**: 
  - Added `executingPlugins` state to track which plugins are currently executing
  - Implemented `executePlugin()` function to call the new `RPCHandler.RerunPlugins` RPC method
  - Added "Execute" button that appears only for deferred plugins, with loading state during execution

- **Backend (`server.ts`)**:
  - Added `/api/rerun-plugins` POST endpoint that delegates to `RPCHandler.RerunPlugins`

- **API client (`api.ts`)**:
  - Registered `RPCHandler.RerunPlugins` → `/api/rerun-plugins` mapping in specialized endpoints

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] Manual verification: deferred plugins show "Execute" button, clicking it re-runs the plugin and updates output

https://claude.ai/code/session_01WyuFqPaUm9Fcq8surLJLXE