### PR TITLE
Add LLM-based diff file ordering for PR reviews

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,10 @@ type Config struct {
 	SectionSorting  map[string]string // Map of section title to sorting method (e.g. "newest_first", "oldest_first")
 	Plugins         []Plugin
 	RepoConfigs     map[string]RepoConfig // Keyed by "owner/repo"
+	// ExperimentalLLMFileOrdering, when true, orders the files in a PR diff via
+	// an LLM (integration first, then implementation, then styling, then tests)
+	// instead of the default test-files-last sort. Off by default.
+	ExperimentalLLMFileOrdering bool
 	DB              *database.DB
 }
 
@@ -140,6 +144,7 @@ func parseConfig(data []byte) (*Config, error) {
 		SectionSorting      map[string]string
 		Plugins             []Plugin
 		RepoConfigs         map[string]RepoConfig
+		ExperimentalLLMFileOrdering bool
 	}
 
 	err := toml.Unmarshal(data, &intermediate_config)
@@ -189,6 +194,7 @@ func parseConfig(data []byte) (*Config, error) {
 		SectionSorting:     intermediate_config.SectionSorting,
 		Plugins:            intermediate_config.Plugins,
 		RepoConfigs:        repoConfigs,
+		ExperimentalLLMFileOrdering: intermediate_config.ExperimentalLLMFileOrdering,
 	}, nil
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -192,6 +192,15 @@ func (db *DB) initSchema() error {
 		UNIQUE(owner, repo, pr_number, plugin_name)
 	);
 
