### PR TITLE
Add branch name parameter to plugin execution

### DIFF
--- a/cmd/example_plugin/main.go
+++ b/cmd/example_plugin/main.go
@@ -12,6 +12,7 @@ func main() {
 	diff := flag.String("diff", "", "PR diff content")
 	comments := flag.String("comments", "", "PR comments JSON")
 	headers := flag.String("headers", "", "PR metadata JSON")
+	branch := flag.String("branch", "", "PR head branch name")
 
 	flag.Parse()
 
@@ -23,6 +24,9 @@ func main() {
 	}
 	if *number != 0 {
 		fmt.Printf("Number: %d\n", *number)
+	}
+	if *branch != "" {
+		fmt.Printf("Branch: %s\n", *branch)
 	}
 	if *diff != "" {
 		fmt.Printf("Diff Content Length: %d\n", len(*diff))

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type Plugin struct {
 	IncludeDiff     bool
 	IncludeHeaders  bool
 	IncludeComments bool
+	IncludeBranch   bool
 	OnlyOnDemand    bool
 }
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -32,6 +32,7 @@ Command = "claude_review"
 IncludeDiff = false
 IncludeHeaders = false
 IncludeComments = false
+IncludeBranch = true   # Passes --branch flag (PR head branch name)
 
 [[Plugins]]
 Name = "Expensive Analysis"
@@ -45,9 +46,12 @@ OnlyOnDemand = true    # This plugin only runs when explicitly requested
 - `Name` (string, required): Display name for the plugin
 - `Command` (string, required): Executable name on your `$PATH`
 - `IncludeDiff` (bool, optional): Pass the PR diff via `--diff` flag
-- `IncludeHeaders` (bool, optional): Pass PR metadata via `--headers` flag
+- `IncludeHeaders` (bool, optional): Pass PR metadata via `--headers` flag (includes `head_ref` among other fields)
 - `IncludeComments` (bool, optional): Pass PR comments via `--comments` flag
+- `IncludeBranch` (bool, optional): Pass the PR's head branch name via `--branch` flag
 - `OnlyOnDemand` (bool, optional, default: false): If true, plugin only runs when explicitly requested via RerunPlugins
+
+> **Note:** The branch name is also available in the `--headers` JSON as the `head_ref` field. Use `IncludeBranch` when you want the branch as a simple standalone argument without parsing the full metadata JSON.
 
 ## Included Plugins
 
@@ -56,7 +60,7 @@ OnlyOnDemand = true    # This plugin only runs when explicitly requested
 - **Style Guidelines**: Uses Gemini 2.5 Flash to evaluate a PR's diff against your personal style guide. Reads rules from `~/.config/style_guidelines.md` and reports violations, compliance highlights, and an overall assessment. Requires `GEMINI_API_KEY`. See [Style Guidelines Plugin](#style-guidelines-plugin) below.
 - **Claude Review**: Runs `claude -p "review PR #<number> on repo <owner>/<repo>" --model sonnet` via the Claude CLI. Written in Zig. Build with `zig build` inside `cmd/claude_review/` and place the resulting binary on your `$PATH`.
 
-Plugins are expected to accept flags like `--owner`, `--repo`, `--number`, and any of the optional content flags enabled above.
+Plugins are expected to accept flags like `--owner`, `--repo`, `--number`, and any of the optional content flags enabled above (`--diff`, `--headers`, `--comments`, `--branch`).
 
 ## Writing a Plugin
 

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -14,8 +14,8 @@ import (
 // This is the central post-update hook. Callers that just need to trigger
 // plugins should still go through here so any new side effects (like the
 // ordering) stay in lockstep with plugin runs.
-func RunPostUpdatePRHooks(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string) {
-	go RunPlugins(owner, repo, number, sha, diff, commentsJSON, metadataJSON)
+func RunPostUpdatePRHooks(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string) {
+	go RunPlugins(owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch)
 	go ensureDiffFileOrdering(repo, number, sha, diff)
 }
 

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -15,14 +15,14 @@ const pluginTimeout = 5 * time.Minute
 // RunPlugins executes all configured plugins for a given PR.
 // It is intended to run asynchronously.
 // Plugins are only executed if the current SHA differs from the SHA for which they were last run.
-func RunPlugins(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string) {
-	RunPluginsForce(owner, repo, number, sha, diff, commentsJSON, metadataJSON, false, nil)
+func RunPlugins(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string) {
+	RunPluginsForce(owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch, false, nil)
 }
 
 // RunPluginsForce executes plugins with optional force rerun and specific plugin selection.
 // force=true bypasses the SHA check and reruns plugins even if SHA hasn't changed.
 // plugins=nil or empty means run all configured plugins; otherwise run only the specified ones.
-func RunPluginsForce(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, force bool, plugins []string) {
+func RunPluginsForce(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string, force bool, plugins []string) {
 	var wg sync.WaitGroup
 	pluginMap := make(map[string]bool)
 	if len(plugins) > 0 {
@@ -50,18 +50,18 @@ func RunPluginsForce(owner, repo string, number int, sha string, diff string, co
 					slog.Error("Plugin runner panicked", "plugin", p.Name, "panic", r)
 				}
 			}()
-			executePluginForce(p, owner, repo, number, sha, diff, commentsJSON, metadataJSON, force)
+			executePluginForce(p, owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch, force)
 		}(plugin)
 	}
 
 	wg.Wait()
 }
 
-func executePlugin(plugin config.Plugin, owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string) {
-	executePluginForce(plugin, owner, repo, number, sha, diff, commentsJSON, metadataJSON, false)
+func executePlugin(plugin config.Plugin, owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string) {
+	executePluginForce(plugin, owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch, false)
 }
 
-func executePluginForce(plugin config.Plugin, owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, force bool) {
+func executePluginForce(plugin config.Plugin, owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string, force bool) {
 	// Check if we need to rerun this plugin
 	storedSHA, err := config.C().DB.GetPluginResultSHA(owner, repo, number, plugin.Name)
 	if err != nil {
@@ -100,6 +100,9 @@ func executePluginForce(plugin config.Plugin, owner, repo string, number int, sh
 	}
 	if plugin.IncludeHeaders {
 		args = append(args, "--headers", metadataJSON)
+	}
+	if plugin.IncludeBranch {
+		args = append(args, "--branch", branch)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), pluginTimeout)

--- a/server/plugins_test.go
+++ b/server/plugins_test.go
@@ -40,7 +40,7 @@ func TestRunPlugins_SkipsOnlyOnDemandPlugins(t *testing.T) {
 	})
 
 	// Normal run (no specific plugins requested) should skip on-demand plugins
-	RunPlugins("owner", "repo", 1, "sha123", "", "", "")
+	RunPlugins("owner", "repo", 1, "sha123", "", "", "", "main")
 
 	if _, err := os.Stat(normalMarker); os.IsNotExist(err) {
 		t.Error("expected normal plugin to run, but it did not")
@@ -77,7 +77,7 @@ func TestRunPluginsForce_RunsOnDemandPluginWhenExplicitlyRequested(t *testing.T)
 	})
 
 	// Explicitly request the on-demand plugin by name
-	RunPluginsForce("owner", "repo", 1, "sha123", "", "", "", true, []string{"expensive-plugin"})
+	RunPluginsForce("owner", "repo", 1, "sha123", "", "", "", "feature-branch", true, []string{"expensive-plugin"})
 
 	if _, err := os.Stat(onDemandMarker); os.IsNotExist(err) {
 		t.Error("expected on-demand plugin to run when explicitly requested, but it did not")
@@ -104,7 +104,7 @@ func TestRunPluginsForce_EmptyListSkipsOnDemandPlugins(t *testing.T) {
 	})
 
 	// Force rerun with empty plugin list should still skip on-demand plugins
-	RunPluginsForce("owner", "repo", 1, "sha123", "", "", "", true, nil)
+	RunPluginsForce("owner", "repo", 1, "sha123", "", "", "", "main", true, nil)
 
 	if _, err := os.Stat(normalMarker); os.IsNotExist(err) {
 		t.Error("expected normal plugin to run, but it did not")

--- a/server/server.go
+++ b/server/server.go
@@ -199,7 +199,7 @@ func (h *RPCHandler) fetchPRAndRunPlugins(owner, repo string, number int, skipCa
 	// Dispatch post-update hooks (plugins + experimental file ordering); each
 	// hook runs in its own goroutine so this returns immediately.
 	metadataJSON, _ := json.Marshal(details.Metadata)
-	RunPostUpdatePRHooks(owner, repo, number, sha, details.Diff, commentsJSON, string(metadataJSON))
+	RunPostUpdatePRHooks(owner, repo, number, sha, details.Diff, commentsJSON, string(metadataJSON), details.Metadata.HeadRef)
 
 	// Get the full formatted response for the UI.
 	// We pass the already fetched details to avoid redundant API calls.
@@ -972,7 +972,7 @@ func (h *RPCHandler) RerunPlugins(args *RerunPluginsArgs, reply *RerunPluginsRep
 
 	// Run plugins with force flag
 	metadataJSON, _ := json.Marshal(details.Metadata)
-	go RunPluginsForce(args.Owner, args.Repo, args.Number, sha, details.Diff, commentsJSON, string(metadataJSON), true, args.Plugins)
+	go RunPluginsForce(args.Owner, args.Repo, args.Number, sha, details.Diff, commentsJSON, string(metadataJSON), details.Metadata.HeadRef, true, args.Plugins)
 
 	reply.Okay = true
 	if len(args.Plugins) == 0 {


### PR DESCRIPTION
## Summary

Adds support for passing the PR's head branch name to plugins via a new `--branch` flag. This allows plugins to access the branch name as a simple standalone argument without needing to parse the full metadata JSON.

### Changes

- Add `branch` parameter to `RunPlugins`, `RunPluginsForce`, `executePlugin`, and `executePluginForce` functions
- Add `IncludeBranch` configuration option to the `Plugin` struct
- Pass `--branch` flag to plugins when `IncludeBranch` is enabled
- Update `RunPostUpdatePRHooks` and `RerunPlugins` to extract and pass `details.Metadata.HeadRef` as the branch name
- Update documentation to describe the new `IncludeBranch` option and note that branch is also available in `--headers` JSON as `head_ref`
- Update example plugin to accept and display the `--branch` flag
- Update test calls to include the branch parameter

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (existing tests updated with branch parameter)

https://claude.ai/code/session_01FtNqXztYtGayxuMGqwrGcX