### PR TITLE
Track GitHub API rate limit status post-cycle

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -364,6 +364,23 @@ func (db *DB) initSchema() error {
 		}
 	}
 
+	// Migration: Add rate limit columns to APICallStats
+	err = db.conn.QueryRow("SELECT COUNT(*) FROM pragma_table_info('APICallStats') WHERE name='rate_limit_remaining'").Scan(&count)
+	if err == nil && count == 0 {
+		_, err = db.conn.Exec("ALTER TABLE APICallStats ADD COLUMN rate_limit_remaining INTEGER NOT NULL DEFAULT -1")
+		if err != nil {
+			slog.Warn("Error adding rate_limit_remaining column to APICallStats", "error", err)
+		}
+		_, err = db.conn.Exec("ALTER TABLE APICallStats ADD COLUMN rate_limit_limit INTEGER NOT NULL DEFAULT -1")
+		if err != nil {
+			slog.Warn("Error adding rate_limit_limit column to APICallStats", "error", err)
+		}
+		_, err = db.conn.Exec("ALTER TABLE APICallStats ADD COLUMN rate_limit_reset_at TEXT NOT NULL DEFAULT ''")
+		if err != nil {
+			slog.Warn("Error adding rate_limit_reset_at column to APICallStats", "error", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1341,14 +1358,16 @@ func (db *DB) QueryRow(query string, args ...interface{}) *sql.Row {
 	return db.conn.QueryRow(query, args...)
 }
 
-// LogAPICallStats persists per-type GitHub API call counts for a completed workflow cycle.
-func (db *DB) LogAPICallStats(prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits int64) error {
+// LogAPICallStats persists per-type GitHub API call counts and post-cycle rate limit
+// status for a completed workflow cycle.
+func (db *DB) LogAPICallStats(prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits int64, rateLimitRemaining, rateLimitLimit int, rateLimitResetAt string) error {
 	total := prList + prSpecific + comments + issueComments + ciStatus + diff + reviews + combinedStatus + checkRuns + commits
 	_, err := db.conn.Exec(
 		`INSERT INTO APICallStats
-			(pr_list, pr_specific, comments, issue_comments, ci_status, diff, reviews, combined_status, check_runs, commits, total)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(pr_list, pr_specific, comments, issue_comments, ci_status, diff, reviews, combined_status, check_runs, commits, total, rate_limit_remaining, rate_limit_limit, rate_limit_reset_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits, total,
+		rateLimitRemaining, rateLimitLimit, rateLimitResetAt,
 	)
 	return err
 }

--- a/git_tools/git_tools.go
+++ b/git_tools/git_tools.go
@@ -506,6 +506,22 @@ func GetRateLimitStatus() RateLimitStatus {
 	return globalRateLimitManager.GetStatus()
 }
 
+// GetRateLimitFromAPI fetches the authoritative rate limit status from GitHub's
+// /rate_limit endpoint. Returns limit, remaining, and reset time for the core API.
+func GetRateLimitFromAPI(client *github.Client) (limit, remaining int, resetAt time.Time, err error) {
+	ctx := context.Background()
+	rateLimits, _, apiErr := client.RateLimits(ctx)
+	if apiErr != nil {
+		return 0, 0, time.Time{}, apiErr
+	}
+	if rateLimits != nil && rateLimits.Core != nil {
+		limit = rateLimits.Core.Limit
+		remaining = rateLimits.Core.Remaining
+		resetAt = rateLimits.Core.Reset.Time
+	}
+	return limit, remaining, resetAt, nil
+}
+
 func GetLeankitCardTitle(pr PullRequest) string {
 	return "abc"
 }

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -489,6 +489,28 @@ func (ms ManagerService) RunOnce(log *slog.Logger, file_change_wg *sync.WaitGrou
 		log.Info("Completed RunOnce Waitgroup")
 	}
 	apiCalls.log(log)
+
+	// Fetch authoritative rate limit status from GitHub's /rate_limit endpoint.
+	rlLimit, rlRemaining, rlResetAt, rlErr := git_tools.GetRateLimitFromAPI(client)
+	if rlErr != nil {
+		log.Warn("Failed to fetch rate limit from GitHub API, using header-based estimate", "error", rlErr)
+		rlStatus := git_tools.GetRateLimitStatus()
+		rlLimit = rlStatus.Limit
+		rlRemaining = rlStatus.Remaining
+		rlResetAt = rlStatus.ResetAt
+	}
+	log.Info("GitHub rate limit post-cycle",
+		"remaining", rlRemaining,
+		"limit", rlLimit,
+		"used_this_cycle", apiCalls.total(),
+		"reset_at", rlResetAt,
+	)
+
+	rlResetAtStr := ""
+	if !rlResetAt.IsZero() {
+		rlResetAtStr = rlResetAt.UTC().Format(time.RFC3339)
+	}
+
 	db := config.C().DB
 	if err := db.LogAPICallStats(
 		apiCalls.PRList.Load(),
@@ -501,6 +523,9 @@ func (ms ManagerService) RunOnce(log *slog.Logger, file_change_wg *sync.WaitGrou
 		apiCalls.CombinedStatus.Load(),
 		apiCalls.CheckRuns.Load(),
 		apiCalls.Commits.Load(),
+		rlRemaining,
+		rlLimit,
+		rlResetAtStr,
 	); err != nil {
 		log.Error("Failed to save API call stats to database", "error", err)
 	}


### PR DESCRIPTION
## Summary

Adds tracking of GitHub API rate limit status (remaining, limit, and reset time) at the end of each workflow cycle. This enables monitoring of rate limit consumption patterns and helps detect when the application is approaching GitHub's API quotas.

### Changes

- **database/database.go**: Added schema migration to create three new columns in `APICallStats` table:
  - `rate_limit_remaining` — remaining API calls in current window
  - `rate_limit_limit` — total API call limit
  - `rate_limit_reset_at` — when the rate limit window resets (RFC3339 format)
- **database/database.go**: Updated `LogAPICallStats()` to accept and persist rate limit parameters
- **workflows/manager.go**: After each workflow cycle, fetch authoritative rate limit status from GitHub's `/rate_limit` endpoint via `GetRateLimitFromAPI()`, with fallback to header-based estimates if the API call fails
- **git_tools/git_tools.go**: Added `GetRateLimitFromAPI()` function to query GitHub's rate limit endpoint and extract core API rate limit details

## Test Plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

https://claude.ai/code/session_01XAuurAc8nLz6bWbYWceCyM