### PR TITLE
Add LLM-based PR review-ease rating feature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,11 @@ type Config struct {
 	// an LLM (integration first, then implementation, then styling, then tests)
 	// instead of the default test-files-last sort. Off by default.
 	ExperimentalLLMFileOrdering bool
+	// ExperimentalLLMReviewEase, when true, rates every PR via an LLM on how
+	// difficult it is to review (easy, medium, or hard). The rating is computed
+	// alongside the LLM diff file ordering and surfaced as `review_ease` in PR
+	// metadata and review list items. Off by default.
+	ExperimentalLLMReviewEase bool
 	DB              *database.DB
 }
 
@@ -146,6 +151,7 @@ func parseConfig(data []byte) (*Config, error) {
 		Plugins             []Plugin
 		RepoConfigs         map[string]RepoConfig
 		ExperimentalLLMFileOrdering bool
+		ExperimentalLLMReviewEase   bool
 	}
 
 	err := toml.Unmarshal(data, &intermediate_config)
@@ -196,6 +202,7 @@ func parseConfig(data []byte) (*Config, error) {
 		Plugins:            intermediate_config.Plugins,
 		RepoConfigs:        repoConfigs,
 		ExperimentalLLMFileOrdering: intermediate_config.ExperimentalLLMFileOrdering,
+		ExperimentalLLMReviewEase:   intermediate_config.ExperimentalLLMReviewEase,
 	}, nil
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -201,6 +201,15 @@ func (db *DB) initSchema() error {
 		UNIQUE(pr_number, repo, sha)
 	);
 
