### PR TITLE
Sort test files last in diff output

### DIFF
--- a/server/renderer.go
+++ b/server/renderer.go
@@ -1672,9 +1672,27 @@ func buildCommentTree(tree []PRComment, filePath string, forceOutdated bool) str
 	return strings.Join(result, "\n")
 }
 
+// isTestFile reports whether a diff file looks like a test file, based on a
+// simple case-insensitive substring match of "test" against either path.
+func isTestFile(file *utils.DiffFile) bool {
+	return strings.Contains(strings.ToLower(file.NewName), "test") ||
+		strings.Contains(strings.ToLower(file.OrigName), "test")
+}
+
+// sortFilesTestsLast returns a copy of files with test files ordered after
+// non-test files, preserving the original relative order within each group.
+func sortFilesTestsLast(files []*utils.DiffFile) []*utils.DiffFile {
+	sorted := make([]*utils.DiffFile, len(files))
+	copy(sorted, files)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return !isTestFile(sorted[i]) && isTestFile(sorted[j])
+	})
+	return sorted
+}
+
 func formatDiff(diff *utils.Diff) string {
 	var builder strings.Builder
-	for _, file := range diff.Files {
+	for _, file := range sortFilesTestsLast(diff.Files) {
 		builder.WriteString(file.DiffHeader + "\n")
 
 		// The diff parser's lookahead misses ---/+++ lines for new/deleted files

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crs/database"
+	"crs/utils"
 	"encoding/json"
 	"sort"
 	"strings"
@@ -848,6 +849,56 @@ func TestGetAllReviewsSorting(t *testing.T) {
 		if got.Status != w.status || got.Repo != w.repo || got.Number != w.number {
 			t.Errorf("[%d] got {%s %s #%d}, want {%s %s #%d}",
 				i, got.Status, got.Repo, got.Number, w.status, w.repo, w.number)
+		}
+	}
+}
+
+func TestSortFilesTestsLast(t *testing.T) {
+	files := []*utils.DiffFile{
+		{NewName: "server/server.go"},
+		{NewName: "server/server_test.go"},
+		{NewName: "config/config.go"},
+		{NewName: "utils/diff_parser_test.go"},
+		{NewName: "client.el/test.el"},
+		{NewName: "README.md"},
+	}
+
+	got := sortFilesTestsLast(files)
+
+	wantOrder := []string{
+		"server/server.go",
+		"config/config.go",
+		"README.md",
+		"server/server_test.go",
+		"utils/diff_parser_test.go",
+		"client.el/test.el",
+	}
+	for i, w := range wantOrder {
+		if got[i].NewName != w {
+			t.Errorf("[%d] got %q, want %q", i, got[i].NewName, w)
+		}
+	}
+
+	// Original slice must not be mutated.
+	if files[1].NewName != "server/server_test.go" {
+		t.Errorf("input slice was mutated: %q", files[1].NewName)
+	}
+}
+
+func TestIsTestFile(t *testing.T) {
+	tests := []struct {
+		file *utils.DiffFile
+		want bool
+	}{
+		{&utils.DiffFile{NewName: "server/server_test.go"}, true},
+		{&utils.DiffFile{NewName: "server/server.go"}, false},
+		{&utils.DiffFile{NewName: "tests/integration.go"}, true},
+		{&utils.DiffFile{NewName: "FooTest.java"}, true},
+		{&utils.DiffFile{NewName: "", OrigName: "old_test.go"}, true},
+	}
+	for i, tc := range tests {
+		if got := isTestFile(tc.file); got != tc.want {
+			t.Errorf("[%d] isTestFile(%+v) = %v, want %v", i, tc.file, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This change reorders files in diff output to display test files after non-test files, improving readability by grouping related code changes together.

### Changes

- Added `isTestFile()` helper function that identifies test files using case-insensitive substring matching against file paths
- Added `sortFilesTestsLast()` function that stably sorts files with test files ordered after non-test files, without mutating the input slice
- Updated `formatDiff()` to use the new sorting function when rendering diffs
- Added comprehensive unit tests for both new functions covering various test file naming conventions (Go `_test.go`, Java `Test.java`, directory-based `tests/`, etc.)

## Test Plan

- [x] `go test ./...` passes — new unit tests `TestSortFilesTestsLast` and `TestIsTestFile` verify the sorting logic and test file detection

https://claude.ai/code/session_01CVfVGHTNVVmwJUsVn9ZFCb