### PR TITLE
Set document title to PR metadata title in Review component

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -292,6 +292,12 @@ export default function Review({
     }, [owner, repo, number]);
 
     useEffect(() => {
+        if (metadata?.title) {
+            document.title = `${metadata.title} (#${number})`;
+        }
+    }, [metadata?.title, number]);
+
+    useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
                 setShowPlugins(false);


### PR DESCRIPTION
## Summary

Updates the Review component to dynamically set the browser document title based on the PR metadata title, improving the user experience when viewing multiple PRs in different browser tabs.

### Changes

- Added a new `useEffect` hook that updates `document.title` whenever the PR metadata title or PR number changes
- The document title now displays in the format: `{PR Title} (#{PR Number})`

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] Manual verification: Open a PR in the Review component and confirm the browser tab title updates to show the PR title and number

https://claude.ai/code/session_01WBNd6WguKv1DtVSX4HrmQA