+	CREATE TABLE IF NOT EXISTS DiffFileOrderingCache (
+		pr_number INTEGER NOT NULL,
+		repo TEXT NOT NULL,
+		sha TEXT NOT NULL,
+		ordering_json TEXT NOT NULL,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(pr_number, repo, sha)
+	);
+
 	CREATE TABLE IF NOT EXISTS Worktrees (
 		id INTEGER PRIMARY KEY,
 		pr_number INTEGER NOT NULL,
@@ -471,6 +480,36 @@ func (db *DB) DeletePluginResultsForPR(owner, repo string, prNumber int, pluginN
 	_, err := db.conn.Exec(
 		"DELETE FROM PluginResults WHERE owner = ? AND repo = ? AND pr_number = ? AND plugin_name = ?",
 		owner, repo, prNumber, pluginName,
+	)
+	return err
+}
+
+// GetDiffFileOrdering retrieves a cached LLM diff file ordering for a PR SHA.
+// It returns an empty string (no error) when there is no cached entry.
+func (db *DB) GetDiffFileOrdering(prNumber int, repo, sha string) (string, error) {
+	var orderingJSON string
+	err := db.conn.QueryRow(
+		"SELECT ordering_json FROM DiffFileOrderingCache WHERE pr_number = ? AND repo = ? AND sha = ?",
+		prNumber, repo, sha,
+	).Scan(&orderingJSON)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return orderingJSON, nil
+}
+
+// UpsertDiffFileOrdering stores an LLM diff file ordering keyed by PR SHA.
+func (db *DB) UpsertDiffFileOrdering(prNumber int, repo, sha, orderingJSON string) error {
+	_, err := db.conn.Exec(
+		`INSERT INTO DiffFileOrderingCache (pr_number, repo, sha, ordering_json, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(pr_number, repo, sha) DO UPDATE SET
+			ordering_json = excluded.ordering_json,
+			updated_at = excluded.updated_at`,
+		prNumber, repo, sha, orderingJSON,
 	)
 	return err
 }

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -1692,7 +1692,7 @@ func sortFilesTestsLast(files []*utils.DiffFile) []*utils.DiffFile {
 
 func formatDiff(diff *utils.Diff) string {
 	var builder strings.Builder
-	for _, file := range sortFilesTestsLast(diff.Files) {
+	for _, file := range orderDiffFiles(diff.Files) {
 		builder.WriteString(file.DiffHeader + "\n")
 
 		// The diff parser's lookahead misses ---/+++ lines for new/deleted files

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -985,7 +985,7 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 	parsedDiff, _ := utils.Parse(diff)
 	formattedDiff := diff
 	if parsedDiff != nil {
-		formattedDiff = formatDiff(parsedDiff)
+		formattedDiff = formatDiff(parsedDiff, repo, number, headSHA)
 	}
 
 	// 4. Fetch Comments (GitHub + Local)
@@ -1432,7 +1432,8 @@ func GetFullPRResponse(owner string, repo string, number int, skipCache bool, de
 	// I will just format the diff.
 	
 	if parsedDiff != nil {
-		sb.WriteString(formatDiff(parsedDiff))
+		headSHA, _, _ := config.C().DB.GetPullRequestSHAs(number, repo)
+		sb.WriteString(formatDiff(parsedDiff, repo, number, headSHA))
 	} else {
 		sb.WriteString(diff) // Fallback if parse failed but we have raw string
 	}
@@ -1615,7 +1616,7 @@ func processPRDiffWithComments(client *github.Client, owner string, repo string,
 			commentsByFileAndLine[key] = append(commentsByFileAndLine[key], tree)
 		}
 	}
-	result := formatDiff(parsedDiff)
+	result := formatDiff(parsedDiff, repo, number, latestSha)
 	// Insert any remaining comments (general file comments or comments we couldn't match)
 	// for key, trees := range commentsByFileAndLine {
 	//	parts := strings.Split(key, ":")
@@ -1690,9 +1691,9 @@ func sortFilesTestsLast(files []*utils.DiffFile) []*utils.DiffFile {
 	return sorted
 }
 
-func formatDiff(diff *utils.Diff) string {
+func formatDiff(diff *utils.Diff, repo string, prNumber int, sha string) string {
 	var builder strings.Builder
-	for _, file := range orderDiffFiles(diff.Files) {
+	for _, file := range orderDiffFiles(diff.Files, repo, prNumber, sha) {
 		builder.WriteString(file.DiffHeader + "\n")
 
 		// The diff parser's lookahead misses ---/+++ lines for new/deleted files

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crs/config"
 	"crs/database"
 	"crs/utils"
 	"encoding/json"
@@ -973,15 +974,75 @@ func TestReorderFilesByNamesUnmentionedAppended(t *testing.T) {
 }
 
 func TestOrderDiffFilesDefaultsToTestsLast(t *testing.T) {
-	// With the experimental flag off (the default), ordering must match
-	// sortFilesTestsLast and make no network calls.
+	// With the experimental flag off, ordering must match sortFilesTestsLast
+	// and make no network calls.
+	config.SetC(config.Config{})
 	files := []*utils.DiffFile{
 		{NewName: "server/server_test.go"},
 		{NewName: "server/server.go"},
 	}
-	got := orderDiffFiles(files)
+	got := orderDiffFiles(files, "code-review-server", 1, "")
 	if got[0].NewName != "server/server.go" || got[1].NewName != "server/server_test.go" {
 		t.Errorf("orderDiffFiles did not fall back to tests-last sort: got %q, %q",
 			got[0].NewName, got[1].NewName)
+	}
+}
+
+func TestOrderDiffFilesUsesCachedOrdering(t *testing.T) {
+	// With the flag on and a cache entry for the PR SHA, orderDiffFiles must
+	// apply the cached ordering without contacting the LLM.
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db, ExperimentalLLMFileOrdering: true})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	files := []*utils.DiffFile{
+		{NewName: "a_test.go"},
+		{NewName: "main.go"},
+		{NewName: "helper.go"},
+	}
+
+	cached, _ := json.Marshal([]string{"main.go", "helper.go", "a_test.go"})
+	if err := db.UpsertDiffFileOrdering(7, "code-review-server", "sha-abc", string(cached)); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	got := orderDiffFiles(files, "code-review-server", 7, "sha-abc")
+
+	wantOrder := []string{"main.go", "helper.go", "a_test.go"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d files, want %d", len(got), len(wantOrder))
+	}
+	for i, w := range wantOrder {
+		if got[i].NewName != w {
+			t.Errorf("[%d] got %q, want %q", i, got[i].NewName, w)
+		}
+	}
+}
+
+func TestDiffFileOrderingCacheRoundtrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Missing entry returns empty string, no error.
+	got, err := db.GetDiffFileOrdering(1, "code-review-server", "sha1")
+	if err != nil {
+		t.Fatalf("unexpected error on cache miss: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty result on cache miss, got %q", got)
+	}
+
+	// Stored entry round-trips, and a re-upsert for the same SHA overwrites.
+	if err := db.UpsertDiffFileOrdering(1, "code-review-server", "sha1", `["a","b"]`); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+	if err := db.UpsertDiffFileOrdering(1, "code-review-server", "sha1", `["b","a"]`); err != nil {
+		t.Fatalf("re-upsert failed: %v", err)
+	}
+	got, err = db.GetDiffFileOrdering(1, "code-review-server", "sha1")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if got != `["b","a"]` {
+		t.Errorf("got %q, want %q", got, `["b","a"]`)
 	}
 }

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -902,3 +902,86 @@ func TestIsTestFile(t *testing.T) {
 		}
 	}
 }
+
+func TestCleanLLMFileName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"server/server.go", "server/server.go"},
+		{"  server/server.go  ", "server/server.go"},
+		{"- server/server.go", "server/server.go"},
+		{"* server/server.go", "server/server.go"},
+		{"`server/server.go`", "server/server.go"},
+		{"\"server/server.go\"", "server/server.go"},
+		{"a/server/server.go", "server/server.go"},
+		{"b/server/server.go", "server/server.go"},
+		{"", ""},
+		{"```", ""},
+	}
+	for i, tc := range tests {
+		if got := cleanLLMFileName(tc.in); got != tc.want {
+			t.Errorf("[%d] cleanLLMFileName(%q) = %q, want %q", i, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestReorderFilesByNames(t *testing.T) {
+	files := []*utils.DiffFile{
+		{NewName: "server/server_test.go"},
+		{NewName: "server/server.go"},
+		{NewName: "config/config.go"},
+		{NewName: "styles/app.css"},
+	}
+
+	// LLM returns the desired reading order; basename-only and a/ prefix
+	// variants must still match.
+	names := []string{"server/server.go", "config.go", "a/styles/app.css", "server/server_test.go"}
+	got := reorderFilesByNames(files, names)
+
+	wantOrder := []string{
+		"server/server.go",
+		"config/config.go",
+		"styles/app.css",
+		"server/server_test.go",
+	}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d files, want %d", len(got), len(wantOrder))
+	}
+	for i, w := range wantOrder {
+		if got[i].NewName != w {
+			t.Errorf("[%d] got %q, want %q", i, got[i].NewName, w)
+		}
+	}
+}
+
+func TestReorderFilesByNamesUnmentionedAppended(t *testing.T) {
+	files := []*utils.DiffFile{
+		{NewName: "a.go"},
+		{NewName: "b.go"},
+		{NewName: "c.go"},
+	}
+	// LLM only mentions one file; the rest keep original relative order.
+	got := reorderFilesByNames(files, []string{"c.go"})
+
+	wantOrder := []string{"c.go", "a.go", "b.go"}
+	for i, w := range wantOrder {
+		if got[i].NewName != w {
+			t.Errorf("[%d] got %q, want %q", i, got[i].NewName, w)
+		}
+	}
+}
+
+func TestOrderDiffFilesDefaultsToTestsLast(t *testing.T) {
+	// With the experimental flag off (the default), ordering must match
+	// sortFilesTestsLast and make no network calls.
+	files := []*utils.DiffFile{
+		{NewName: "server/server_test.go"},
+		{NewName: "server/server.go"},
+	}
+	got := orderDiffFiles(files)
+	if got[0].NewName != "server/server.go" || got[1].NewName != "server/server_test.go" {
+		t.Errorf("orderDiffFiles did not fall back to tests-last sort: got %q, %q",
+			got[0].NewName, got[1].NewName)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1024,17 +1024,73 @@ type geminiResponse struct {
 
 // orderDiffFiles returns the diff files in display order. It dispatches to the
 // experimental LLM ordering when enabled, otherwise to the default sort that
-// places test files last.
-func orderDiffFiles(files []*utils.DiffFile) []*utils.DiffFile {
+// places test files last. LLM orderings are cached per PR SHA so the LLM is
+// queried at most once per revision.
+func orderDiffFiles(files []*utils.DiffFile, repo string, prNumber int, sha string) []*utils.DiffFile {
 	if !config.C().ExperimentalLLMFileOrdering {
 		return sortFilesTestsLast(files)
 	}
-	ordered, err := orderFilesWithLLM(files)
+	if len(files) < 2 {
+		return files
+	}
+
+	if names := cachedFileOrdering(repo, prNumber, sha); names != nil {
+		return reorderFilesByNames(files, names)
+	}
+
+	names, err := llmFileOrdering(files)
 	if err != nil {
 		slog.Warn("LLM diff file ordering failed, falling back to default sort", "error", err)
 		return sortFilesTestsLast(files)
 	}
-	return ordered
+
+	storeFileOrdering(repo, prNumber, sha, names)
+	return reorderFilesByNames(files, names)
+}
+
+// cachedFileOrdering returns a previously cached LLM file ordering for the
+// given PR SHA, or nil when there is no usable cache entry.
+func cachedFileOrdering(repo string, prNumber int, sha string) []string {
+	if sha == "" {
+		return nil
+	}
+	db := config.C().DB
+	if db == nil {
+		return nil
+	}
+	stored, err := db.GetDiffFileOrdering(prNumber, repo, sha)
+	if err != nil {
+		slog.Warn("failed to read diff file ordering cache", "error", err)
+		return nil
+	}
+	if stored == "" {
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(stored), &names); err != nil {
+		slog.Warn("failed to decode cached diff file ordering", "error", err)
+		return nil
+	}
+	return names
+}
+
+// storeFileOrdering persists an LLM file ordering keyed by PR SHA.
+func storeFileOrdering(repo string, prNumber int, sha string, names []string) {
+	if sha == "" {
+		return
+	}
+	db := config.C().DB
+	if db == nil {
+		return
+	}
+	encoded, err := json.Marshal(names)
+	if err != nil {
+		slog.Warn("failed to encode diff file ordering for cache", "error", err)
+		return
+	}
+	if err := db.UpsertDiffFileOrdering(prNumber, repo, sha, string(encoded)); err != nil {
+		slog.Warn("failed to write diff file ordering cache", "error", err)
+	}
 }
 
 // diffFileName returns the path used to identify a diff file, preferring the
@@ -1046,23 +1102,14 @@ func diffFileName(file *utils.DiffFile) string {
 	return file.OrigName
 }
 
-// orderFilesWithLLM asks an LLM to order the diff files so the PR reads
+// llmFileOrdering asks an LLM to order the diff files so the PR reads
 // top-to-bottom from integration points through implementation to tests.
-func orderFilesWithLLM(files []*utils.DiffFile) ([]*utils.DiffFile, error) {
-	if len(files) < 2 {
-		return files, nil
-	}
-
+func llmFileOrdering(files []*utils.DiffFile) ([]string, error) {
 	token := os.Getenv("GEMINI_API_KEY")
 	if token == "" {
 		return nil, fmt.Errorf("GEMINI_API_KEY not set")
 	}
-
-	names, err := requestFileOrdering(files, token)
-	if err != nil {
-		return nil, err
-	}
-	return reorderFilesByNames(files, names), nil
+	return requestFileOrdering(files, token)
 }
 
 // requestFileOrdering sends the diff to the LLM and returns the ordered list of

--- a/server/server.go
+++ b/server/server.go
@@ -1,19 +1,24 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crs/config"
 	"crs/database"
 	"crs/git_tools"
+	"crs/utils"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v48/github"
 )
@@ -977,5 +982,236 @@ func (h *RPCHandler) RerunPlugins(args *RerunPluginsArgs, reply *RerunPluginsRep
 
 	// Return empty output for now (plugins running async)
 	reply.Output = make(map[string]database.PluginResult)
+	return nil
+}
+
+// Experimental: LLM-based diff file ordering.
+//
+// When config.ExperimentalLLMFileOrdering is enabled, the files in a PR diff
+// are ordered by an LLM so a reviewer can read the PR top-to-bottom: the
+// integration / entry-point changes first, then implementation and helpers,
+// then styling changes, then tests last. When the flag is off (the default),
+// or if the LLM call fails for any reason, ordering falls back to
+// sortFilesTestsLast.
+
+const (
+	llmOrderingModel       = "gemini-2.5-flash"
+	llmOrderingMaxDiffSize = 200000
+	llmOrderingTimeout     = 30 * time.Second
+)
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiRequest struct {
+	Contents []geminiContent `json:"contents"`
+}
+
+type geminiResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"content"`
+	} `json:"candidates"`
+}
+
+// orderDiffFiles returns the diff files in display order. It dispatches to the
+// experimental LLM ordering when enabled, otherwise to the default sort that
+// places test files last.
+func orderDiffFiles(files []*utils.DiffFile) []*utils.DiffFile {
+	if !config.C().ExperimentalLLMFileOrdering {
+		return sortFilesTestsLast(files)
+	}
+	ordered, err := orderFilesWithLLM(files)
+	if err != nil {
+		slog.Warn("LLM diff file ordering failed, falling back to default sort", "error", err)
+		return sortFilesTestsLast(files)
+	}
+	return ordered
+}
+
+// diffFileName returns the path used to identify a diff file, preferring the
+// new name and falling back to the original name for deleted files.
+func diffFileName(file *utils.DiffFile) string {
+	if file.NewName != "" {
+		return file.NewName
+	}
+	return file.OrigName
+}
+
+// orderFilesWithLLM asks an LLM to order the diff files so the PR reads
+// top-to-bottom from integration points through implementation to tests.
+func orderFilesWithLLM(files []*utils.DiffFile) ([]*utils.DiffFile, error) {
+	if len(files) < 2 {
+		return files, nil
+	}
+
+	token := os.Getenv("GEMINI_API_KEY")
+	if token == "" {
+		return nil, fmt.Errorf("GEMINI_API_KEY not set")
+	}
+
+	names, err := requestFileOrdering(files, token)
+	if err != nil {
+		return nil, err
+	}
+	return reorderFilesByNames(files, names), nil
+}
+
+// requestFileOrdering sends the diff to the LLM and returns the ordered list of
+// file paths it responds with.
+func requestFileOrdering(files []*utils.DiffFile, token string) ([]string, error) {
+	var fileList strings.Builder
+	for _, f := range files {
+		fileList.WriteString("- " + diffFileName(f) + "\n")
+	}
+
+	diffText := buildDiffForLLM(files)
+	if len(diffText) > llmOrderingMaxDiffSize {
+		diffText = diffText[:llmOrderingMaxDiffSize] + "\n... (diff truncated)\n"
+	}
+
+	prompt := fmt.Sprintf(`You are ordering the files of a pull request diff so a reviewer can read the PR from top to bottom and understand it.
+
+Order the files by this priority:
+1. The most important and relevant changes first: the entry points where the change is integrated (call sites, public APIs, top-level wiring).
+2. Then helper functions and implementation details: how the change actually works.
+3. Then styling changes such as CSS: after code, but before tests.
+4. Then test files, last.
+
+A reviewer should be able to read top to bottom: starting where the change is integrated, then into how it works, then the tests.
+
+Files in this diff:
+%s
+Full diff:
+%s
+
+Respond with ONLY the file paths, one per line, in the order they should be displayed. Use the exact file paths listed above. Do not include numbering, bullets, commentary, or code fences.`, fileList.String(), diffText)
+
+	reqBody := geminiRequest{
+		Contents: []geminiContent{
+			{Parts: []geminiPart{{Text: prompt}}},
+		},
+	}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	url := "https://generativelanguage.googleapis.com/v1beta/models/" + llmOrderingModel + ":generateContent?key=" + token
+	client := &http.Client{Timeout: llmOrderingTimeout}
+	resp, err := client.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Gemini API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var geminiResp geminiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
+		return nil, err
+	}
+	if len(geminiResp.Candidates) == 0 || len(geminiResp.Candidates[0].Content.Parts) == 0 {
+		return nil, fmt.Errorf("no content in Gemini response")
+	}
+
+	var names []string
+	for _, line := range strings.Split(geminiResp.Candidates[0].Content.Parts[0].Text, "\n") {
+		if cleaned := cleanLLMFileName(line); cleaned != "" {
+			names = append(names, cleaned)
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("Gemini response contained no file paths")
+	}
+	return names, nil
+}
+
+// buildDiffForLLM renders the diff files into a plain-text form for the LLM,
+// labelling each file so the model can refer back to exact paths.
+func buildDiffForLLM(files []*utils.DiffFile) string {
+	var b strings.Builder
+	for _, f := range files {
+		b.WriteString("=== FILE: " + diffFileName(f) + " ===\n")
+		for _, hunk := range f.Hunks {
+			b.WriteString(hunk.RangeHeader() + "\n")
+			for _, line := range hunk.WholeRange.Lines {
+				b.WriteString(line.Render())
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// cleanLLMFileName normalizes a single line of LLM output into a bare file
+// path, stripping list markers, surrounding quotes/backticks, and a/ b/
+// prefixes. It returns an empty string for lines that are not file paths.
+func cleanLLMFileName(line string) string {
+	s := strings.TrimSpace(line)
+	s = strings.Trim(s, "`")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.TrimPrefix(s, "- ")
+	s = strings.TrimPrefix(s, "* ")
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "\"'`")
+	s = strings.TrimPrefix(s, "a/")
+	s = strings.TrimPrefix(s, "b/")
+	return strings.TrimSpace(s)
+}
+
+// reorderFilesByNames reorders files to match the sequence of paths returned by
+// the LLM. Files the LLM did not mention (or that could not be matched) keep
+// their original relative order and are appended at the end.
+func reorderFilesByNames(files []*utils.DiffFile, names []string) []*utils.DiffFile {
+	used := make(map[*utils.DiffFile]bool)
+	result := make([]*utils.DiffFile, 0, len(files))
+
+	for _, name := range names {
+		if f := matchDiffFile(files, name, used); f != nil {
+			result = append(result, f)
+			used[f] = true
+		}
+	}
+	for _, f := range files {
+		if !used[f] {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
+// matchDiffFile finds an unused diff file whose path matches name, trying an
+// exact match first and then a basename match.
+func matchDiffFile(files []*utils.DiffFile, name string, used map[*utils.DiffFile]bool) *utils.DiffFile {
+	for _, f := range files {
+		if !used[f] && diffFileName(f) == name {
+			return f
+		}
+	}
+	base := name[strings.LastIndex(name, "/")+1:]
+	for _, f := range files {
+		if used[f] {
+			continue
+		}
+		fn := diffFileName(f)
+		if fn[strings.LastIndex(fn, "/")+1:] == base {
+			return f
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds experimental LLM-based file ordering for pull request diffs. When enabled via `ExperimentalLLMFileOrdering` config, files are ordered by an LLM to present changes top-to-bottom: integration points first, then implementation, then styling, then tests. Falls back to the default test-files-last sort if the LLM call fails or the feature is disabled.

### Changes

- **LLM integration**: New `orderDiffFiles()` function dispatches to Gemini API (gemini-2.5-flash) to intelligently order PR diff files based on review flow (entry points → implementation → styling → tests)
- **Caching**: LLM orderings are cached per PR SHA in a new `DiffFileOrderingCache` database table to avoid redundant API calls
- **Fallback behavior**: If LLM ordering fails for any reason (missing API key, network error, parsing failure), gracefully falls back to `sortFilesTestsLast()`
- **File matching**: Robust file path matching handles exact paths, basenames, and `a/`/`b/` prefixes from LLM responses
- **Config flag**: New `ExperimentalLLMFileOrdering` boolean in config (defaults to false)
- **Integration**: Updated `formatDiff()` calls in `renderer.go` to pass repo, PR number, and SHA for cache lookups
- **Comprehensive tests**: Added unit tests for file name cleaning, reordering logic, caching, and end-to-end ordering with and without cache

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — includes new tests for `cleanLLMFileName()`, `reorderFilesByNames()`, `orderDiffFiles()` with caching, and database cache round-trip

https://claude.ai/code/session_01AEE1uBa4eFpbzwArBZ3PSj