### PR TITLE
Fix FilterWaitingOnMe by comparing GitHub logins case-insensitively

### DIFF
--- a/git_tools/git_tools.go
+++ b/git_tools/git_tools.go
@@ -871,7 +871,7 @@ func CalculateInteractionState(myLogin string, pr *github.PullRequest, reviews [
 		if r == nil || r.SubmittedAt == nil || r.User == nil || r.User.Login == nil {
 			continue
 		}
-		if *r.User.Login == myLogin {
+		if strings.EqualFold(*r.User.Login, myLogin) {
 			if r.SubmittedAt.After(state.LastMeTime) {
 				state.LastMeTime = *r.SubmittedAt
 			}
@@ -899,7 +899,7 @@ func CalculateInteractionState(myLogin string, pr *github.PullRequest, reviews [
 
 		threads[rootID] = *c.User.Login
 
-		if *c.User.Login == myLogin {
+		if strings.EqualFold(*c.User.Login, myLogin) {
 			participation[rootID] = true
 			if c.CreatedAt != nil && c.CreatedAt.After(state.LastMeTime) {
 				state.LastMeTime = *c.CreatedAt
@@ -912,7 +912,7 @@ func CalculateInteractionState(myLogin string, pr *github.PullRequest, reviews [
 	}
 
 	for rootID, lastCommenter := range threads {
-		if participation[rootID] && lastCommenter != myLogin {
+		if participation[rootID] && !strings.EqualFold(lastCommenter, myLogin) {
 			state.HasUnrespondedComments = true
 			break
 		}
@@ -924,7 +924,7 @@ func CalculateInteractionState(myLogin string, pr *github.PullRequest, reviews [
 		if c == nil || c.User == nil || c.User.Login == nil {
 			continue
 		}
-		if *c.User.Login == myLogin {
+		if strings.EqualFold(*c.User.Login, myLogin) {
 			iParticipated = true
 			if c.CreatedAt != nil && c.CreatedAt.After(state.LastMeTime) {
 				state.LastMeTime = *c.CreatedAt
@@ -1105,7 +1105,11 @@ func FilterWaitingOnMe(prs []*github.PullRequest) []*github.PullRequest {
 			// Is Personally Requested?
 			isRequested := false
 			for _, r := range pr.RequestedReviewers {
-				if r != nil && r.Login != nil && *r.Login == myLogin {
+				// GitHub logins are case-insensitive, so compare with EqualFold:
+				// a casing mismatch between the configured GithubUsername and the
+				// login returned by the API would otherwise make isRequested
+				// always false and the filter would match nothing.
+				if r != nil && r.Login != nil && strings.EqualFold(*r.Login, myLogin) {
 					isRequested = true
 					break
 				}

--- a/git_tools/waiting_on_me_test.go
+++ b/git_tools/waiting_on_me_test.go
@@ -133,6 +133,43 @@ func TestFilterWaitingOnMe(t *testing.T) {
 	}
 }
 
+// TestFilterWaitingOnMeUsernameCaseInsensitive guards against a regression where
+// a casing difference between the configured GithubUsername and the login
+// returned by the GitHub API caused the filter to recognize no one as "me",
+// silently matching zero PRs. GitHub logins are case-insensitive.
+func TestFilterWaitingOnMeUsernameCaseInsensitive(t *testing.T) {
+	cfg := config.C()
+	cfg.GithubUsername = "MyUser" // configured with different casing than the PR data
+	config.SetC(cfg)
+
+	owner := "owner"
+	repo := "repo"
+	number := 500
+
+	pr := &github.PullRequest{
+		Number: &number,
+		User:   &github.User{Login: github.String("author")},
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				Owner: &github.User{Login: &owner},
+				Name:  &repo,
+			},
+		},
+		// API returns the login in lowercase; config has "MyUser".
+		RequestedReviewers: []*github.User{{Login: github.String("myuser")}},
+	}
+
+	// Fresh request: no prior interaction, so the only reason to include is the
+	// requested-reviewer check, which must match case-insensitively.
+	cacheKey := fmt.Sprintf("interaction_state:%s/%s:%d", owner, repo, number)
+	GlobalCache.Set(cacheKey, InteractionState{}, 1*time.Hour)
+
+	result := FilterWaitingOnMe([]*github.PullRequest{pr})
+	if len(result) != 1 {
+		t.Errorf("expected PR to be included despite username casing mismatch, got %d results", len(result))
+	}
+}
+
 func TestCalculateInteractionState(t *testing.T) {
 	myLogin := "myself"
 	other := "other"


### PR DESCRIPTION
GitHub usernames are case-insensitive, but FilterWaitingOnMe and
CalculateInteractionState compared the configured GithubUsername against
API-returned logins with exact ==. Any casing difference (e.g. config
"MyUser" vs API "myuser") made the user unrecognizable: isRequested was
always false and LastMeTime/HasUnrespondedComments never reflected the
user's own activity, so the filter silently matched zero PRs.

Switch all login comparisons to strings.EqualFold, matching the fix
already applied to the sibling filterMyReviewRequested. Add a regression
test that reproduces the casing-mismatch failure.