+	CREATE TABLE IF NOT EXISTS ReviewEaseCache (
+		pr_number INTEGER NOT NULL,
+		repo TEXT NOT NULL,
+		sha TEXT NOT NULL,
+		ease TEXT NOT NULL,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(pr_number, repo)
+	);
+
 	CREATE TABLE IF NOT EXISTS Worktrees (
 		id INTEGER PRIMARY KEY,
 		pr_number INTEGER NOT NULL,
@@ -527,6 +536,40 @@ func (db *DB) UpsertDiffFileOrdering(prNumber int, repo, sha, orderingJSON strin
 			ordering_json = excluded.ordering_json,
 			updated_at = excluded.updated_at`,
 		prNumber, repo, sha, orderingJSON,
+	)
+	return err
+}
+
+// GetReviewEase retrieves the cached LLM review-ease rating for a PR along
+// with the head SHA it was computed for. It returns empty strings (no error)
+// when there is no cached entry.
+func (db *DB) GetReviewEase(prNumber int, repo string) (string, string, error) {
+	var ease, sha string
+	err := db.conn.QueryRow(
+		"SELECT ease, sha FROM ReviewEaseCache WHERE pr_number = ? AND repo = ?",
+		prNumber, repo,
+	).Scan(&ease, &sha)
+	if err == sql.ErrNoRows {
+		return "", "", nil
+	}
+	if err != nil {
+		return "", "", err
+	}
+	return ease, sha, nil
+}
+
+// UpsertReviewEase stores the LLM review-ease rating for a PR, recording the
+// head SHA it was computed for. One rating is kept per PR; a rating for a new
+// SHA replaces the previous one.
+func (db *DB) UpsertReviewEase(prNumber int, repo, sha, ease string) error {
+	_, err := db.conn.Exec(
+		`INSERT INTO ReviewEaseCache (pr_number, repo, sha, ease, updated_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(pr_number, repo) DO UPDATE SET
+			sha = excluded.sha,
+			ease = excluded.ease,
+			updated_at = excluded.updated_at`,
+		prNumber, repo, sha, ease,
 	)
 	return err
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -51,9 +51,28 @@ Fetches all review sections from the local database, rendered as org-mode format
 ```
 
 **Reply** (`GetReviewsReply`):
-| Field     | Type   | Description                                      |
-|-----------|--------|--------------------------------------------------|
-| `Content` | string | Org-mode formatted string of all review sections |
+| Field     | Type         | Description                                          |
+|-----------|--------------|------------------------------------------------------|
+| `content` | string       | Org-mode formatted string of all review sections     |
+| `items`   | []ReviewItem | Structured metadata for every PR in the review list  |
+
+#### ReviewItem Object
+
+| Field              | Type   | Description                                                        |
+|--------------------|--------|--------------------------------------------------------------------|
+| `section`          | string | Title of the section the PR belongs to                             |
+| `section_priority` | int    | Priority of the section (lower is better)                          |
+| `status`           | string | Org status of the item (`TODO`, `WAITING`, `DONE`)                 |
+| `tags`             | string | Comma-separated tags (e.g. repo name, `merged`)                    |
+| `title`            | string | PR title line                                                      |
+| `owner`            | string | Repository owner                                                   |
+| `repo`             | string | Repository name                                                    |
+| `number`           | int    | Pull request number                                                |
+| `author`           | string | PR author login                                                    |
+| `url`              | string | GitHub HTML URL                                                    |
+| `release_status`   | string | Release status of the PR (if computed)                             |
+| `review_ease`      | string | AI rating of how difficult the PR is to review: `easy`, `medium`, or `hard`. Empty unless `ExperimentalLLMReviewEase` is enabled in the server config and the rating has been computed |
+| `created_at`       | Time   | When the PR was created                                            |
 
 ---
 
@@ -103,6 +122,12 @@ Fetches a pull request from GitHub and returns it as rendered content (including
 | `body`                 | string   | PR description body                                       |
 | `url`                  | string   | GitHub HTML URL                                           |
 | `worktree_path`        | string   | Absolute path to the local git worktree (if managed by server) |
+| `release_status`       | string   | Release status of the PR (if computed)                    |
+| `review_ease`          | string   | AI rating of how difficult the PR is to review: `easy`, `medium`, or `hard`. Empty unless `ExperimentalLLMReviewEase` is enabled in the server config and the rating has been computed |
+
+#### Review Ease Rating
+
+When `ExperimentalLLMReviewEase = true` is set in the server config (and `GEMINI_API_KEY` is set), each PR is rated by an LLM on how difficult it is to review. The rating is one of `easy`, `medium`, or `hard` and is returned in the `review_ease` field of both `PRMetadata` (single PR) and `ReviewItem` (review list). The rating is computed asynchronously after a PR is fetched or updated — in the same LLM request as the experimental diff file ordering when that feature is also enabled — and is cached per PR head SHA. Until a rating has been computed (or when the feature is disabled), `review_ease` is the empty string; clients should treat an empty value as "no rating".
 
 #### Using the Worktree
 

--- a/sample.config.toml
+++ b/sample.config.toml
@@ -11,6 +11,10 @@ SleepDuration = 10 # Time to wait between updates (in minutes)
 GithubUsername = "your-github-username"
 RepoLocation = "~/" # Base directory where repos are cloned
 AutoWorktree = false # Automatically manage worktrees for PRs
+
+# Experimental LLM features (both require GEMINI_API_KEY in the environment)
+ExperimentalLLMFileOrdering = false # Order diff files for top-to-bottom review flow using an LLM
+ExperimentalLLMReviewEase = false   # Rate each PR easy/medium/hard to review using an LLM (returned as review_ease in PR metadata)
 [SectionPriority]
 "My Open PRs" = 10
 "Needs My Team's Review" = 20

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -8,23 +8,26 @@ import (
 
 // RunPostUpdatePRHooks runs the side-effecting work that should happen after a
 // PR is fetched or updated: configured plugins, plus the experimental LLM diff
-// file ordering when enabled. Each hook is dispatched in its own goroutine so
-// they run in parallel and the call returns immediately.
+// file ordering and review-ease rating when enabled. Each hook is dispatched
+// in its own goroutine so they run in parallel and the call returns
+// immediately.
 //
 // This is the central post-update hook. Callers that just need to trigger
 // plugins should still go through here so any new side effects (like the
 // ordering) stay in lockstep with plugin runs.
 func RunPostUpdatePRHooks(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string) {
 	go RunPlugins(owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch)
-	go ensureDiffFileOrdering(repo, number, sha, diff)
+	go ensureDiffLLMAnalysis(repo, number, sha, diff)
 }
 
-// ensureDiffFileOrdering pre-computes and caches the LLM diff file ordering
-// for a PR SHA so subsequent renders hit the cache. The underlying ordering
-// function is cache-first and SHA-keyed, so repeated calls for the same SHA
-// are cheap.
-func ensureDiffFileOrdering(repo string, prNumber int, sha, diff string) {
-	if !config.C().ExperimentalLLMFileOrdering {
+// ensureDiffLLMAnalysis pre-computes and caches the LLM diff file ordering and
+// review-ease rating for a PR SHA so subsequent renders hit the cache. The
+// underlying functions are cache-first and SHA-keyed, so repeated calls for
+// the same SHA are cheap. When both features are enabled the ordering request
+// computes the ease rating too, so a single LLM call covers both.
+func ensureDiffLLMAnalysis(repo string, prNumber int, sha, diff string) {
+	cfg := config.C()
+	if !cfg.ExperimentalLLMFileOrdering && !cfg.ExperimentalLLMReviewEase {
 		return
 	}
 	if sha == "" || diff == "" {
@@ -32,8 +35,13 @@ func ensureDiffFileOrdering(repo string, prNumber int, sha, diff string) {
 	}
 	parsed, err := utils.Parse(diff)
 	if err != nil || parsed == nil {
-		slog.Warn("Failed to parse diff for file ordering hook", "repo", repo, "pr", prNumber, "error", err)
+		slog.Warn("Failed to parse diff for LLM analysis hook", "repo", repo, "pr", prNumber, "error", err)
 		return
 	}
-	orderDiffFiles(parsed.Files, repo, prNumber, sha)
+	if cfg.ExperimentalLLMFileOrdering {
+		orderDiffFiles(parsed.Files, repo, prNumber, sha)
+	}
+	// Pick up any rating the ordering request did not produce: ordering
+	// disabled, ordering already cached, or no usable rating in the response.
+	ensureReviewEase(parsed.Files, repo, prNumber, sha)
 }

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -216,6 +216,7 @@ type ReviewItem struct {
 	Author        string    `json:"author"`
 	URL           string    `json:"url"`
 	ReleaseStatus string    `json:"release_status"`
+	ReviewEase    string    `json:"review_ease"` // LLM review difficulty rating: easy, medium, or hard ("" when disabled or not yet computed)
 	CreatedAt     time.Time `json:"created_at"`
 }
 
@@ -303,10 +304,13 @@ func (r *OrgRenderer) parseItemToReviewItem(item *database.Item, sectionName str
 		}
 	}
 
-	// Look up release status from DB if we have owner/repo/number
+	// Look up release status and review ease from DB if we have owner/repo/number
 	if reviewItem.Owner != "" && reviewItem.Repo != "" && reviewItem.Number > 0 {
 		if status, err := r.db.GetReleaseStatus(reviewItem.Owner, reviewItem.Repo, reviewItem.Number); err == nil && status != "" {
 			reviewItem.ReleaseStatus = status
+		}
+		if ease, _, err := r.db.GetReviewEase(reviewItem.Number, reviewItem.Repo); err == nil && ease != "" {
+			reviewItem.ReviewEase = ease
 		}
 	}
 
@@ -469,6 +473,7 @@ type PRMetadata struct {
 	RepoPath           string   `json:"repo_path"`
 	WorktreePath       string   `json:"worktree_path"`
 	ReleaseStatus      string   `json:"release_status"`
+	ReviewEase         string   `json:"review_ease"` // LLM review difficulty rating: easy, medium, or hard ("" when disabled or not yet computed)
 	ChangedFiles       int      `json:"changed_files"`
 	Additions          int      `json:"additions"`
 	Deletions          int      `json:"deletions"`
@@ -960,6 +965,11 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 	// Load release status from DB
 	if releaseStatus, err := config.C().DB.GetReleaseStatus(owner, repo, number); err == nil && releaseStatus != "" {
 		metadata.ReleaseStatus = releaseStatus
+	}
+
+	// Load the LLM review-ease rating from DB (computed by post-update hooks)
+	if ease, _, err := config.C().DB.GetReviewEase(number, repo); err == nil && ease != "" {
+		metadata.ReviewEase = ease
 	}
 
 	// 3. Fetch Diff (with caching)

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -1046,3 +1046,90 @@ func TestDiffFileOrderingCacheRoundtrip(t *testing.T) {
 		t.Errorf("got %q, want %q", got, `["b","a"]`)
 	}
 }
+
+func TestParseReviewEase(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"easy", "easy"},
+		{"medium", "medium"},
+		{"hard", "hard"},
+		{" Easy ", "easy"},
+		{"`medium`", "medium"},
+		{"\"HARD\"", "hard"},
+		{"hard.", "hard"},
+		{"very hard", ""},
+		{"", ""},
+		{"unknown", ""},
+	}
+	for _, c := range cases {
+		if got := parseReviewEase(c.in); got != c.want {
+			t.Errorf("parseReviewEase(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestReviewEaseCacheRoundtrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Missing entry returns empty strings, no error.
+	ease, sha, err := db.GetReviewEase(1, "code-review-server")
+	if err != nil {
+		t.Fatalf("unexpected error on cache miss: %v", err)
+	}
+	if ease != "" || sha != "" {
+		t.Errorf("expected empty result on cache miss, got %q / %q", ease, sha)
+	}
+
+	// Stored rating round-trips; a rating for a newer SHA replaces it.
+	if err := db.UpsertReviewEase(1, "code-review-server", "sha1", "medium"); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+	if err := db.UpsertReviewEase(1, "code-review-server", "sha2", "hard"); err != nil {
+		t.Fatalf("re-upsert failed: %v", err)
+	}
+	ease, sha, err = db.GetReviewEase(1, "code-review-server")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if ease != "hard" || sha != "sha2" {
+		t.Errorf("got %q / %q, want %q / %q", ease, sha, "hard", "sha2")
+	}
+}
+
+func TestNeedsReviewEase(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	// Flag off: never needed.
+	config.SetC(config.Config{DB: db})
+	if needsReviewEase("code-review-server", 1, "sha1") {
+		t.Error("expected false when ExperimentalLLMReviewEase is disabled")
+	}
+
+	config.SetC(config.Config{DB: db, ExperimentalLLMReviewEase: true})
+
+	// No SHA: cannot key the cache, so nothing to compute.
+	if needsReviewEase("code-review-server", 1, "") {
+		t.Error("expected false for empty SHA")
+	}
+
+	// Flag on, nothing cached yet: needed.
+	if !needsReviewEase("code-review-server", 1, "sha1") {
+		t.Error("expected true when no rating is cached")
+	}
+
+	// Cached for the same SHA: not needed.
+	if err := db.UpsertReviewEase(1, "code-review-server", "sha1", "easy"); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+	if needsReviewEase("code-review-server", 1, "sha1") {
+		t.Error("expected false when rating is cached for the same SHA")
+	}
+
+	// Cached for an older SHA: needs recomputing.
+	if !needsReviewEase("code-review-server", 1, "sha2") {
+		t.Error("expected true when cached rating is for a different SHA")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1039,13 +1039,14 @@ func orderDiffFiles(files []*utils.DiffFile, repo string, prNumber int, sha stri
 		return reorderFilesByNames(files, names)
 	}
 
-	names, err := llmFileOrdering(files)
+	names, ease, err := llmFileOrdering(files, needsReviewEase(repo, prNumber, sha))
 	if err != nil {
 		slog.Warn("LLM diff file ordering failed, falling back to default sort", "error", err)
 		return sortFilesTestsLast(files)
 	}
 
 	storeFileOrdering(repo, prNumber, sha, names)
+	storeReviewEase(repo, prNumber, sha, ease)
 	return reorderFilesByNames(files, names)
 }
 
@@ -1104,18 +1105,20 @@ func diffFileName(file *utils.DiffFile) string {
 }
 
 // llmFileOrdering asks an LLM to order the diff files so the PR reads
-// top-to-bottom from integration points through implementation to tests.
-func llmFileOrdering(files []*utils.DiffFile) ([]string, error) {
+// top-to-bottom from integration points through implementation to tests. When
+// includeEase is true, the same request also asks for a review-ease rating;
+// the returned ease is "" when not requested or not usable.
+func llmFileOrdering(files []*utils.DiffFile, includeEase bool) ([]string, string, error) {
 	token := os.Getenv("GEMINI_API_KEY")
 	if token == "" {
-		return nil, fmt.Errorf("GEMINI_API_KEY not set")
+		return nil, "", fmt.Errorf("GEMINI_API_KEY not set")
 	}
-	return requestFileOrdering(files, token)
+	return requestFileOrdering(files, token, includeEase)
 }
 
-// requestFileOrdering sends the diff to the LLM and returns the ordered list of
-// file paths it responds with.
-func requestFileOrdering(files []*utils.DiffFile, token string) ([]string, error) {
+// requestFileOrdering sends the diff to the LLM and returns the ordered list
+// of file paths it responds with, plus the review-ease rating when requested.
+func requestFileOrdering(files []*utils.DiffFile, token string, includeEase bool) ([]string, string, error) {
 	var fileList strings.Builder
 	for _, f := range files {
 		fileList.WriteString("- " + diffFileName(f) + "\n")
@@ -1124,6 +1127,13 @@ func requestFileOrdering(files []*utils.DiffFile, token string) ([]string, error
 	diffText := buildDiffForLLM(files)
 	if len(diffText) > llmOrderingMaxDiffSize {
 		diffText = diffText[:llmOrderingMaxDiffSize] + "\n... (diff truncated)\n"
+	}
+
+	easeTask := ""
+	responseFormat := "Respond with ONLY the file paths, one per line, in the order they should be displayed."
+	if includeEase {
+		easeTask = "\nAdditionally:\n" + reviewEaseCriteria + "\n"
+		responseFormat = "Respond with ONLY the file paths, one per line, in the order they should be displayed, followed by a final line of the form `EASE: <rating>` with your difficulty rating."
 	}
 
 	prompt := fmt.Sprintf(`You are ordering the files of a pull request diff so a reviewer can read the PR from top to bottom and understand it.
@@ -1135,14 +1145,40 @@ Order the files by this priority:
 4. Then test files, last.
 
 A reviewer should be able to read top to bottom: starting where the change is integrated, then into how it works, then the tests.
-
+%s
 Files in this diff:
 %s
 Full diff:
 %s
 
-Respond with ONLY the file paths, one per line, in the order they should be displayed. Use the exact file paths listed above. Do not include numbering, bullets, commentary, or code fences.`, fileList.String(), diffText)
+%s Use the exact file paths listed above. Do not include numbering, bullets, commentary, or code fences.`, easeTask, fileList.String(), diffText, responseFormat)
 
+	text, err := geminiGenerate(prompt, token)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var names []string
+	var ease string
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToUpper(trimmed), reviewEasePrefix) {
+			ease = parseReviewEase(trimmed[len(reviewEasePrefix):])
+			continue
+		}
+		if cleaned := cleanLLMFileName(line); cleaned != "" {
+			names = append(names, cleaned)
+		}
+	}
+	if len(names) == 0 {
+		return nil, "", fmt.Errorf("Gemini response contained no file paths")
+	}
+	return names, ease, nil
+}
+
+// geminiGenerate sends a single-prompt generateContent request to the Gemini
+// API and returns the text of the first candidate.
+func geminiGenerate(prompt, token string) (string, error) {
 	reqBody := geminiRequest{
 		Contents: []geminiContent{
 			{Parts: []geminiPart{{Text: prompt}}},
@@ -1150,40 +1186,155 @@ Respond with ONLY the file paths, one per line, in the order they should be disp
 	}
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	url := "https://generativelanguage.googleapis.com/v1beta/models/" + llmOrderingModel + ":generateContent?key=" + token
 	client := &http.Client{Timeout: llmOrderingTimeout}
 	resp, err := client.Post(url, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("Gemini API request failed with status %d: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("Gemini API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var geminiResp geminiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
-		return nil, err
+		return "", err
 	}
 	if len(geminiResp.Candidates) == 0 || len(geminiResp.Candidates[0].Content.Parts) == 0 {
-		return nil, fmt.Errorf("no content in Gemini response")
+		return "", fmt.Errorf("no content in Gemini response")
+	}
+	return geminiResp.Candidates[0].Content.Parts[0].Text, nil
+}
+
+// Experimental: LLM-based PR review-ease rating.
+//
+// When config.ExperimentalLLMReviewEase is enabled, every PR is rated by an
+// LLM on how difficult it is to review: easy, medium, or hard. The rating is
+// computed in the same LLM request as the experimental diff file ordering
+// when that flag is also enabled, and in a standalone request otherwise. It
+// is cached per PR head SHA and surfaced as `review_ease` in PR metadata and
+// review list items.
+
+// reviewEasePrefix marks the rating line in LLM responses (`EASE: <rating>`).
+const reviewEasePrefix = "EASE:"
+
+// reviewEaseCriteria is the rating scale shared by the combined
+// ordering-plus-ease prompt and the standalone ease prompt.
+const reviewEaseCriteria = `Rate how difficult this pull request is to review, as exactly one of: easy, medium, hard.
+- easy: small, focused, or mechanical changes that can be reviewed quickly.
+- medium: moderate size or complexity; requires some careful reading.
+- hard: large, complex, or risky changes touching many concerns; requires significant reviewer effort.`
+
+// needsReviewEase reports whether a review-ease rating still has to be
+// computed for the given PR head SHA.
+func needsReviewEase(repo string, prNumber int, sha string) bool {
+	if !config.C().ExperimentalLLMReviewEase || sha == "" {
+		return false
+	}
+	db := config.C().DB
+	if db == nil {
+		return false
+	}
+	ease, cachedSHA, err := db.GetReviewEase(prNumber, repo)
+	if err != nil {
+		slog.Warn("failed to read review ease cache", "error", err)
+		return false
+	}
+	return ease == "" || cachedSHA != sha
+}
+
+// storeReviewEase persists a review-ease rating keyed to the PR's head SHA.
+// Empty ratings (rating disabled, or the LLM did not produce one) are ignored.
+func storeReviewEase(repo string, prNumber int, sha, ease string) {
+	if sha == "" || ease == "" {
+		return
+	}
+	db := config.C().DB
+	if db == nil {
+		return
+	}
+	if err := db.UpsertReviewEase(prNumber, repo, sha, ease); err != nil {
+		slog.Warn("failed to write review ease cache", "error", err)
+	}
+}
+
+// ensureReviewEase computes and caches the review-ease rating for a PR head
+// SHA via a standalone LLM request, unless the feature is disabled or a
+// rating for this SHA is already cached. It covers the cases the combined
+// ordering request cannot: file ordering disabled, ordering already cached,
+// or the combined response missing a usable rating.
+func ensureReviewEase(files []*utils.DiffFile, repo string, prNumber int, sha string) {
+	if !needsReviewEase(repo, prNumber, sha) {
+		return
+	}
+	ease, err := llmReviewEase(files)
+	if err != nil {
+		slog.Warn("LLM review ease rating failed", "error", err)
+		return
+	}
+	storeReviewEase(repo, prNumber, sha, ease)
+}
+
+// llmReviewEase asks the LLM to rate how difficult the PR diff is to review.
+func llmReviewEase(files []*utils.DiffFile) (string, error) {
+	token := os.Getenv("GEMINI_API_KEY")
+	if token == "" {
+		return "", fmt.Errorf("GEMINI_API_KEY not set")
+	}
+	return requestReviewEase(files, token)
+}
+
+// requestReviewEase sends the diff to the LLM and returns the review-ease
+// rating it responds with.
+func requestReviewEase(files []*utils.DiffFile, token string) (string, error) {
+	diffText := buildDiffForLLM(files)
+	if len(diffText) > llmOrderingMaxDiffSize {
+		diffText = diffText[:llmOrderingMaxDiffSize] + "\n... (diff truncated)\n"
 	}
 
-	var names []string
-	for _, line := range strings.Split(geminiResp.Candidates[0].Content.Parts[0].Text, "\n") {
-		if cleaned := cleanLLMFileName(line); cleaned != "" {
-			names = append(names, cleaned)
+	prompt := fmt.Sprintf(`You are rating how difficult a pull request will be to review.
+
+%s
+
+Full diff:
+%s
+
+Respond with ONLY a single line of the form:
+EASE: <rating>`, reviewEaseCriteria, diffText)
+
+	text, err := geminiGenerate(prompt, token)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToUpper(trimmed), reviewEasePrefix) {
+			trimmed = trimmed[len(reviewEasePrefix):]
+		}
+		if ease := parseReviewEase(trimmed); ease != "" {
+			return ease, nil
 		}
 	}
-	if len(names) == 0 {
-		return nil, fmt.Errorf("Gemini response contained no file paths")
+	return "", fmt.Errorf("Gemini response contained no review ease rating")
+}
+
+// parseReviewEase normalizes an LLM ease answer to one of easy/medium/hard,
+// returning "" for anything else.
+func parseReviewEase(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "`\"'*.")
+	s = strings.ToLower(strings.TrimSpace(s))
+	switch s {
+	case "easy", "medium", "hard":
+		return s
 	}
-	return names, nil
+	return ""
 }
 
 // buildDiffForLLM renders the diff files into a plain-text form for the LLM,


### PR DESCRIPTION
## Summary

Adds an experimental LLM-based feature to rate how difficult each PR is to review (easy, medium, or hard). The rating is computed via Gemini API and cached per PR head SHA. When both the new review-ease feature and the existing diff file ordering feature are enabled, a single LLM request computes both, improving efficiency.

### Changes

- **New `ExperimentalLLMReviewEase` config flag** to enable/disable the feature
- **Review-ease rating functions**: `llmReviewEase()`, `requestReviewEase()`, and `parseReviewEase()` handle standalone LLM requests for the rating
- **Combined ordering + ease request**: Modified `llmFileOrdering()` and `requestFileOrdering()` to optionally compute review-ease in the same LLM call when both features are enabled
- **Database schema & methods**: Added `ReviewEaseCache` table with `GetReviewEase()` and `UpsertReviewEase()` methods to cache ratings per PR
- **Cache management**: `needsReviewEase()` checks if a rating needs computing; `storeReviewEase()` persists it; `ensureReviewEase()` handles standalone requests when the combined ordering request doesn't produce a rating
- **Post-update hook integration**: Renamed `ensureDiffFileOrdering()` to `ensureDiffLLMAnalysis()` to coordinate both features
- **API & rendering**: Added `review_ease` field to `PRMetadata` and `ReviewItem` structs; updated protocol documentation
- **Unit tests**: Added `TestParseReviewEase()`, `TestReviewEaseCacheRoundtrip()`, and `TestNeedsReviewEase()` to cover the new functionality
- **Refactoring**: Extracted `geminiGenerate()` helper to reduce duplication between ordering and ease requests

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — includes new unit tests for parsing, caching, and cache-need detection

https://claude.ai/code/session_01KLGhz2Q8TwDPQGgD5yP65e