### PR TITLE
Centralize keybindings to crs-client.el

### DIFF
--- a/client.el/crs-client.el
+++ b/client.el/crs-client.el
@@ -23,6 +23,149 @@
 (require 'crs-review-actions)
 (require 'crs-plugins)
 
+
+;;; Keybindings
+;;
+;; All keybindings are defined here, after every module has been required, so
+;; that every command and mode keymap is loaded before it is bound.  Each mode
+;; declares an empty keymap next to its `define-derived-mode'; the bindings are
+;; installed below.  Non-evil bindings populate the keymaps directly, while
+;; evil bindings are deferred until evil itself is loaded.
+
+(define-keymap :keymap crs-list-mode-map
+  "TAB" #'crs-list-toggle-heading
+  "<tab>" #'crs-list-toggle-heading
+  "<backtab>" #'crs-list-cycle-global
+  "RET" #'crs-start-review-at-point
+  "<return>" #'crs-start-review-at-point
+  "g" #'crs-refresh-reviews
+  "q" #'quit-window)
+
+(define-keymap :keymap my-code-review-mode-map
+  "TAB" #'crs-toggle-section
+  "<tab>" #'crs-toggle-section
+  "<backtab>" #'crs-collapse-all-sections
+  "c" #'crs-add-or-edit-comment
+  "d" #'crs-delete-local-comment
+  "C-c C-c" #'crs-submit-review
+  ;; "ra" #'crs-approve-review
+  ;; "rc" #'crs-comment-review
+  ;; "rr" #'crs-request-changes-review
+  "g" #'crs-sync-pr
+  "p" #'crs-get-plugin-output
+  "P" #'crs-get-single-plugin-output
+  "D" #'crs-run-on-demand-plugin
+  "R" #'crs-rerun-plugin
+  "H" #'crs-toggle-comments
+  "f" #'crs-set-review-feedback
+  "RET" #'crs-visit-file
+  "<return>" #'crs-visit-file
+  "O" #'crs-expand-hunk-before
+  "o" #'crs-expand-hunk-after
+  "q" #'quit-window
+  "]" #'crs-next-pr
+  "[" #'crs-prev-pr
+  "<" #'crs-expand-hunk-before
+  ">" #'crs-expand-hunk-after)
+
+(define-keymap :keymap crs-outdated-comments-mode-map
+  "q" #'crs-quit-outdated-comments)
+
+(define-keymap :keymap comment-edit-mode-map
+  "C-c C-c" #'crs-submit-comment
+  "C-c C-k" #'crs-abort-comment)
+
+(define-keymap :keymap crs-plugin-output-mode-map
+  "r" #'crs-refresh-plugin-output
+  "q" #'crs-quit-plugin-output
+  "w" #'crs-wash-plugin-output
+  "D" #'crs-run-on-demand-plugin
+  "R" #'crs-rerun-plugin)
+
+(with-eval-after-load 'evil
+  ;; Global normal-state leader bindings: available in any buffer/mode,
+  ;; not only crs-list-mode.
+  (evil-define-key 'normal 'global
+    (kbd ", r s") #'crs-start-review-at-point
+    (kbd ", r b") #'crs-get-reviews)
+  ;; my-code-review-mode: normal state
+  (evil-define-key 'normal my-code-review-mode-map
+    (kbd "TAB") #'crs-toggle-section
+    (kbd "<tab>") #'crs-toggle-section
+    (kbd "<backtab>") #'crs-collapse-all-sections
+    "c" #'crs-add-or-edit-comment
+    "d" #'crs-delete-local-comment
+    (kbd "C-c C-c") #'crs-submit-review
+    "ra" #'crs-approve-review
+    "rc" #'crs-comment-review
+    "rr" #'crs-request-changes-review
+    "rg" #'crs-sync-pr
+    "rf" #'crs-set-review-feedback
+    "p" #'crs-get-plugin-output
+    "P" #'crs-get-single-plugin-output
+    "D" #'crs-run-on-demand-plugin
+    "R" #'crs-rerun-plugin
+    "H" #'crs-toggle-comments
+    "f" #'crs-set-review-feedback
+    (kbd "RET") #'crs-visit-file
+    "O" #'crs-expand-hunk-before
+    "o" #'crs-expand-hunk-after
+    "q" #'quit-window
+    "]" #'crs-next-pr
+    "[" #'crs-prev-pr
+    (kbd "SPC C-R") #'crs-get-rate-limit-status)
+  ;; my-code-review-mode: visual state
+  (evil-define-key 'visual my-code-review-mode-map
+    (kbd "TAB") #'crs-toggle-section
+    (kbd "<tab>") #'crs-toggle-section
+    (kbd "<backtab>") #'crs-collapse-all-sections
+    "c" #'crs-add-or-edit-comment
+    "d" #'crs-delete-local-comment
+    (kbd "C-c C-c") #'crs-submit-review
+    "ra" #'crs-approve-review
+    "rc" #'crs-comment-review
+    "rr" #'crs-request-changes-review
+    "rg" #'crs-sync-pr
+    "rf" #'crs-set-review-feedback
+    "p" #'crs-get-plugin-output
+    "P" #'crs-get-single-plugin-output
+    "D" #'crs-run-on-demand-plugin
+    "R" #'crs-rerun-plugin
+    "H" #'crs-toggle-comments
+    "f" #'crs-set-review-feedback
+    (kbd "RET") #'crs-visit-file
+    "O" #'crs-expand-hunk-before
+    "o" #'crs-expand-hunk-after
+    "q" #'quit-window
+    "]" #'crs-next-pr
+    "[" #'crs-prev-pr
+    (kbd "SPC C-R") #'crs-get-rate-limit-status)
+  ;; my-code-review-mode: insert state
+  (evil-define-key 'insert my-code-review-mode-map
+    (kbd "C-c C-c") #'crs-submit-review)
+  ;; crs-outdated-comments-mode
+  (evil-define-key 'normal crs-outdated-comments-mode-map
+    "q" #'crs-quit-outdated-comments)
+  ;; comment-edit-mode
+  (evil-define-key 'normal comment-edit-mode-map
+    "C-c C-c" #'crs-submit-comment
+    "C-c C-k" #'crs-abort-comment
+    ", c" #'crs-submit-comment
+    ", k" #'crs-abort-comment)
+  (evil-define-key 'insert comment-edit-mode-map
+    "C-c C-c" #'crs-submit-comment
+    "C-c C-k" #'crs-abort-comment)
+  (evil-define-key 'visual comment-edit-mode-map
+    "C-c C-c" #'crs-submit-comment
+    "C-c C-k" #'crs-abort-comment)
+  ;; crs-plugin-output-mode
+  (evil-define-key 'normal crs-plugin-output-mode-map
+    "r" #'crs-refresh-plugin-output
+    "q" #'crs-quit-plugin-output
+    "D" #'crs-run-on-demand-plugin
+    "R" #'crs-rerun-plugin
+    "w" #'crs-wash-plugin-output))
+
 (provide 'crs-client)
 
 ;;; crs-client.el ends here

--- a/client.el/crs-comments.el
+++ b/client.el/crs-comments.el
@@ -78,23 +78,7 @@
   (message "Comment aborted."))
 
 (define-derived-mode comment-edit-mode markdown-mode "Code Review Comment"
-  "Major mode for editing code review comments."
-  (local-set-key (kbd "C-c C-c") 'crs-submit-comment)
-  (local-set-key (kbd "C-c C-k") 'crs-abort-comment))
-
-(when (fboundp 'evil-define-key)
-  (evil-define-key 'normal comment-edit-mode-map
-    "C-c C-c" #'crs-submit-comment
-    "C-c C-k" #'crs-abort-comment
-    ", c" #'crs-submit-comment
-    ", k" #'crs-abort-comment
-    )
-  (evil-define-key 'insert comment-edit-mode-map
-    "C-c C-c" #'crs-submit-comment
-    "C-c C-k" #'crs-abort-comment)
-  (evil-define-key 'visual comment-edit-mode-map
-    "C-c C-c" #'crs-submit-comment
-    "C-c C-k" #'crs-abort-comment))
+  "Major mode for editing code review comments.")
 
 ;; Buffer-local variables for plugin output mode
 

--- a/client.el/crs-list-mode.el
+++ b/client.el/crs-list-mode.el
@@ -190,13 +190,7 @@ its children still collapsed."
       (message "All collapsed"))))
 
 (defvar-keymap crs-list-mode-map
-  "TAB" #'crs-list-toggle-heading
-  "<tab>" #'crs-list-toggle-heading
-  "<backtab>" #'crs-list-cycle-global
-  "RET" #'crs-start-review-at-point
-  "<return>" #'crs-start-review-at-point
-  "g" #'crs-refresh-reviews
-  "q" #'quit-window)
+  :doc "Keymap for `crs-list-mode'.  Bindings are defined in crs-client.el.")
 
 (define-derived-mode crs-list-mode fundamental-mode "CRS-List"
   "Major mode for viewing the code review PR list.

--- a/client.el/crs-plugins.el
+++ b/client.el/crs-plugins.el
@@ -73,25 +73,13 @@ Temporarily disables read-only mode (required when called from
         (setq buffer-read-only t)))))
 
 (defvar-keymap crs-plugin-output-mode-map
-  "r" #'crs-refresh-plugin-output
-  "q" #'crs-quit-plugin-output
-  "w" #'crs-wash-plugin-output
-  "D" #'crs-run-on-demand-plugin
-  "R" #'crs-rerun-plugin)
+  :doc "Keymap for `crs-plugin-output-mode'.  Bindings are defined in crs-client.el.")
 
 (define-derived-mode crs-plugin-output-mode markdown-mode "Plugin Output"
   "Major mode for viewing plugin output.
   Inherits from markdown-mode and is read-only.
   \\{crs-plugin-output-mode-map}"
   (setq buffer-read-only t))
