### PR TITLE
Consolidate post-update hooks into central RunPostUpdatePRHooks

### DIFF
--- a/server/hooks.go
+++ b/server/hooks.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"crs/config"
+	"crs/utils"
+	"log/slog"
+)
+
+// RunPostUpdatePRHooks runs the side-effecting work that should happen after a
+// PR is fetched or updated: configured plugins, plus the experimental LLM diff
+// file ordering when enabled. It is intended to run asynchronously.
+//
+// This is the central post-update hook. Callers that just need to trigger
+// plugins should still go through here so any new side effects (like the
+// ordering) stay in lockstep with plugin runs.
+func RunPostUpdatePRHooks(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string) {
+	RunPlugins(owner, repo, number, sha, diff, commentsJSON, metadataJSON)
+	ensureDiffFileOrdering(repo, number, sha, diff)
+}
+
+// ensureDiffFileOrdering pre-computes and caches the LLM diff file ordering
+// for a PR SHA so subsequent renders hit the cache. The underlying ordering
+// function is cache-first and SHA-keyed, so repeated calls for the same SHA
+// are cheap.
+func ensureDiffFileOrdering(repo string, prNumber int, sha, diff string) {
+	if !config.C().ExperimentalLLMFileOrdering {
+		return
+	}
+	if sha == "" || diff == "" {
+		return
+	}
+	parsed, err := utils.Parse(diff)
+	if err != nil || parsed == nil {
+		slog.Warn("Failed to parse diff for file ordering hook", "repo", repo, "pr", prNumber, "error", err)
+		return
+	}
+	orderDiffFiles(parsed.Files, repo, prNumber, sha)
+}

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -8,14 +8,15 @@ import (
 
 // RunPostUpdatePRHooks runs the side-effecting work that should happen after a
 // PR is fetched or updated: configured plugins, plus the experimental LLM diff
-// file ordering when enabled. It is intended to run asynchronously.
+// file ordering when enabled. Each hook is dispatched in its own goroutine so
+// they run in parallel and the call returns immediately.
 //
 // This is the central post-update hook. Callers that just need to trigger
 // plugins should still go through here so any new side effects (like the
 // ordering) stay in lockstep with plugin runs.
 func RunPostUpdatePRHooks(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string) {
-	RunPlugins(owner, repo, number, sha, diff, commentsJSON, metadataJSON)
-	ensureDiffFileOrdering(repo, number, sha, diff)
+	go RunPlugins(owner, repo, number, sha, diff, commentsJSON, metadataJSON)
+	go ensureDiffFileOrdering(repo, number, sha, diff)
 }
 
 // ensureDiffFileOrdering pre-computes and caches the LLM diff file ordering

--- a/server/server.go
+++ b/server/server.go
@@ -196,9 +196,9 @@ func (h *RPCHandler) fetchPRAndRunPlugins(owner, repo string, number int, skipCa
 	// Extract SHA from DB
 	_, sha, _ := config.C().DB.GetPullRequest(number, repo)
 
-	// Run plugins in background
+	// Run post-update hooks in background (plugins + experimental file ordering)
 	metadataJSON, _ := json.Marshal(details.Metadata)
-	go RunPlugins(owner, repo, number, sha, details.Diff, commentsJSON, string(metadataJSON))
+	go RunPostUpdatePRHooks(owner, repo, number, sha, details.Diff, commentsJSON, string(metadataJSON))
 
 	// Get the full formatted response for the UI.
 	// We pass the already fetched details to avoid redundant API calls.

--- a/server/server.go
+++ b/server/server.go
@@ -196,9 +196,10 @@ func (h *RPCHandler) fetchPRAndRunPlugins(owner, repo string, number int, skipCa
 	// Extract SHA from DB
 	_, sha, _ := config.C().DB.GetPullRequest(number, repo)
 
-	// Run post-update hooks in background (plugins + experimental file ordering)
+	// Dispatch post-update hooks (plugins + experimental file ordering); each
+	// hook runs in its own goroutine so this returns immediately.
 	metadataJSON, _ := json.Marshal(details.Metadata)
-	go RunPostUpdatePRHooks(owner, repo, number, sha, details.Diff, commentsJSON, string(metadataJSON))
+	RunPostUpdatePRHooks(owner, repo, number, sha, details.Diff, commentsJSON, string(metadataJSON))
 
 	// Get the full formatted response for the UI.
 	// We pass the already fetched details to avoid redundant API calls.


### PR DESCRIPTION
## Summary

Refactor post-PR-update side effects into a single centralized hook function. This prepares the codebase for coordinating multiple async operations (plugins + experimental LLM file ordering) that should run together after a PR is fetched or updated.

### Changes

- Add `server/hooks.go` with `RunPostUpdatePRHooks()` as the central post-update hook that coordinates plugin execution and experimental LLM diff file ordering
- Add `ensureDiffFileOrdering()` helper that pre-computes and caches LLM-ordered file lists when the experimental feature is enabled
- Update `server.go` to call `RunPostUpdatePRHooks()` instead of `RunPlugins()` directly, ensuring new side effects stay in lockstep with plugin runs

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_01AgERtZJbu2q54Jh1nDNH1G