### PR TITLE
perf(bun_client): virtualize and memoize large file/LSP code views

### DIFF
--- a/bun_client/frontend/src/components/CodeViewerModal.tsx
+++ b/bun_client/frontend/src/components/CodeViewerModal.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import {
     oneDark,
     oneLight,
@@ -15,8 +14,8 @@ import { colors, shadows } from '../design';
 import { readFile, listFiles } from '../api';
 import type { Theme } from '../design';
 import { useLsp } from '../hooks/useLsp';
-import { getClickColumn } from '../utils/dom';
 import LspPopover from './LspPopover';
+import VirtualizedCodeBlock, { CODE_LINE_HEIGHT } from './VirtualizedCodeBlock';
 
 interface CodeViewerModalProps {
     isOpen: boolean;
@@ -234,7 +233,6 @@ export default function CodeViewerModal({
     }, [currentFilePath]);
 
     const modalRef = useRef<HTMLDivElement>(null);
-    const contentRef = useRef<HTMLDivElement>(null);
     const animationFrameId = useRef<number | null>(null);
     const resizeFrameId = useRef<number | null>(null);
 
@@ -279,6 +277,7 @@ export default function CodeViewerModal({
 
     // Sync currentFilePath when prop changes (if user clicks another file link in Review.tsx)
     useEffect(() => {
+        setScrollToLine(null);
         setCurrentFilePath(filePath);
     }, [filePath]);
 
@@ -313,23 +312,6 @@ export default function CodeViewerModal({
 
         fetchContent();
     }, [isOpen, currentFilePath, repoPath]);
-
-    // Scroll to target line when content loads
-    useEffect(() => {
-        const targetLine = scrollToLine ?? (currentFilePath === filePath ? initialLine : null);
-        if (content && contentRef.current && targetLine) {
-            setTimeout(() => {
-                const lineElement = contentRef.current?.querySelector(
-                    `code > span:nth-child(${targetLine})`
-                );
-                if (lineElement) {
-                    lineElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                }
-                // Clear scrollToLine after scrolling so it doesn't re-trigger
-                if (scrollToLine) setScrollToLine(null);
-            }, 100);
-        }
-    }, [content, initialLine, currentFilePath, filePath, scrollToLine]);
 
     // Handle ESC key
     useEffect(() => {
@@ -521,6 +503,73 @@ export default function CodeViewerModal({
         [expandedDirs]
     );
 
+    // Toggle an LSP query for the clicked line/column.
+    const handleLspLineClick = useCallback(
+        (line: number, column: number) => {
+            if (!lsp.available) return;
+            if (activeLspLine === line) {
+                setActiveLspLine(null);
+                lsp.clearData();
+                return;
+            }
+            lsp.query(line - 1, column).then(result => {
+                if (result) setActiveLspLine(line);
+            });
+        },
+        [lsp, activeLspLine]
+    );
+
+    const targetLine = scrollToLine ?? (currentFilePath === filePath ? initialLine : null);
+
+    // Single highlighted, virtualization-aware file view shared by both the
+    // docked and floating layouts.
+    const codeViewer =
+        !loading && !error && content ? (
+            <VirtualizedCodeBlock
+                content={content}
+                language={language}
+                syntaxStyle={syntaxTheme}
+                activeLine={activeLspLine}
+                targetLine={targetLine}
+                scrollToLine={targetLine}
+                clickable={!!lsp.available}
+                onLineClick={handleLspLineClick}
+            >
+                {activeLspLine !== null && lsp.lspData && (
+                    <div
+                        style={{
+                            position: 'absolute',
+                            top: `${activeLspLine * CODE_LINE_HEIGHT + CODE_LINE_HEIGHT}px`,
+                            left: '60px',
+                            zIndex: 100,
+                        }}
+                    >
+                        <LspPopover
+                            hover={lsp.lspData.hover}
+                            refs={lsp.lspData.refs}
+                            definitions={lsp.lspData.definitions}
+                            typeDefinitions={lsp.lspData.typeDefinitions}
+                            variant="floating"
+                            onRefClick={r => {
+                                const refPath = r.uri.replace('file://', '');
+                                const relativePath = refPath.startsWith(repoPath + '/')
+                                    ? refPath.slice(repoPath.length + 1)
+                                    : refPath;
+                                setCurrentFilePath(relativePath);
+                                setScrollToLine(r.range.start.line + 1);
+                                setActiveLspLine(null);
+                                lsp.clearData();
+                            }}
+                            onClose={() => {
+                                setActiveLspLine(null);
+                                lsp.clearData();
+                            }}
+                        />
+                    </div>
+                )}
+            </VirtualizedCodeBlock>
+        ) : null;
+
     const renderFileTree = useCallback(
         (nodes: FileNode[], depth: number = 0): React.ReactNode => {
             return nodes.map(node => (
@@ -551,6 +600,7 @@ export default function CodeViewerModal({
                             if (node.isDirectory) {
                                 toggleDir(node.path);
                             } else {
+                                setScrollToLine(null);
                                 setCurrentFilePath(node.path);
                             }
                         }}
@@ -811,11 +861,9 @@ export default function CodeViewerModal({
 
                     {/* Main Content */}
                     <div
-                        ref={contentRef}
-                        className="custom-scrollbar"
                         style={{
                             flex: 1,
-                            overflow: 'auto',
+                            overflow: 'hidden',
                             background: 'var(--bg-primary)',
                         }}
                     >
@@ -829,114 +877,7 @@ export default function CodeViewerModal({
                                 Error: {error}
                             </div>
                         )}
-                        {!loading && !error && content && (
-                            <div style={{ position: 'relative' }}>
-                                <SyntaxHighlighter
-                                    language={language}
-                                    style={syntaxTheme}
-                                    showLineNumbers={true}
-                                    wrapLines={true}
-                                    lineProps={(lineNumber: number) => {
-                                        const isInitialTarget =
-                                            currentFilePath === filePath &&
-                                            lineNumber === initialLine;
-                                        const isScrollTarget =
-                                            scrollToLine !== null && lineNumber === scrollToLine;
-                                        const isTargetLine = isInitialTarget || isScrollTarget;
-                                        const isLspActive = activeLspLine === lineNumber;
-                                        return {
-                                            style: {
-                                                display: 'block',
-                                                position: 'relative' as const,
-                                                background: isLspActive
-                                                    ? colors.bgInfoDim
-                                                    : isTargetLine
-                                                      ? colors.bgWarningDim
-                                                      : 'transparent',
-                                                borderLeft: isLspActive
-                                                    ? `3px solid var(--accent)`
-                                                    : isTargetLine
-                                                      ? `3px solid ${colors.warning}`
-                                                      : '3px solid transparent',
-                                                paddingLeft: '8px',
-                                                cursor: lsp.available ? 'pointer' : 'default',
-                                            },
-                                            onClick: (e: React.MouseEvent) => {
-                                                if (!lsp.available) return;
-                                                const col = getClickColumn(
-                                                    e,
-                                                    e.currentTarget as HTMLElement
-                                                );
-                                                const lspLine = lineNumber - 1; // 0-indexed for LSP
-                                                if (activeLspLine === lineNumber) {
-                                                    setActiveLspLine(null);
-                                                    lsp.clearData();
-                                                } else {
-                                                    lsp.query(lspLine, col).then(result => {
-                                                        if (result) {
-                                                            setActiveLspLine(lineNumber);
-                                                        }
-                                                    });
-                                                }
-                                            },
-                                        };
-                                    }}
-                                    lineNumberStyle={{
-                                        minWidth: '50px',
-                                        paddingRight: '8px',
-                                        textAlign: 'right',
-                                        color: 'var(--text-tertiary)',
-                                        background: 'var(--bg-secondary)',
-                                        borderRight: '1px solid var(--border)',
-                                        userSelect: 'none',
-                                    }}
-                                    customStyle={{
-                                        margin: 0,
-                                        padding: 0,
-                                        background: 'transparent',
-                                        fontFamily: 'var(--font-mono)',
-                                        fontSize: '13px',
-                                    }}
-                                >
-                                    {content}
-                                </SyntaxHighlighter>
-                                {activeLspLine !== null && lsp.lspData && (
-                                    <div
-                                        style={{
-                                            position: 'absolute',
-                                            top: `${activeLspLine * 20 + 20}px`,
-                                            left: '60px',
-                                            zIndex: 100,
-                                        }}
-                                    >
-                                        <LspPopover
-                                            hover={lsp.lspData.hover}
-                                            refs={lsp.lspData.refs}
-                                            definitions={lsp.lspData.definitions}
-                                            typeDefinitions={lsp.lspData.typeDefinitions}
-                                            variant="floating"
-                                            onRefClick={r => {
-                                                const refPath = r.uri.replace('file://', '');
-                                                const relativePath = refPath.startsWith(
-                                                    repoPath + '/'
-                                                )
-                                                    ? refPath.slice(repoPath.length + 1)
-                                                    : refPath;
-                                                const targetLine = r.range.start.line + 1;
-                                                setCurrentFilePath(relativePath);
-                                                setScrollToLine(targetLine);
-                                                setActiveLspLine(null);
-                                                lsp.clearData();
-                                            }}
-                                            onClose={() => {
-                                                setActiveLspLine(null);
-                                                lsp.clearData();
-                                            }}
-                                        />
-                                    </div>
-                                )}
-                            </div>
-                        )}
+                        {codeViewer}
                     </div>
                 </div>
             </div>
@@ -1020,11 +961,9 @@ export default function CodeViewerModal({
 
                     {/* Main Content */}
                     <div
-                        ref={contentRef}
-                        className="custom-scrollbar"
                         style={{
                             flex: 1,
-                            overflow: 'auto',
+                            overflow: 'hidden',
                             background: 'var(--bg-primary)',
                         }}
                     >
@@ -1038,114 +977,7 @@ export default function CodeViewerModal({
                                 Error: {error}
                             </div>
                         )}
-                        {!loading && !error && content && (
-                            <div style={{ position: 'relative' }}>
-                                <SyntaxHighlighter
-                                    language={language}
-                                    style={syntaxTheme}
-                                    showLineNumbers={true}
-                                    wrapLines={true}
-                                    lineProps={(lineNumber: number) => {
-                                        const isInitialTarget =
-                                            currentFilePath === filePath &&
-                                            lineNumber === initialLine;
-                                        const isScrollTarget =
-                                            scrollToLine !== null && lineNumber === scrollToLine;
-                                        const isTargetLine = isInitialTarget || isScrollTarget;
-                                        const isLspActive = activeLspLine === lineNumber;
-                                        return {
-                                            style: {
-                                                display: 'block',
-                                                position: 'relative' as const,
-                                                background: isLspActive
-                                                    ? colors.bgInfoDim
-                                                    : isTargetLine
-                                                      ? colors.bgWarningDim
-                                                      : 'transparent',
-                                                borderLeft: isLspActive
-                                                    ? `3px solid var(--accent)`
-                                                    : isTargetLine
-                                                      ? `3px solid ${colors.warning}`
-                                                      : '3px solid transparent',
-                                                paddingLeft: '8px',
-                                                cursor: lsp.available ? 'pointer' : 'default',
-                                            },
-                                            onClick: (e: React.MouseEvent) => {
-                                                if (!lsp.available) return;
-                                                const col = getClickColumn(
-                                                    e,
-                                                    e.currentTarget as HTMLElement
-                                                );
-                                                const lspLine = lineNumber - 1; // 0-indexed for LSP
-                                                if (activeLspLine === lineNumber) {
-                                                    setActiveLspLine(null);
-                                                    lsp.clearData();
-                                                } else {
-                                                    lsp.query(lspLine, col).then(result => {
-                                                        if (result) {
-                                                            setActiveLspLine(lineNumber);
-                                                        }
-                                                    });
-                                                }
-                                            },
-                                        };
-                                    }}
-                                    lineNumberStyle={{
-                                        minWidth: '50px',
-                                        paddingRight: '8px',
-                                        textAlign: 'right',
-                                        color: 'var(--text-tertiary)',
-                                        background: 'var(--bg-secondary)',
-                                        borderRight: '1px solid var(--border)',
-                                        userSelect: 'none',
-                                    }}
-                                    customStyle={{
-                                        margin: 0,
-                                        padding: 0,
-                                        background: 'transparent',
-                                        fontFamily: 'var(--font-mono)',
-                                        fontSize: '13px',
-                                    }}
-                                >
-                                    {content}
-                                </SyntaxHighlighter>
-                                {activeLspLine !== null && lsp.lspData && (
-                                    <div
-                                        style={{
-                                            position: 'absolute',
-                                            top: `${activeLspLine * 20 + 20}px`,
-                                            left: '60px',
-                                            zIndex: 100,
-                                        }}
-                                    >
-                                        <LspPopover
-                                            hover={lsp.lspData.hover}
-                                            refs={lsp.lspData.refs}
-                                            definitions={lsp.lspData.definitions}
-                                            typeDefinitions={lsp.lspData.typeDefinitions}
-                                            variant="floating"
-                                            onRefClick={r => {
-                                                const refPath = r.uri.replace('file://', '');
-                                                const relativePath = refPath.startsWith(
-                                                    repoPath + '/'
-                                                )
-                                                    ? refPath.slice(repoPath.length + 1)
-                                                    : refPath;
-                                                const targetLine = r.range.start.line + 1;
-                                                setCurrentFilePath(relativePath);
-                                                setScrollToLine(targetLine);
-                                                setActiveLspLine(null);
-                                                lsp.clearData();
-                                            }}
-                                            onClose={() => {
-                                                setActiveLspLine(null);
-                                                lsp.clearData();
-                                            }}
-                                        />
-                                    </div>
-                                )}
-                            </div>
-                        )}
+                        {codeViewer}
                     </div>
                 </div>
 

--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -61,6 +61,10 @@ function CopyUrlButton({ url }: { url: string }) {
     );
 }
 
+// Above this many changed lines in a single file, the diff renders that file
+// without per-line syntax highlighting to avoid thousands of Prism instances.
+const MAX_HIGHLIGHT_LINES_PER_FILE = 2000;
+
 // Stable slug for in-page anchor IDs from file paths.
 const slugify = (s: string): string => s.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
 
@@ -1103,6 +1107,11 @@ export default function Review({
 
         const processFileSection = (file: string, linesData: typeof fileLines) => {
             if (linesData.length === 0) return;
+
+            // Each highlighted line spins up its own Prism instance, so very large
+            // file sections are left unhighlighted to keep big diffs responsive.
+            // The renderer falls back to plain text when no entry exists for a line.
+            if (linesData.length > MAX_HIGHLIGHT_LINES_PER_FILE) return;
 
             const language = getLanguageFromFilename(file);
 

--- a/bun_client/frontend/src/components/VirtualizedCodeBlock.tsx
+++ b/bun_client/frontend/src/components/VirtualizedCodeBlock.tsx
@@ -1,0 +1,295 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Prism as SyntaxHighlighter, createElement } from 'react-syntax-highlighter';
+import type { createElementProps } from 'react-syntax-highlighter';
+import { colors } from '../design';
+import { getClickColumn } from '../utils/dom';
+
+// Fixed row geometry. Virtualization math and the active/target line overlays
+// all depend on every rendered line being exactly this tall, so the line
+// elements below pin their height/line-height to these constants and never wrap.
+export const CODE_LINE_HEIGHT = 20;
+const CODE_FONT_SIZE = 13;
+
+// Files at or below this many lines are highlighted once and rendered in full
+// (correct highlighting, no windowing artifacts). Larger files switch to
+// windowed rendering so we never mount thousands of DOM nodes at once.
+const VIRTUALIZE_THRESHOLD = 1500;
+// Extra lines rendered above/below the viewport in windowed mode. Also gives
+// multi-line tokens (block comments, template strings) some context so the
+// highlighting at the window edges is usually correct.
+const OVERSCAN = 40;
+
+type RowNode = createElementProps['node'];
+type Stylesheet = { [key: string]: React.CSSProperties };
+
+interface RendererArgs {
+    rows: RowNode[];
+    stylesheet: Stylesheet;
+    useInlineStyles: boolean;
+}
+
+interface VirtualizedCodeBlockProps {
+    content: string;
+    language: string;
+    syntaxStyle: Stylesheet;
+    /** 1-based line clicked for an LSP query (gets the "active" highlight). */
+    activeLine?: number | null;
+    /** 1-based line to emphasise (jump target from a reference/definition). */
+    targetLine?: number | null;
+    /** 1-based line to scroll into view (centered) when it or the content changes. */
+    scrollToLine?: number | null;
+    /** Fires with a 1-based line and 0-based column on click. */
+    onLineClick?: (line: number, column: number) => void;
+    clickable?: boolean;
+    /** Rendered inside the scrolled content area (e.g. an LSP popover). */
+    children?: React.ReactNode;
+}
+
+const PRE_CODE_RESET: React.CSSProperties = {
+    margin: 0,
+    padding: 0,
+    background: 'transparent',
+    fontFamily: 'var(--font-mono)',
+    fontSize: `${CODE_FONT_SIZE}px`,
+    lineHeight: `${CODE_LINE_HEIGHT}px`,
+};
+
+/**
+ * Renders one source line per row with a sticky gutter. Shared by the full and
+ * windowed render paths; `offset` is the 0-based index of the first row so line
+ * numbers stay correct when only a window of the file is highlighted.
+ */
+function renderRows(
+    { rows, stylesheet, useInlineStyles }: RendererArgs,
+    offset: number,
+    gutterWidth: number
+): React.ReactNode {
+    return rows.map((node, i) => {
+        const lineNumber = offset + i + 1;
+        return (
+            <div
+                key={lineNumber}
+                data-line={lineNumber}
+                style={{
+                    display: 'flex',
+                    height: `${CODE_LINE_HEIGHT}px`,
+                    lineHeight: `${CODE_LINE_HEIGHT}px`,
+                }}
+            >
+                <span
+                    aria-hidden="true"
+                    style={{
+                        flex: `0 0 ${gutterWidth}px`,
+                        width: `${gutterWidth}px`,
+                        position: 'sticky',
+                        left: 0,
+                        zIndex: 2,
+                        textAlign: 'right',
+                        paddingRight: '8px',
+                        color: 'var(--text-tertiary)',
+                        background: 'var(--bg-secondary)',
+                        borderRight: '1px solid var(--border)',
+                        userSelect: 'none',
+                    }}
+                >
+                    {lineNumber}
+                </span>
+                <span className="vcb-code" style={{ paddingLeft: '8px', whiteSpace: 'pre' }}>
+                    {createElement({ node, stylesheet, useInlineStyles, key: `c-${i}` })}
+                </span>
+            </div>
+        );
+    });
+}
+
+/**
+ * Displays a whole file with syntax highlighting. Highlighting is decoupled from
+ * interaction state (drag, resize, LSP selection) so it is computed once for
+ * normal files; very large files are windowed to keep the DOM small.
+ */
+export default function VirtualizedCodeBlock({
+    content,
+    language,
+    syntaxStyle,
+    activeLine,
+    targetLine,
+    scrollToLine,
+    onLineClick,
+    clickable = false,
+    children,
+}: VirtualizedCodeBlockProps) {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const rafRef = useRef<number | null>(null);
+
+    const lines = useMemo(() => content.split('\n'), [content]);
+    const total = lines.length;
+    const virtualize = total > VIRTUALIZE_THRESHOLD;
+
+    const gutterWidth = useMemo(() => {
+        const digits = String(Math.max(total, 1)).length;
+        return Math.max(48, digits * 9 + 16);
+    }, [total]);
+
+    const [scrollTop, setScrollTop] = useState(0);
+    const [viewportH, setViewportH] = useState(0);
+
+    // Track viewport height for windowing.
+    useEffect(() => {
+        const el = scrollRef.current;
+        if (!el || !virtualize) return;
+        const measure = () => setViewportH(el.clientHeight);
+        measure();
+        const ro = new ResizeObserver(measure);
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, [virtualize]);
+
+    const handleScroll = useCallback(() => {
+        if (!virtualize) return;
+        if (rafRef.current !== null) return;
+        rafRef.current = requestAnimationFrame(() => {
+            rafRef.current = null;
+            setScrollTop(scrollRef.current?.scrollTop ?? 0);
+        });
+    }, [virtualize]);
+
+    useEffect(
+        () => () => {
+            if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+        },
+        []
+    );
+
+    // Scroll a requested line into view (centered). Re-runs when the target line
+    // changes or when fresh content loads (e.g. navigating to another file).
+    useEffect(() => {
+        const el = scrollRef.current;
+        if (!scrollToLine || !el) return;
+        const id = setTimeout(() => {
+            const top = Math.max(0, (scrollToLine - 1) * CODE_LINE_HEIGHT - el.clientHeight / 2);
+            el.scrollTo({ top, behavior: 'smooth' });
+        }, 50);
+        return () => clearTimeout(id);
+    }, [scrollToLine, content]);
+
+    const fullRenderer = useCallback(
+        (args: RendererArgs) => renderRows(args, 0, gutterWidth),
+        [gutterWidth]
+    );
+
+    // Full highlight: computed once per content/language/theme. Memoizing the
+    // element keeps interaction-driven re-renders from re-tokenizing the file.
+    const fullBlock = useMemo(
+        () => (
+            <SyntaxHighlighter
+                language={language}
+                style={syntaxStyle}
+                renderer={fullRenderer}
+                PreTag="div"
+                CodeTag="div"
+                customStyle={PRE_CODE_RESET}
+            >
+                {content}
+            </SyntaxHighlighter>
+        ),
+        [content, language, syntaxStyle, fullRenderer]
+    );
+
+    let codeBody: React.ReactNode;
+    if (!virtualize) {
+        codeBody = <div style={{ position: 'relative', zIndex: 1 }}>{fullBlock}</div>;
+    } else {
+        const start = Math.max(0, Math.floor(scrollTop / CODE_LINE_HEIGHT) - OVERSCAN);
+        const end = Math.min(
+            total,
+            Math.ceil((scrollTop + (viewportH || 0)) / CODE_LINE_HEIGHT) + OVERSCAN
+        );
+        const visibleText = lines.slice(start, end).join('\n');
+        codeBody = (
+            <div
+                style={{
+                    position: 'absolute',
+                    top: `${start * CODE_LINE_HEIGHT}px`,
+                    left: 0,
+                    right: 0,
+                    zIndex: 1,
+                }}
+            >
+                <SyntaxHighlighter
+                    language={language}
+                    style={syntaxStyle}
+                    renderer={(args: RendererArgs) => renderRows(args, start, gutterWidth)}
+                    PreTag="div"
+                    CodeTag="div"
+                    customStyle={PRE_CODE_RESET}
+                >
+                    {visibleText || ' '}
+                </SyntaxHighlighter>
+            </div>
+        );
+    }
+
+    const lineOverlay = (line: number | null | undefined, bg: string, border: string) => {
+        if (!line || line < 1 || line > total) return null;
+        return (
+            <div
+                style={{
+                    position: 'absolute',
+                    top: `${(line - 1) * CODE_LINE_HEIGHT}px`,
+                    left: 0,
+                    right: 0,
+                    height: `${CODE_LINE_HEIGHT}px`,
+                    background: bg,
+                    borderLeft: `3px solid ${border}`,
+                    zIndex: 0,
+                    pointerEvents: 'none',
+                }}
+            />
+        );
+    };
+
+    const handleClick = useCallback(
+        (e: React.MouseEvent) => {
+            if (!clickable || !onLineClick) return;
+            const lineEl = (e.target as HTMLElement).closest('[data-line]');
+            if (!lineEl) return;
+            const line = Number(lineEl.getAttribute('data-line'));
+            if (!line) return;
+            const codeEl = lineEl.querySelector('.vcb-code') as HTMLElement | null;
+            const column = codeEl ? getClickColumn(e, codeEl) : 0;
+            onLineClick(line, column);
+        },
+        [clickable, onLineClick]
+    );
+
+    return (
+        <div
+            ref={scrollRef}
+            className="custom-scrollbar"
+            onScroll={handleScroll}
+            onClick={handleClick}
+            style={{
+                height: '100%',
+                overflow: 'auto',
+                background: 'var(--bg-primary)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: `${CODE_FONT_SIZE}px`,
+                cursor: clickable ? 'pointer' : 'default',
+            }}
+        >
+            <div
+                style={{
+                    position: 'relative',
+                    minWidth: '100%',
+                    width: 'fit-content',
+                    height: virtualize ? `${total * CODE_LINE_HEIGHT}px` : undefined,
+                }}
+            >
+                {lineOverlay(targetLine, colors.bgWarningDim, colors.warning)}
+                {lineOverlay(activeLine, colors.bgInfoDim, 'var(--accent)')}
+                {codeBody}
+                {children}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Opening a large reference file (e.g. 3,000 lines) via LSP find-definition/
references made the web UI unbearably slow. The CodeViewerModal rendered the
whole file through a single react-syntax-highlighter with an inline lineProps
closure, so Prism re-tokenized the entire file on every interaction-driven
re-render (drag, resize, every LSP click), and all lines were mounted as DOM
nodes at once.

- Add VirtualizedCodeBlock: highlights a file once (memoized, decoupled from
  interaction state) and windows files over 1500 lines so only visible rows
  are mounted. Active/target line highlighting is drawn as a cheap overlay and
  clicks are handled via delegation, so selecting a line no longer re-tokenizes.
- Use it for both the docked and floating CodeViewerModal layouts, replacing
  the per-render lineProps highlighter.
- Review.tsx: skip per-line syntax highlighting for file sections over 2000
  changed lines (falls back to plain text) to avoid thousands of Prism
  instances on large diffs.