### PR TITLE
Display per-file and total add/delete counts in review UI

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,10 @@
       "Bash(/home/chris/.bun/bin/bun run:*)",
       "Bash(cargo build:*)",
       "Bash(cargo test:*)",
-      "Bash(bun run:*)"
+      "Bash(bun run:*)",
+      "Bash(gh pr *)",
+      "Bash(gh run *)",
+      "Bash(bunx prettier *)"
     ]
   }
 }

--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -1245,6 +1245,20 @@ export default function Review({
         const lines = sortParsedLinesTestsLast(parseDiff());
         if (lines.length === 0) return null;
 
+        // Pre-compute per-file add/del counts for display in file headers.
+        const fileCounts = new Map<string, { add: number; del: number }>();
+        let fcFile: string | null = null;
+        for (const p of lines) {
+            if (p.lineType === 'file-header') {
+                fcFile = p.file;
+                if (fcFile && !fileCounts.has(fcFile)) fileCounts.set(fcFile, { add: 0, del: 0 });
+            } else if (fcFile && fileCounts.has(fcFile)) {
+                const fc = fileCounts.get(fcFile)!;
+                if (p.lineType === 'addition') fc.add++;
+                else if (p.lineType === 'deletion') fc.del++;
+            }
+        }
+
         let currentFile: string | null = null;
 
         return lines.map((item, idx) => {
@@ -1379,6 +1393,40 @@ export default function Review({
                                     ? `${item.origName} → ${item.text}`
                                     : item.text}
                             </span>
+                            {(() => {
+                                const fc = item.file ? fileCounts.get(item.file) : null;
+                                if (!fc || (fc.add === 0 && fc.del === 0)) return null;
+                                return (
+                                    <span
+                                        style={{
+                                            display: 'inline-flex',
+                                            gap: '4px',
+                                            marginLeft: '4px',
+                                        }}
+                                    >
+                                        {fc.add > 0 && (
+                                            <span
+                                                style={{
+                                                    color: 'var(--text-success)',
+                                                    fontSize: '12px',
+                                                }}
+                                            >
+                                                +{fc.add}
+                                            </span>
+                                        )}
+                                        {fc.del > 0 && (
+                                            <span
+                                                style={{
+                                                    color: 'var(--text-danger)',
+                                                    fontSize: '12px',
+                                                }}
+                                            >
+                                                −{fc.del}
+                                            </span>
+                                        )}
+                                    </span>
+                                );
+                            })()}
                             {hasOutdated && (
                                 <button
                                     onClick={e => {
@@ -3036,6 +3084,9 @@ export default function Review({
                     }
                 }
 
+                const totalAdd = [...counts.values()].reduce((s, c) => s + c.add, 0);
+                const totalDel = [...counts.values()].reduce((s, c) => s + c.del, 0);
+
                 const scrollToFile = (file: string) => {
                     // Expand the file if it was collapsed so the diff is visible.
                     if (collapsedFiles.has(file)) {
@@ -3070,6 +3121,28 @@ export default function Review({
                         >
                             {fileHeaders.length} file{fileHeaders.length === 1 ? '' : 's'}
                         </span>
+                        {totalAdd > 0 && (
+                            <span
+                                style={{
+                                    color: 'var(--text-success)',
+                                    fontSize: '11px',
+                                    alignSelf: 'center',
+                                }}
+                            >
+                                +{totalAdd}
+                            </span>
+                        )}
+                        {totalDel > 0 && (
+                            <span
+                                style={{
+                                    color: 'var(--text-danger)',
+                                    fontSize: '11px',
+                                    alignSelf: 'center',
+                                }}
+                            >
+                                −{totalDel}
+                            </span>
+                        )}
                         {fileHeaders.map(p => {
                             if (!p.file) return null;
                             const info = getFileStatusInfo(p.fileStatus);


### PR DESCRIPTION
## Summary

Adds visual indicators showing the number of lines added and deleted for each file in the diff review, as well as a total count in the file list header. This provides quick visibility into the scope of changes at a glance.

### Changes

- Pre-compute per-file addition/deletion counts from parsed diff lines and store in a `fileCounts` map
- Display `+X` and `−Y` badges next to each file header in the diff view (green for additions, red for deletions)
- Calculate and display total additions/deletions in the file list header section
- Use semantic color variables (`--text-success` and `--text-danger`) for consistency with existing UI

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] `bun run format:check` passes
- Verify file-level counts display correctly in the diff view
- Verify total counts display in the file list header
- Verify counts are accurate for files with mixed additions and deletions

https://claude.ai/code/session_01Vg2X8D3toFRQa5exZ2BCnU