-
-(when (fboundp 'evil-define-key)
-  (evil-define-key 'normal crs-plugin-output-mode-map
-    "r" #'crs-refresh-plugin-output
-    "q" #'crs-quit-plugin-output
-    "D" #'crs-run-on-demand-plugin
-    "R" #'crs-rerun-plugin
-    "w" #'crs-wash-plugin-output))
 
 
 (defun crs-get-plugin-output ()

--- a/client.el/crs-review.el
+++ b/client.el/crs-review.el
@@ -29,32 +29,7 @@
 (declare-function crs-rerun-plugin "crs-plugins")
 
 (defvar-keymap my-code-review-mode-map
-  "TAB" #'crs-toggle-section
-  "<tab>" #'crs-toggle-section
-  "<backtab>" #'crs-collapse-all-sections
-  "c" #'crs-add-or-edit-comment
-  "d" #'crs-delete-local-comment
-  "C-c C-c" #'crs-submit-review
-  ;; "ra" #'crs-approve-review
-  ;; "rc" #'crs-comment-review
-  ;; "rr" #'crs-request-changes-review
-  "g" #'crs-sync-pr
-  "p" #'crs-get-plugin-output
-  "P" #'crs-get-single-plugin-output
-  "D" #'crs-run-on-demand-plugin
-  "R" #'crs-rerun-plugin
-  "H" #'crs-toggle-comments
-  "f" #'crs-set-review-feedback
-  "RET" #'crs-visit-file
-  "<return>" #'crs-visit-file
-  "O" #'crs-expand-hunk-before
-  "o" #'crs-expand-hunk-after
-  "q" #'quit-window
-  "]" #'crs-next-pr
-  "[" #'crs-prev-pr
-  "<" #'crs-expand-hunk-before
-  ">" #'crs-expand-hunk-after
-  )
+  :doc "Keymap for `my-code-review-mode'.  Bindings are defined in crs-client.el.")
 
 (define-derived-mode my-code-review-mode fundamental-mode "Code Review"
   "Major mode for viewing code reviews."
@@ -62,64 +37,6 @@
   (highlight-review-comments)
   (add-to-invisibility-spec '(codereview-hide . t))
   (add-hook 'post-command-hook #'crs--maybe-show-collapsed-comments nil t))
-
-
-(with-eval-after-load 'evil
-  ;; Define keys for normal state
-  (evil-define-key 'normal my-code-review-mode-map
-    (kbd "TAB") #'crs-toggle-section
-    (kbd "<tab>") #'crs-toggle-section
-    (kbd "<backtab>") #'crs-collapse-all-sections
-    "c" #'crs-add-or-edit-comment
-    "d" #'crs-delete-local-comment
-    (kbd "C-c C-c") #'crs-submit-review
-    "ra" #'crs-approve-review
-    "rc" #'crs-comment-review
-    "rr" #'crs-request-changes-review
-    "rg" #'crs-sync-pr
-    "rf" #'crs-set-review-feedback
-    "p" #'crs-get-plugin-output
-    "P" #'crs-get-single-plugin-output
-    "D" #'crs-run-on-demand-plugin
-    "R" #'crs-rerun-plugin
-    "H" #'crs-toggle-comments
-    "f" #'crs-set-review-feedback
-    (kbd "RET") #'crs-visit-file
-    "O" #'crs-expand-hunk-before
-    "o" #'crs-expand-hunk-after
-    "q" #'quit-window
-    "]" #'crs-next-pr
-    "[" #'crs-prev-pr
-    (kbd "SPC C-R") #'crs-get-rate-limit-status)
-  ;; Define keys for visual state
-  (evil-define-key 'visual my-code-review-mode-map
-    (kbd "TAB") #'crs-toggle-section
-    (kbd "<tab>") #'crs-toggle-section
-    (kbd "<backtab>") #'crs-collapse-all-sections
-    "c" #'crs-add-or-edit-comment
-    "d" #'crs-delete-local-comment
-    (kbd "C-c C-c") #'crs-submit-review
-    "ra" #'crs-approve-review
-    "rc" #'crs-comment-review
-    "rr" #'crs-request-changes-review
-    "rg" #'crs-sync-pr
-    "rf" #'crs-set-review-feedback
-    "p" #'crs-get-plugin-output
-    "P" #'crs-get-single-plugin-output
-    "D" #'crs-run-on-demand-plugin
-    "R" #'crs-rerun-plugin
-    "H" #'crs-toggle-comments
-    "f" #'crs-set-review-feedback
-    (kbd "RET") #'crs-visit-file
-    "O" #'crs-expand-hunk-before
-    "o" #'crs-expand-hunk-after
-    "q" #'quit-window
-    "]" #'crs-next-pr
-    "[" #'crs-prev-pr
-    (kbd "SPC C-R") #'crs-get-rate-limit-status)
-  ;; Define keys for insert state
-  (evil-define-key 'insert my-code-review-mode-map
-    (kbd "C-c C-c") #'crs-submit-review))
 
 
 (defun crs--review-buffer-name (owner repo number)
@@ -295,17 +212,13 @@ If point is on a URL: line, open the URL in the browser instead."
   (quit-window t))
 
 (defvar-keymap crs-outdated-comments-mode-map
-  "q" #'crs-quit-outdated-comments)
+  :doc "Keymap for `crs-outdated-comments-mode'.  Bindings are defined in crs-client.el.")
 
 (define-derived-mode crs-outdated-comments-mode markdown-mode "Outdated Comments"
   "Major mode for viewing outdated comments.
   Inherits from markdown-mode and is read-only.
   \\{crs-outdated-comments-mode-map}"
   (setq buffer-read-only t))
-
-(with-eval-after-load 'evil
-  (evil-define-key 'normal crs-outdated-comments-mode-map
-    "q" #'crs-quit-outdated-comments))
 
 (defun crs--get-current-review-info ()
   "Extract (owner repo number) from the current review buffer's name.


### PR DESCRIPTION
## Summary

Consolidate all keybinding definitions from individual mode modules into a single location in `crs-client.el`. This improves maintainability by having all keybindings defined in one place after all modules are loaded, rather than scattered across multiple files.

### Changes

- Moved all non-evil keybindings from `crs-review.el`, `crs-comments.el`, `crs-plugins.el`, and `crs-list-mode.el` to `crs-client.el` using `define-keymap`
- Moved all evil-mode keybindings from individual modules to a centralized `with-eval-after-load 'evil` block in `crs-client.el`
- Updated keymap declarations in mode modules to be empty with documentation pointing to `crs-client.el`
- Removed redundant `local-set-key` calls and conditional evil binding checks from mode definitions
- Added comprehensive comments explaining the keybinding organization strategy

## Test Plan

- [ ] Verify all keybindings work in non-evil mode (TAB, RET, g, q, etc.)
- [ ] Verify all keybindings work in evil mode (normal, visual, insert states)
- [ ] Verify evil-specific bindings (leader keys like `, r s`) function correctly
- [ ] Confirm no keybinding conflicts or regressions in existing functionality

https://claude.ai/code/session_01PPzihy4sU8ZhH9uRn4AKsf