### PR TITLE
Move PR navigation buttons to App header

### DIFF
--- a/bun_client/frontend/src/App.tsx
+++ b/bun_client/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import PRList from './components/PRList';
 import Review from './components/Review';
 import PluginOutput from './components/PluginOutput';
+import { rpcCall } from './api';
 import {
     Modal,
     Select,
@@ -22,6 +23,7 @@ function App() {
     const [view, setView] = useState<'LIST' | 'REVIEW' | 'PLUGIN_OUTPUT'>('LIST');
     const [currentPR, setCurrentPR] = useState<PRParams | null>(null);
     const [showPrefs, setShowPrefs] = useState(false);
+    const [navigating, setNavigating] = useState(false);
     const [theme, setTheme] = useState<Theme>(() => {
         const saved = localStorage.getItem('theme') as Theme;
         if (saved && VALID_THEMES.includes(saved)) return saved;
@@ -126,6 +128,31 @@ function App() {
         setCurrentPR(null);
     };
 
+    const handleNavigatePR = async (previous: boolean) => {
+        if (!currentPR) return;
+        setNavigating(true);
+        try {
+            const res = await rpcCall<{
+                adjacent_owner: string;
+                adjacent_repo: string;
+                adjacent_number: number;
+            }>('RPCHandler.GetAdjacentPR', [
+                { Owner: currentPR.owner, Repo: currentPR.repo, Number: currentPR.number, Previous: previous },
+            ]);
+            handleOpenReview(
+                res.adjacent_owner || currentPR.owner,
+                res.adjacent_repo || currentPR.repo,
+                res.adjacent_number
+            );
+        } catch (e: any) {
+            const msg = e?.message || String(e);
+            const parsed = (() => { try { return JSON.parse(msg); } catch { return null; } })();
+            alert(parsed?.message ?? msg);
+        } finally {
+            setNavigating(false);
+        }
+    };
+
     return (
         <div className="app-container" style={{ minHeight: '100vh', padding: '20px' }}>
             <header
@@ -184,20 +211,58 @@ function App() {
                     </button>
                 </div>
                 {(view === 'REVIEW' || view === 'PLUGIN_OUTPUT') && (
-                    <button
-                        onClick={handleBack}
-                        style={{
-                            background: 'transparent',
-                            border: '1px solid var(--border)',
-                            color: 'var(--text-secondary)',
-                            padding: '8px 16px',
-                            borderRadius: '6px',
-                            fontSize: '14px',
-                            cursor: 'pointer',
-                        }}
-                    >
-                        ← Back to List
-                    </button>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        {view === 'REVIEW' && (
+                            <>
+                                <button
+                                    onClick={() => handleNavigatePR(true)}
+                                    disabled={navigating}
+                                    style={{
+                                        background: 'transparent',
+                                        border: '1px solid var(--border)',
+                                        color: 'var(--text-secondary)',
+                                        padding: '8px 16px',
+                                        borderRadius: '6px',
+                                        fontSize: '14px',
+                                        cursor: navigating ? 'not-allowed' : 'pointer',
+                                        opacity: navigating ? 0.5 : 1,
+                                    }}
+                                >
+                                    ← Prev PR
+                                </button>
+                                <button
+                                    onClick={() => handleNavigatePR(false)}
+                                    disabled={navigating}
+                                    style={{
+                                        background: 'transparent',
+                                        border: '1px solid var(--border)',
+                                        color: 'var(--text-secondary)',
+                                        padding: '8px 16px',
+                                        borderRadius: '6px',
+                                        fontSize: '14px',
+                                        cursor: navigating ? 'not-allowed' : 'pointer',
+                                        opacity: navigating ? 0.5 : 1,
+                                    }}
+                                >
+                                    Next PR →
+                                </button>
+                            </>
+                        )}
+                        <button
+                            onClick={handleBack}
+                            style={{
+                                background: 'transparent',
+                                border: '1px solid var(--border)',
+                                color: 'var(--text-secondary)',
+                                padding: '8px 16px',
+                                borderRadius: '6px',
+                                fontSize: '14px',
+                                cursor: 'pointer',
+                            }}
+                        >
+                            ← Back to List
+                        </button>
+                    </div>
                 )}
             </header>
 
@@ -218,7 +283,6 @@ function App() {
                         number={currentPR.number}
                         theme={theme}
                         onThemeChange={setTheme}
-                        onNavigate={handleOpenReview}
                     />
                 )}
                 {view === 'PLUGIN_OUTPUT' && currentPR && (

--- a/bun_client/frontend/src/App.tsx
+++ b/bun_client/frontend/src/App.tsx
@@ -137,7 +137,12 @@ function App() {
                 adjacent_repo: string;
                 adjacent_number: number;
             }>('RPCHandler.GetAdjacentPR', [
-                { Owner: currentPR.owner, Repo: currentPR.repo, Number: currentPR.number, Previous: previous },
+                {
+                    Owner: currentPR.owner,
+                    Repo: currentPR.repo,
+                    Number: currentPR.number,
+                    Previous: previous,
+                },
             ]);
             handleOpenReview(
                 res.adjacent_owner || currentPR.owner,
@@ -146,7 +151,13 @@ function App() {
             );
         } catch (e: any) {
             const msg = e?.message || String(e);
-            const parsed = (() => { try { return JSON.parse(msg); } catch { return null; } })();
+            const parsed = (() => {
+                try {
+                    return JSON.parse(msg);
+                } catch {
+                    return null;
+                }
+            })();
             alert(parsed?.message ?? msg);
         } finally {
             setNavigating(false);

--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -74,7 +74,6 @@ interface ReviewProps {
     number: number;
     theme: Theme;
     onThemeChange: (theme: Theme) => void;
-    onNavigate?: (owner: string, repo: string, number: number) => void;
 }
 
 interface Comment {
@@ -226,7 +225,6 @@ export default function Review({
     number,
     theme,
     onThemeChange: _onThemeChange,
-    onNavigate,
 }: ReviewProps) {
     const [content, setContent] = useState<string>('');
     const [diff, setDiff] = useState<string>('');
@@ -506,41 +504,6 @@ export default function Review({
             setDiff(newLines.join('\n'));
         } catch (e) {
             console.error('Failed to expand hunk context:', e);
-        }
-    };
-
-    const handleNavigate = async (previous: boolean) => {
-        setLoading(true);
-        try {
-            const res = await rpcCall<
-                PRResponse & {
-                    adjacent_owner: string;
-                    adjacent_repo: string;
-                    adjacent_number: number;
-                }
-            >('RPCHandler.GetAdjacentPR', [
-                { Owner: owner, Repo: repo, Number: number, Previous: previous },
-            ]);
-            if (onNavigate) {
-                onNavigate(
-                    res.adjacent_owner || owner,
-                    res.adjacent_repo || repo,
-                    res.adjacent_number
-                );
-            }
-        } catch (e: any) {
-            console.error(e);
-            const msg = e?.message || String(e);
-            const parsed = (() => {
-                try {
-                    return JSON.parse(msg);
-                } catch {
-                    return null;
-                }
-            })();
-            alert(parsed?.message ?? msg);
-        } finally {
-            setLoading(false);
         }
     };
 
@@ -2953,22 +2916,6 @@ export default function Review({
                     zIndex: 10,
                 }}
             >
-                <Button
-                    onClick={() => handleNavigate(true)}
-                    variant="secondary"
-                    disabled={loading}
-                    title="Previous PR"
-                >
-                    ← Prev PR
-                </Button>
-                <Button
-                    onClick={() => handleNavigate(false)}
-                    variant="secondary"
-                    disabled={loading}
-                    title="Next PR"
-                >
-                    Next PR →
-                </Button>
                 <Button onClick={handleSync} loading={loading}>
                     {loading ? 'Syncing...' : '↻ Sync'}
                 </Button>


### PR DESCRIPTION
## Summary

Refactored PR navigation (previous/next) button logic from the Review component to the App component header. This centralizes navigation state management and improves the UI layout by placing navigation controls alongside the back button in a consistent header area.

### Changes

- Added `navigating` state to App component to track PR navigation in progress
- Implemented `handleNavigatePR` function in App to call `RPCHandler.GetAdjacentPR` and handle navigation
- Moved "Prev PR" and "Next PR" buttons from Review component to App header, displayed only in REVIEW view
- Removed `onNavigate` prop from Review component and deleted the duplicate `handleNavigate` function
- Updated button styling to match existing header button patterns with disabled/loading states

## Test Plan

- [ ] `bun run type-check` passes (TypeScript validation)
- [ ] `bun run lint` passes (ESLint)
- [ ] Manual verification: Navigation buttons appear in header when viewing a PR
- [ ] Manual verification: Clicking prev/next buttons navigates to adjacent PRs
- [ ] Manual verification: Buttons are disabled during navigation
- [ ] Manual verification: Error handling displays alert on navigation failure

https://claude.ai/code/session_01L2GLUeZ5BbDsDscWHVxT5f