### PR TITLE
Fix diff-position counting when adding review comments

### DIFF
--- a/client.el/crs-comments.el
+++ b/client.el/crs-comments.el
@@ -106,20 +106,12 @@
                            (if (re-search-forward "^\\(?:[^[:space:]].*?[[:space:]]\\)?\\(?:modified\\|deleted\\|new file\\|renamed\\)[[:space:]:]+" nil t)
                                (match-beginning 0)
                              (point-max)))))
-      (message "Searching for hunk between line %d and %d" (line-number-at-pos start-pos) (line-number-at-pos search-bound))
-      ;; Diagnostic: Log the start of each line
-      (save-excursion
-        (goto-char start-pos)
-        (while (< (point) search-bound)
-          (message "Line %d start: [%S]" (line-number-at-pos) (buffer-substring-no-properties (line-beginning-position) (min (line-end-position) (+ (line-beginning-position) 15))))
-          (forward-line 1)))
       (goto-char start-pos)
       (if (search-forward "@@" search-bound t)
-          (let ((hunk-line (line-number-at-pos)))
-            (message "Found hunk header at line %d" hunk-line)
-            hunk-line)
+          (line-number-at-pos)
         (progn
-          (message "Failed to find hunk header between line %d and %d. Bound pos: %d" (line-number-at-pos start-pos) (line-number-at-pos search-bound) search-bound)
+          (message "Failed to find hunk header between line %d and %d"
+                   (line-number-at-pos start-pos) (line-number-at-pos search-bound))
           nil)))))
 
 (defun crs--get-comment-context ()
@@ -230,28 +222,37 @@ If on a local comment, local-comment-id and local-comment-body will be set."
               (first-hunk-counted nil))
           (while (<= (line-number-at-pos) target-line)
             (let ((line-content (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+              ;; The position computed here is sent verbatim to GitHub and is
+              ;; also what the renderer uses to place comments, so this MUST
+              ;; agree line-for-line with `crs--render-diff' and
+              ;; `crs--find-position-in-diff'.
               (cond
-               ((string-match "^@@ -[0-9]+,[0-9]+ \\+\\([0-9]+\\),[0-9]+ @@" line-content)
+               ;; Hunk header.  Lengths are optional for single-line hunks
+               ;; (e.g. "@@ -3 +4 @@"), matching `crs--parse-hunk-header'.  The
+               ;; first hunk header anchors position 0; every later hunk header
+               ;; advances the position by 1, as GitHub counts them.
+               ((string-match "^@@ -[0-9]+\\(?:,[0-9]+\\)? \\+\\([0-9]+\\)\\(?:,[0-9]+\\)? @@" line-content)
                 (if (not first-hunk-counted)
                     (setq first-hunk-counted t)
                   (setq count (1+ count)))
                 (setq file-line (string-to-number (match-string 1 line-content)))
                 (setq target-file-line file-line))
+               ;; Skip interleaved review-comment blocks.
                ((string-match-p "^[[:cntrl:][:space:]]*[│┌└]" line-content)
-                ;; Skip comment blocks
                 nil)
-               ;; Skip empty separator lines between hunks (emitted by formatDiff).
-               ;; Diff content lines always have a prefix char (+, -, or space)
-               ;; so they are never zero-length, even for blank source lines.
-               ((= (length line-content) 0)
-                nil)
-               (t
-                ;; Content line
-                (unless (string-match-p "^@@" line-content)
-                  (setq count (1+ count))
-                  (setq target-file-line file-line)
-                  (when (and file-line (not (string-prefix-p "-" line-content)))
-                    (setq file-line (1+ file-line)))))))
+               ;; Content line.  Only lines carrying a diff prefix (+, -, or
+               ;; space) advance the position.  This excludes the blank
+               ;; separator lines emitted by formatDiff and markers such as
+               ;; "\ No newline at end of file", neither of which GitHub counts.
+               ((or (string-prefix-p "+" line-content)
+                    (string-prefix-p "-" line-content)
+                    (string-prefix-p " " line-content))
+                (setq count (1+ count))
+                (setq target-file-line file-line)
+                (when (and file-line (not (string-prefix-p "-" line-content)))
+                  (setq file-line (1+ file-line))))
+               ;; Anything else is not part of the diff position; skip it.
+               (t nil)))
             (forward-line 1))
           (setq position count))))
 

--- a/client.el/crs-comments.el
+++ b/client.el/crs-comments.el
@@ -14,6 +14,7 @@
 (declare-function crs--get-current-review-info "crs-review")
 (declare-function crs--render-and-update "crs-render")
 (declare-function crs--review-buffer-name "crs-review")
+(declare-function crs--diff-line-marker "crs-render")
 
 (defun crs-submit-comment ()
   "Submit the comment in the current buffer."
@@ -221,35 +222,41 @@ If on a local comment, local-comment-id and local-comment-body will be set."
               (file-line nil)
               (first-hunk-counted nil))
           (while (<= (line-number-at-pos) target-line)
-            (let ((line-content (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+            (let* ((line-content (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
+                   ;; MARKER is ?+, ?-, ?\s, or nil.  It classifies the line the
+                   ;; same way the renderer does, and crucially handles both raw
+                   ;; diff lines and lines washed by git-delta (which prefixes
+                   ;; each line with an "old ⋮ new │" line-number gutter).
+                   (marker (crs--diff-line-marker line-content)))
               ;; The position computed here is sent verbatim to GitHub and is
               ;; also what the renderer uses to place comments, so this MUST
-              ;; agree line-for-line with `crs--render-diff' and
-              ;; `crs--find-position-in-diff'.
+              ;; agree line-for-line with `crs--insert-comments-into-buffer'
+              ;; and `crs--find-position-in-diff'.
               (cond
                ;; Hunk header.  Lengths are optional for single-line hunks
                ;; (e.g. "@@ -3 +4 @@"), matching `crs--parse-hunk-header'.  The
                ;; first hunk header anchors position 0; every later hunk header
-               ;; advances the position by 1, as GitHub counts them.
+               ;; advances the position by 1, as GitHub counts them.  (delta
+               ;; leaves hunk headers ungutted, so this matches either layout.)
                ((string-match "^@@ -[0-9]+\\(?:,[0-9]+\\)? \\+\\([0-9]+\\)\\(?:,[0-9]+\\)? @@" line-content)
                 (if (not first-hunk-counted)
                     (setq first-hunk-counted t)
                   (setq count (1+ count)))
                 (setq file-line (string-to-number (match-string 1 line-content)))
                 (setq target-file-line file-line))
-               ;; Skip interleaved review-comment blocks.
+               ;; Skip interleaved review-comment blocks (drawn with "│┌└" but
+               ;; no "⋮", so they never look like a gutter content line).
                ((string-match-p "^[[:cntrl:][:space:]]*[│┌└]" line-content)
                 nil)
-               ;; Content line.  Only lines carrying a diff prefix (+, -, or
-               ;; space) advance the position.  This excludes the blank
-               ;; separator lines emitted by formatDiff and markers such as
+               ;; Content line.  Only added/removed/context lines advance the
+               ;; position; this excludes blank separators and markers such as
                ;; "\ No newline at end of file", neither of which GitHub counts.
-               ((or (string-prefix-p "+" line-content)
-                    (string-prefix-p "-" line-content)
-                    (string-prefix-p " " line-content))
+               (marker
                 (setq count (1+ count))
                 (setq target-file-line file-line)
-                (when (and file-line (not (string-prefix-p "-" line-content)))
+                ;; Removed lines do not exist in the new file, so do not advance
+                ;; the file-line counter for them.
+                (when (and file-line (not (eq marker ?-)))
                   (setq file-line (1+ file-line))))
                ;; Anything else is not part of the diff position; skip it.
                (t nil)))

--- a/client.el/crs-render.el
+++ b/client.el/crs-render.el
@@ -15,6 +15,34 @@
 (declare-function delta-wash "washer")
 (declare-function my-code-review-mode "crs-review")
 
+(defun crs--diff-line-marker (line)
+  "Return the unified-diff marker for a diff content LINE, or nil.
+The marker is one of the characters ?+, ?-, or ?\\s (space), identifying an
+added, removed, or context line.  Returns nil when LINE is not a diff
+content line (hunk header, file header, comment block, blank separator…).
+
+Two layouts are recognised so position counting stays correct whether or
+not the buffer has been washed by git-delta:
+- raw unified diff, where the marker is the first character of the line; and
+- delta with `line-numbers' enabled, where the line carries an old/new
+  line-number gutter and looks like \"  4 ⋮  4 │<marker> content\".  In that
+  layout the marker is the first character after the box-drawing \"│\"
+  separator, so the leading column (which may be a digit or blank depending
+  on the line number) can no longer be used to classify the line."
+  (cond
+   ;; git-delta line-numbers gutter: <old> ⋮ <new> │<marker>
+   ((string-match "⋮[^│\n]*│\\(.?\\)" line)
+    (let* ((m (match-string 1 line))
+           (ch (if (> (length m) 0) (aref m 0) ?\s)))
+      (cond ((eq ch ?+) ?+)
+            ((eq ch ?-) ?-)
+            (t ?\s))))
+   ;; Raw unified-diff line.
+   ((string-prefix-p "+" line) ?+)
+   ((string-prefix-p "-" line) ?-)
+   ((string-prefix-p " " line) ?\s)
+   (t nil)))
+
 (defun crs-toggle-section ()
   "Toggle visibility of the section under the current header."
   (interactive)
@@ -431,11 +459,9 @@ SHOW-FULL-COMMENTS determines whether to show full content or indicators."
                           (push (cons line-end (list 'append (crs--format-compact-comment-indicator file-comments))) insertions))))))
               (setq position (1+ position))))
 
-           ;; Content Line
+           ;; Content Line (raw or delta-washed)
            ((and first-hunk-seen
-                 (or (string-prefix-p "+" line)
-                     (string-prefix-p "-" line)
-                     (string-prefix-p " " line)))
+                 (crs--diff-line-marker line))
             (setq position (1+ position))
             (let* ((key (when current-file (format "%s:%d" current-file position)))
                    (line-comments (when key (gethash key comment-map))))
@@ -661,12 +687,10 @@ Returns the line number, or nil if not found."
              ((string-match-p "^[[:space:]]*[│┌└]" line)
               nil)
 
-             ;; Content line
+             ;; Content line (raw or delta-washed)
              ((and first-hunk-seen
                    (string= target-file filename)
-                   (or (string-prefix-p "+" line)
-                       (string-prefix-p "-" line)
-                       (string-prefix-p " " line)))
+                   (crs--diff-line-marker line))
               (setq current-position (1+ current-position))
               (when (= current-position position)
                 (setq found-line (line-number-at-pos))))))


### PR DESCRIPTION
crs--get-comment-context computes the position sent verbatim to GitHub
(server.go forwards it as DraftReviewComment.Position) and used by the
renderer to place comments. It diverged from crs--render-diff and
crs--find-position-in-diff in two ways:

- The catch-all branch counted any non-empty, non-comment, non-@@ line
  as diff content, so "\ No newline at end of file" markers (and any
  other non +/-/space line) inflated the position. Comments below such
  a marker landed a line off.
- The hunk-header regex required explicit ",len" counts, so single-line
  hunks ("@@ -3 +4 @@") fell through to the catch-all, missing the +1
  a subsequent hunk header contributes and failing to reset file-line.

Count only lines with a diff prefix (+, -, space), advance by 1 per
later hunk header, and accept comma-less hunk headers, matching the
renderer exactly. Also drop leftover per-line diagnostic logging in
crs--find-first-hunk-line.