### PR TITLE
Fix comments vanishing after creation when a hunk is expanded

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -233,6 +233,12 @@ export default function Review({
 }: ReviewProps) {
     const [content, setContent] = useState<string>('');
     const [diff, setDiff] = useState<string>('');
+    // Indices (into diff.split('\n')) of context lines fetched on demand via
+    // hunk expansion. These lines are NOT part of the PR's canonical diff, so
+    // they must not consume a GitHub comment "position" — otherwise every line
+    // below an expansion shifts and comments created while expanded are stored
+    // at a position that no longer exists once the canonical diff is restored.
+    const [expandedLineIndices, setExpandedLineIndices] = useState<Set<number>>(new Set());
     const [comments, setComments] = useState<Comment[]>([]);
     const [outdatedComments, setOutdatedComments] = useState<Comment[]>([]);
     const [reviews, setReviews] = useState<ReviewData[]>([]);
@@ -407,6 +413,7 @@ export default function Review({
             ]);
             setContent(res.content || '');
             setDiff(res.diff || '');
+            setExpandedLineIndices(new Set());
             setComments(res.comments || []);
             setOutdatedComments(res.outdated_comments || []);
             setReviews(res.reviews || []);
@@ -432,6 +439,7 @@ export default function Review({
             ]);
             setContent(res.content || '');
             setDiff(res.diff || '');
+            setExpandedLineIndices(new Set());
             setComments(res.comments || []);
             setOutdatedComments(res.outdated_comments || []);
             setReviews(res.reviews || []);
@@ -498,8 +506,9 @@ export default function Review({
                 newLines[hunkLineIndex] = res.range_header;
             }
 
+            let insertAt: number;
             if (direction === 'before') {
-                newLines.splice(hunkLineIndex + 1, 0, ...contextLines);
+                insertAt = hunkLineIndex + 1;
             } else {
                 // Find the end of this hunk: next hunk header, next file, or EOF.
                 let endIdx = hunkLineIndex + 1;
@@ -508,8 +517,25 @@ export default function Review({
                     if (l.startsWith('@@ ') || l.startsWith('diff --git ')) break;
                     endIdx++;
                 }
-                newLines.splice(endIdx, 0, ...contextLines);
+                insertAt = endIdx;
             }
+            newLines.splice(insertAt, 0, ...contextLines);
+
+            // Record the newly inserted lines as expanded context, shifting any
+            // previously expanded indices at/after the insertion point. Keeping
+            // this in sync with the diff string lets parseDiff exclude these
+            // lines from comment-position counting.
+            const expandedCount = contextLines.length;
+            setExpandedLineIndices(prev => {
+                const next = new Set<number>();
+                for (const i of prev) {
+                    next.add(i >= insertAt ? i + expandedCount : i);
+                }
+                for (let k = 0; k < expandedCount; k++) {
+                    next.add(insertAt + k);
+                }
+                return next;
+            });
 
             setDiff(newLines.join('\n'));
         } catch (e) {
@@ -547,6 +573,7 @@ export default function Review({
             const res = await rpcCall<PRResponse>('RPCHandler.AddComment', [params]);
             setContent(res.content || '');
             setDiff(res.diff || '');
+            setExpandedLineIndices(new Set());
             setComments(res.comments || []);
             setOutdatedComments(res.outdated_comments || []);
             setReviews(res.reviews || []);
@@ -588,6 +615,7 @@ export default function Review({
             ]);
             setContent(res.content || '');
             setDiff(res.diff || '');
+            setExpandedLineIndices(new Set());
             setComments(res.comments || []);
             setOutdatedComments(res.outdated_comments || []);
             setReviews(res.reviews || []);
@@ -890,19 +918,35 @@ export default function Review({
                                 currentHunkContext = (m[5] || '').replace(/^\s+/, '');
                             }
                         } else if (isAddition || isDeletion || isContextLine) {
-                            currentPos++;
-                            pos = currentPos;
                             file = currentFile;
-                            clickable = true;
-                            lineType = isAddition ? 'addition' : isDeletion ? 'deletion' : 'code';
 
-                            if (isAddition) {
-                                lineNewNo = newLineCursor++;
-                            } else if (isDeletion) {
+                            if (expandedLineIndices.has(index)) {
+                                // On-demand expanded context: render it and keep
+                                // the gutter line numbers advancing, but do NOT
+                                // consume a comment position or allow commenting,
+                                // since it has no position in the canonical diff.
+                                clickable = false;
+                                lineType = 'code';
                                 lineOldNo = oldLineCursor++;
+                                lineNewNo = newLineCursor++;
                             } else {
-                                lineOldNo = oldLineCursor++;
-                                lineNewNo = newLineCursor++;
+                                currentPos++;
+                                pos = currentPos;
+                                clickable = true;
+                                lineType = isAddition
+                                    ? 'addition'
+                                    : isDeletion
+                                      ? 'deletion'
+                                      : 'code';
+
+                                if (isAddition) {
+                                    lineNewNo = newLineCursor++;
+                                } else if (isDeletion) {
+                                    lineOldNo = oldLineCursor++;
+                                } else {
+                                    lineOldNo = oldLineCursor++;
+                                    lineNewNo = newLineCursor++;
+                                }
                             }
                         }
                     }

--- a/bun_client/frontend/src/diff_utils.ts
+++ b/bun_client/frontend/src/diff_utils.ts
@@ -10,7 +10,21 @@ export interface ParsedLine {
     originalLineIndex: number;
 }
 
-export const parseDiff = (diff: string): ParsedLine[] => {
+/**
+ * Parse a unified diff into renderable lines, tracking each line's GitHub
+ * comment "position".
+ *
+ * `expandedLineIndices` holds indices (into `diff.split('\n')`) of context lines
+ * that were fetched on demand via hunk expansion. They are displayed but are NOT
+ * part of the PR's canonical diff, so they must not consume a comment position —
+ * otherwise every line below an expansion shifts and comments created while a
+ * hunk is expanded are stored at a position that no longer exists once the
+ * canonical diff is restored.
+ */
+export const parseDiff = (
+    diff: string,
+    expandedLineIndices?: ReadonlySet<number>
+): ParsedLine[] => {
     const parsedLines: ParsedLine[] = [];
 
     // Add Diff lines and track positions for comments
@@ -137,11 +151,18 @@ export const parseDiff = (diff: string): ParsedLine[] => {
                         clickable = false;
                         lineType = 'hunk';
                     } else if (isAddition || isDeletion || isContextLine) {
-                        currentPos++;
-                        pos = currentPos;
                         file = currentFile;
-                        clickable = true;
-                        lineType = isAddition ? 'addition' : isDeletion ? 'deletion' : 'code';
+                        if (expandedLineIndices?.has(index)) {
+                            // On-demand expanded context: render it but don't
+                            // consume a comment position or allow commenting.
+                            clickable = false;
+                            lineType = 'code';
+                        } else {
+                            currentPos++;
+                            pos = currentPos;
+                            clickable = true;
+                            lineType = isAddition ? 'addition' : isDeletion ? 'deletion' : 'code';
+                        }
                     }
                 }
             }

--- a/bun_client/frontend/src/repro_comment_position.test.ts
+++ b/bun_client/frontend/src/repro_comment_position.test.ts
@@ -1,0 +1,81 @@
+import { expect, test, describe } from 'bun:test';
+import { parseDiff } from './diff_utils';
+
+// Regression test for comments disappearing after creation.
+//
+// Hunk expansion splices extra context lines into the displayed diff. Those
+// lines are NOT part of the PR's canonical diff, so they must not consume a
+// GitHub comment "position". If they do, every line below an expansion shifts,
+// and a comment created while a hunk is expanded is stored at a position that
+// no longer matches any line once the canonical diff is restored — so it
+// silently vanishes from the UI.
+
+const baseDiff = `diff --git a/foo.go b/foo.go
+index 1111111..2222222 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,4 +1,4 @@
+ package main
+-import "old"
++import "new"
+ func main() {
+@@ -20,3 +20,4 @@ func main() {
+ 	a := 1
+ 	b := 2
++	c := 3
+`;
+
+describe('comment position is invariant to hunk expansion', () => {
+    const canonical = parseDiff(baseDiff);
+    const canonicalTarget = canonical.find(l => l.text.includes('c := 3'))!;
+
+    test('sanity: the comment target has a stable canonical position', () => {
+        expect(canonicalTarget).toBeTruthy();
+        expect(canonicalTarget.pos).not.toBeNull();
+    });
+
+    test('expanded context lines keep real-line positions unchanged', () => {
+        // Simulate handleExpandHunk inserting two context lines after the
+        // first hunk header (index 5 in the split lines: the "@@ -1,4..." line
+        // is index 4, so the inserted lines land at indices 5 and 6).
+        const lines = baseDiff.split('\n');
+        const hunkHeaderIdx = lines.findIndex(l => l.startsWith('@@ -1,4'));
+        const insertAt = hunkHeaderIdx + 1;
+        const contextLines = [' ctxA', ' ctxB'];
+        const expandedLines = [
+            ...lines.slice(0, insertAt),
+            ...contextLines,
+            ...lines.slice(insertAt),
+        ];
+        const expandedIndices = new Set<number>([insertAt, insertAt + 1]);
+
+        const expanded = parseDiff(expandedLines.join('\n'), expandedIndices);
+
+        // The expanded context lines are rendered but not commentable...
+        const ctxA = expanded.find(l => l.text === ' ctxA')!;
+        expect(ctxA.clickable).toBe(false);
+        expect(ctxA.pos).toBeNull();
+
+        // ...and the real line the user clicks reports the SAME position as in
+        // the canonical diff, so the stored comment survives the diff reload.
+        const expandedTarget = expanded.find(l => l.text.includes('c := 3'))!;
+        expect(expandedTarget.pos).toBe(canonicalTarget.pos);
+    });
+
+    test('without the fix, expansion would shift the position (control)', () => {
+        // Same expansion, but NOT flagging the inserted lines as expanded:
+        // positions shift and the bug reproduces.
+        const lines = baseDiff.split('\n');
+        const hunkHeaderIdx = lines.findIndex(l => l.startsWith('@@ -1,4'));
+        const insertAt = hunkHeaderIdx + 1;
+        const expandedLines = [
+            ...lines.slice(0, insertAt),
+            ' ctxA',
+            ' ctxB',
+            ...lines.slice(insertAt),
+        ];
+        const shifted = parseDiff(expandedLines.join('\n')); // no expanded set
+        const shiftedTarget = shifted.find(l => l.text.includes('c := 3'))!;
+        expect(shiftedTarget.pos).not.toBe(canonicalTarget.pos);
+    });
+});


### PR DESCRIPTION
Comments created in the web UI could silently disappear right after being
added. The cause was hunk expansion: on-demand context lines fetched via
GetHunkContext are spliced into the displayed diff and were counted toward
each line's GitHub "position". That inflated the position of every line
below the expansion, so a comment created while a hunk was expanded was
stored at a position that no longer existed once handleAddComment restored
the canonical diff — leaving the comment with no line to attach to.

Track the indices of expanded context lines and exclude them from position
counting in parseDiff, so real diff lines keep their canonical positions
regardless of expansion. Expanded lines are still rendered (with correct
gutter numbers) but are no longer commentable, which matches the fact that
they have no position in the PR's canonical diff. The tracking set is reset
whenever a fresh server diff replaces the current one.

Mirror the same expansion-awareness in the shared diff_utils parser and add
a regression test locking the position invariant.