### PR TITLE
Add LLM review-ease rating alongside diff file ordering

### DIFF
--- a/bun_client/frontend/src/components/PRList.tsx
+++ b/bun_client/frontend/src/components/PRList.tsx
@@ -8,6 +8,7 @@ import {
     Input,
     Select,
     mapStatusToVariant,
+    mapReviewEase,
     Theme,
     ReviewLocation,
 } from '../design';
@@ -30,6 +31,7 @@ interface ReviewItem {
     number: number;
     author: string;
     url: string;
+    review_ease: string; // LLM review-ease rating: "easy", "medium", "hard", or ""
 }
 
 interface GetReviewsResponse {
@@ -446,205 +448,231 @@ export default function PRList({
                                                         No items in this section
                                                     </div>
                                                 ) : (
-                                                    section.items.map((item, iIdx) => (
-                                                        <Card
-                                                            key={iIdx}
-                                                            variant="outlined"
-                                                            padding="md"
-                                                            hover
-                                                            className="pr-item-card"
-                                                            style={{
-                                                                display: 'flex',
-                                                                flexDirection: isMobile
-                                                                    ? 'column'
-                                                                    : 'row',
-                                                                justifyContent: 'space-between',
-                                                                alignItems: isMobile
-                                                                    ? 'stretch'
-                                                                    : 'center',
-                                                                padding: 0, // Remove padding from card to allow <a> to fill area
-                                                                overflow: 'hidden',
-                                                            }}
-                                                        >
-                                                            <a
-                                                                href={
-                                                                    reviewLocation === 'github'
-                                                                        ? item.url
-                                                                        : `/?owner=${item.owner}&repo=${item.repo}&number=${item.number}`
-                                                                }
-                                                                onClick={e => {
-                                                                    if (item.number <= 0) {
-                                                                        e.preventDefault();
-                                                                        return;
-                                                                    }
-                                                                    // Only handle standard left-click without modifiers for SPA navigation
-                                                                    if (
-                                                                        e.button === 0 &&
-                                                                        !e.ctrlKey &&
-                                                                        !e.metaKey &&
-                                                                        !e.shiftKey &&
-                                                                        !e.altKey
-                                                                    ) {
-                                                                        e.preventDefault();
-                                                                        if (
-                                                                            reviewLocation ===
-                                                                            'github'
-                                                                        ) {
-                                                                            window.open(
-                                                                                item.url,
-                                                                                '_blank'
-                                                                            );
-                                                                        } else {
-                                                                            onOpenReview(
-                                                                                item.owner,
-                                                                                item.repo,
-                                                                                item.number
-                                                                            );
-                                                                        }
-                                                                    }
-                                                                }}
+                                                    section.items.map((item, iIdx) => {
+                                                        const easeDisplay = mapReviewEase(
+                                                            item.review_ease
+                                                        );
+                                                        return (
+                                                            <Card
+                                                                key={iIdx}
+                                                                variant="outlined"
+                                                                padding="md"
+                                                                hover
+                                                                className="pr-item-card"
                                                                 style={{
-                                                                    flex: 1,
-                                                                    textDecoration: 'none',
-                                                                    color: 'inherit',
-                                                                    padding: '16px',
-                                                                    display: 'block',
+                                                                    display: 'flex',
+                                                                    flexDirection: isMobile
+                                                                        ? 'column'
+                                                                        : 'row',
+                                                                    justifyContent: 'space-between',
+                                                                    alignItems: isMobile
+                                                                        ? 'stretch'
+                                                                        : 'center',
+                                                                    padding: 0, // Remove padding from card to allow <a> to fill area
+                                                                    overflow: 'hidden',
                                                                 }}
                                                             >
-                                                                <div style={{ flex: 1 }}>
+                                                                <a
+                                                                    href={
+                                                                        reviewLocation === 'github'
+                                                                            ? item.url
+                                                                            : `/?owner=${item.owner}&repo=${item.repo}&number=${item.number}`
+                                                                    }
+                                                                    onClick={e => {
+                                                                        if (item.number <= 0) {
+                                                                            e.preventDefault();
+                                                                            return;
+                                                                        }
+                                                                        // Only handle standard left-click without modifiers for SPA navigation
+                                                                        if (
+                                                                            e.button === 0 &&
+                                                                            !e.ctrlKey &&
+                                                                            !e.metaKey &&
+                                                                            !e.shiftKey &&
+                                                                            !e.altKey
+                                                                        ) {
+                                                                            e.preventDefault();
+                                                                            if (
+                                                                                reviewLocation ===
+                                                                                'github'
+                                                                            ) {
+                                                                                window.open(
+                                                                                    item.url,
+                                                                                    '_blank'
+                                                                                );
+                                                                            } else {
+                                                                                onOpenReview(
+                                                                                    item.owner,
+                                                                                    item.repo,
+                                                                                    item.number
+                                                                                );
+                                                                            }
+                                                                        }
+                                                                    }}
+                                                                    style={{
+                                                                        flex: 1,
+                                                                        textDecoration: 'none',
+                                                                        color: 'inherit',
+                                                                        padding: '16px',
+                                                                        display: 'block',
+                                                                    }}
+                                                                >
+                                                                    <div style={{ flex: 1 }}>
+                                                                        <div
+                                                                            style={{
+                                                                                display: 'flex',
+                                                                                alignItems:
+                                                                                    'center',
+                                                                                gap: '10px',
+                                                                                marginBottom: '4px',
+                                                                            }}
+                                                                        >
+                                                                            {easeDisplay && (
+                                                                                <Badge
+                                                                                    variant={
+                                                                                        easeDisplay.variant
+                                                                                    }
+                                                                                    size="sm"
+                                                                                >
+                                                                                    {
+                                                                                        easeDisplay.label
+                                                                                    }
+                                                                                </Badge>
+                                                                            )}
+                                                                            <Badge
+                                                                                variant={mapStatusToVariant(
+                                                                                    item.status
+                                                                                )}
+                                                                                size="sm"
+                                                                            >
+                                                                                {item.status}
+                                                                            </Badge>
+                                                                            <span
+                                                                                className={
+                                                                                    item.number > 0
+                                                                                        ? 'pr-title'
+                                                                                        : ''
+                                                                                }
+                                                                                style={{
+                                                                                    fontWeight: 500,
+                                                                                    fontSize:
+                                                                                        '15px',
+                                                                                }}
+                                                                            >
+                                                                                {item.title}
+                                                                            </span>
+                                                                        </div>
+                                                                        {item.number ? (
+                                                                            <div
+                                                                                style={{
+                                                                                    fontSize:
+                                                                                        '13px',
+                                                                                    color: 'var(--text-secondary)',
+                                                                                    fontFamily:
+                                                                                        'var(--font-mono)',
+                                                                                }}
+                                                                            >
+                                                                                {item.owner}/
+                                                                                {item.repo}{' '}
+                                                                                <span
+                                                                                    style={{
+                                                                                        color: 'var(--accent)',
+                                                                                    }}
+                                                                                >
+                                                                                    #{item.number}
+                                                                                </span>
+                                                                                {item.author && (
+                                                                                    <span
+                                                                                        style={{
+                                                                                            marginLeft:
+                                                                                                '8px',
+                                                                                            color: 'var(--text-secondary)',
+                                                                                        }}
+                                                                                    >
+                                                                                        by{' '}
+                                                                                        {
+                                                                                            item.author
+                                                                                        }
+                                                                                    </span>
+                                                                                )}
+                                                                            </div>
+                                                                        ) : (
+                                                                            <div
+                                                                                style={{
+                                                                                    fontSize:
+                                                                                        '12px',
+                                                                                    color: 'var(--text-secondary)',
+                                                                                    fontStyle:
+                                                                                        'italic',
+                                                                                }}
+                                                                            >
+                                                                                Non-PR item
+                                                                            </div>
+                                                                        )}
+                                                                    </div>
+                                                                </a>
+                                                                {item.number > 0 && (
                                                                     <div
                                                                         style={{
                                                                             display: 'flex',
-                                                                            alignItems: 'center',
-                                                                            gap: '10px',
-                                                                            marginBottom: '4px',
+                                                                            gap: '12px',
+                                                                            marginLeft: isMobile
+                                                                                ? 0
+                                                                                : 'auto',
+                                                                            padding: '16px',
+                                                                            paddingTop: isMobile
+                                                                                ? 0
+                                                                                : '16px',
+                                                                            paddingLeft: isMobile
+                                                                                ? '16px'
+                                                                                : 0,
                                                                         }}
                                                                     >
-                                                                        <Badge
-                                                                            variant={mapStatusToVariant(
-                                                                                item.status
-                                                                            )}
+                                                                        <Button
+                                                                            onClick={e => {
+                                                                                e.stopPropagation();
+                                                                                onOpenPluginOutput(
+                                                                                    item.owner,
+                                                                                    item.repo,
+                                                                                    item.number
+                                                                                );
+                                                                            }}
+                                                                            variant="ghost"
                                                                             size="sm"
                                                                         >
-                                                                            {item.status}
-                                                                        </Badge>
-                                                                        <span
-                                                                            className={
-                                                                                item.number > 0
-                                                                                    ? 'pr-title'
-                                                                                    : ''
-                                                                            }
-                                                                            style={{
-                                                                                fontWeight: 500,
-                                                                                fontSize: '15px',
+                                                                            Plugins
+                                                                        </Button>
+                                                                        <Button
+                                                                            onClick={e => {
+                                                                                e.stopPropagation();
+                                                                                window.open(
+                                                                                    item.url,
+                                                                                    '_blank'
+                                                                                );
                                                                             }}
+                                                                            variant="secondary"
+                                                                            size="sm"
                                                                         >
-                                                                            {item.title}
-                                                                        </span>
+                                                                            GitHub
+                                                                        </Button>
+                                                                        <Button
+                                                                            onClick={e => {
+                                                                                e.stopPropagation();
+                                                                                onOpenReview(
+                                                                                    item.owner,
+                                                                                    item.repo,
+                                                                                    item.number
+                                                                                );
+                                                                            }}
+                                                                            size="sm"
+                                                                        >
+                                                                            Review
+                                                                        </Button>
                                                                     </div>
-                                                                    {item.number ? (
-                                                                        <div
-                                                                            style={{
-                                                                                fontSize: '13px',
-                                                                                color: 'var(--text-secondary)',
-                                                                                fontFamily:
-                                                                                    'var(--font-mono)',
-                                                                            }}
-                                                                        >
-                                                                            {item.owner}/{item.repo}{' '}
-                                                                            <span
-                                                                                style={{
-                                                                                    color: 'var(--accent)',
-                                                                                }}
-                                                                            >
-                                                                                #{item.number}
-                                                                            </span>
-                                                                            {item.author && (
-                                                                                <span
-                                                                                    style={{
-                                                                                        marginLeft:
-                                                                                            '8px',
-                                                                                        color: 'var(--text-secondary)',
-                                                                                    }}
-                                                                                >
-                                                                                    by {item.author}
-                                                                                </span>
-                                                                            )}
-                                                                        </div>
-                                                                    ) : (
-                                                                        <div
-                                                                            style={{
-                                                                                fontSize: '12px',
-                                                                                color: 'var(--text-secondary)',
-                                                                                fontStyle: 'italic',
-                                                                            }}
-                                                                        >
-                                                                            Non-PR item
-                                                                        </div>
-                                                                    )}
-                                                                </div>
-                                                            </a>
-                                                            {item.number > 0 && (
-                                                                <div
-                                                                    style={{
-                                                                        display: 'flex',
-                                                                        gap: '12px',
-                                                                        marginLeft: isMobile
-                                                                            ? 0
-                                                                            : 'auto',
-                                                                        padding: '16px',
-                                                                        paddingTop: isMobile
-                                                                            ? 0
-                                                                            : '16px',
-                                                                        paddingLeft: isMobile
-                                                                            ? '16px'
-                                                                            : 0,
-                                                                    }}
-                                                                >
-                                                                    <Button
-                                                                        onClick={e => {
-                                                                            e.stopPropagation();
-                                                                            onOpenPluginOutput(
-                                                                                item.owner,
-                                                                                item.repo,
-                                                                                item.number
-                                                                            );
-                                                                        }}
-                                                                        variant="ghost"
-                                                                        size="sm"
-                                                                    >
-                                                                        Plugins
-                                                                    </Button>
-                                                                    <Button
-                                                                        onClick={e => {
-                                                                            e.stopPropagation();
-                                                                            window.open(
-                                                                                item.url,
-                                                                                '_blank'
-                                                                            );
-                                                                        }}
-                                                                        variant="secondary"
-                                                                        size="sm"
-                                                                    >
-                                                                        GitHub
-                                                                    </Button>
-                                                                    <Button
-                                                                        onClick={e => {
-                                                                            e.stopPropagation();
-                                                                            onOpenReview(
-                                                                                item.owner,
-                                                                                item.repo,
-                                                                                item.number
-                                                                            );
-                                                                        }}
-                                                                        size="sm"
-                                                                    >
-                                                                        Review
-                                                                    </Button>
-                                                                </div>
-                                                            )}
-                                                        </Card>
-                                                    ))
+                                                                )}
+                                                            </Card>
+                                                        );
+                                                    })
                                                 )}
                                             </div>
                                         )}

--- a/bun_client/frontend/src/design/styles/utils.ts
+++ b/bun_client/frontend/src/design/styles/utils.ts
@@ -60,6 +60,37 @@ export function mapStatusToVariant(status: string): StatusVariant {
 }
 
 /**
+ * How a review-ease rating should be displayed
+ */
+export interface ReviewEaseDisplay {
+    label: string;
+    variant: StatusVariant;
+}
+
+/**
+ * Map the backend's review-ease rating to a display label and badge variant.
+ *
+ * The backend currently rates review ease as "easy" | "medium" | "hard", but
+ * the rating scheme may change (e.g. to a numeric 0-100 score). Keep all
+ * interpretation of the raw rating here so a scheme change only needs to be
+ * handled in this one place. Returns null when there is no usable rating
+ * (feature disabled, or not yet computed), in which case nothing should be
+ * rendered.
+ */
+export function mapReviewEase(ease: string | undefined): ReviewEaseDisplay | null {
+    switch ((ease || '').toLowerCase()) {
+        case 'easy':
+            return { label: 'EASY', variant: 'success' };
+        case 'medium':
+            return { label: 'MEDIUM', variant: 'warning' };
+        case 'hard':
+            return { label: 'HARD', variant: 'danger' };
+        default:
+            return null;
+    }
+}
+
+/**
  * Combine class names, filtering out falsy values
  */
 export function cn(...classNames: (string | undefined | null | false)[]): string {

--- a/client.el/crs-list-mode.el
+++ b/client.el/crs-list-mode.el
@@ -80,6 +80,21 @@
   "Face for :tag: markers in the PR list."
   :group 'crs)
 
+(defface crs-list-ease-easy-face
+  '((t (:foreground "#859900" :weight bold)))
+  "Face for the :easy: review-ease tag in the PR list."
+  :group 'crs)
+
+(defface crs-list-ease-medium-face
+  '((t (:foreground "#b58900" :weight bold)))
+  "Face for the :medium: review-ease tag in the PR list."
+  :group 'crs)
+
+(defface crs-list-ease-hard-face
+  '((t (:foreground "#dc322f" :weight bold)))
+  "Face for the :hard: review-ease tag in the PR list."
+  :group 'crs)
+
 (defvar crs-list--heading-regexp "^\\(\\*+\\) "
   "Regexp matching org-style heading lines by leading stars.")
 
@@ -100,7 +115,13 @@
     ;; [n/m] progress ratio
     ("\\[\\([0-9]+/[0-9]+\\)\\]" 0 'crs-list-ratio-face t)
     ;; :tag: markers
-    ("\\(:[a-zA-Z0-9_@-]+:\\)+" 0 'crs-list-tag-face t))
+    ("\\(:[a-zA-Z0-9_@-]+:\\)+" 0 'crs-list-tag-face t)
+    ;; Review-ease tags — listed after the generic tag rule so they win.
+    ;; Only the word inside the colons is re-fontified, so the colons keep
+    ;; the generic tag face (tags share colons, e.g. :repo:easy:).
+    (":\\(easy\\):" 1 'crs-list-ease-easy-face t)
+    (":\\(medium\\):" 1 'crs-list-ease-medium-face t)
+    (":\\(hard\\):" 1 'crs-list-ease-hard-face t))
   "Font-lock keywords for `crs-list-mode'.")
 
 (defun crs-list--heading-level ()

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,11 @@ type Config struct {
 	// an LLM (integration first, then implementation, then styling, then tests)
 	// instead of the default test-files-last sort. Off by default.
 	ExperimentalLLMFileOrdering bool
+	// ExperimentalLLMReviewEase, when true, rates how easy each PR is to review
+	// ("easy", "medium", or "hard") in the same LLM call that computes the diff
+	// file ordering. The rating is exposed as the review_ease field in PR
+	// metadata and review list items. Off by default; requires GEMINI_API_KEY.
+	ExperimentalLLMReviewEase bool
 	DB              *database.DB
 }
 
@@ -146,6 +151,7 @@ func parseConfig(data []byte) (*Config, error) {
 		Plugins             []Plugin
 		RepoConfigs         map[string]RepoConfig
 		ExperimentalLLMFileOrdering bool
+		ExperimentalLLMReviewEase   bool
 	}
 
 	err := toml.Unmarshal(data, &intermediate_config)
@@ -196,6 +202,7 @@ func parseConfig(data []byte) (*Config, error) {
 		Plugins:            intermediate_config.Plugins,
 		RepoConfigs:        repoConfigs,
 		ExperimentalLLMFileOrdering: intermediate_config.ExperimentalLLMFileOrdering,
+		ExperimentalLLMReviewEase:   intermediate_config.ExperimentalLLMReviewEase,
 	}, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -154,6 +154,20 @@ Repos = ["owner/repo"]
 			wantErr: false,
 		},
 		{
+			name: "Experimental LLM flags",
+			content: `
+ExperimentalLLMFileOrdering = true
+ExperimentalLLMReviewEase = true
+`,
+			want: &Config{
+				RepoLocation:                "~/",
+				SleepDuration:               10 * time.Minute,
+				ExperimentalLLMFileOrdering: true,
+				ExperimentalLLMReviewEase:   true,
+			},
+			wantErr: false,
+		},
+		{
 			name: "Custom Sleep and Repo Location",
 			content: `
 RepoLocation = "/custom/path"

--- a/database/database.go
+++ b/database/database.go
@@ -197,6 +197,7 @@ func (db *DB) initSchema() error {
 		repo TEXT NOT NULL,
 		sha TEXT NOT NULL,
 		ordering_json TEXT NOT NULL,
+		review_ease TEXT NOT NULL DEFAULT '',
 		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 		UNIQUE(pr_number, repo, sha)
 	);
@@ -307,6 +308,19 @@ func (db *DB) initSchema() error {
 			_, err = db.conn.Exec("ALTER TABLE PluginResults ADD COLUMN sha TEXT DEFAULT ''")
 			if err != nil {
 				slog.Warn("Error adding sha column to PluginResults", "error", err)
+			}
+		}
+	}
+	// Migration: Add review_ease column to DiffFileOrderingCache if it doesn't
+	// exist. Same table-existence guard as the PluginResults migration above.
+	var orderingCacheExists int
+	_ = db.conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='DiffFileOrderingCache'").Scan(&orderingCacheExists)
+	if orderingCacheExists > 0 {
+		err = db.conn.QueryRow("SELECT COUNT(*) FROM pragma_table_info('DiffFileOrderingCache') WHERE name='review_ease'").Scan(&count)
+		if err == nil && count == 0 {
+			_, err = db.conn.Exec("ALTER TABLE DiffFileOrderingCache ADD COLUMN review_ease TEXT NOT NULL DEFAULT ''")
+			if err != nil {
+				slog.Warn("Error adding review_ease column to DiffFileOrderingCache", "error", err)
 			}
 		}
 	}
@@ -527,6 +541,58 @@ func (db *DB) UpsertDiffFileOrdering(prNumber int, repo, sha, orderingJSON strin
 			ordering_json = excluded.ordering_json,
 			updated_at = excluded.updated_at`,
 		prNumber, repo, sha, orderingJSON,
+	)
+	return err
+}
+
+// GetReviewEase retrieves a cached LLM review-ease rating for a PR SHA.
+// It returns an empty string (no error) when there is no cached entry.
+func (db *DB) GetReviewEase(prNumber int, repo, sha string) (string, error) {
+	var ease string
+	err := db.conn.QueryRow(
+		"SELECT review_ease FROM DiffFileOrderingCache WHERE pr_number = ? AND repo = ? AND sha = ?",
+		prNumber, repo, sha,
+	).Scan(&ease)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return ease, nil
+}
+
+// GetLatestReviewEase returns the most recently stored review-ease rating for
+// a PR across all of its SHAs, so callers that don't know the current head SHA
+// (and PRs whose newest revision hasn't been rated yet) still get the latest
+// known rating. Returns an empty string (no error) when no rating is stored.
+func (db *DB) GetLatestReviewEase(prNumber int, repo string) (string, error) {
+	var ease string
+	err := db.conn.QueryRow(
+		`SELECT review_ease FROM DiffFileOrderingCache
+		 WHERE pr_number = ? AND repo = ? AND review_ease != ''
+		 ORDER BY updated_at DESC LIMIT 1`,
+		prNumber, repo,
+	).Scan(&ease)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return ease, nil
+}
+
+// UpsertReviewEase stores an LLM review-ease rating keyed by PR SHA, leaving
+// any cached file ordering for the same SHA untouched.
+func (db *DB) UpsertReviewEase(prNumber int, repo, sha, ease string) error {
+	_, err := db.conn.Exec(
+		`INSERT INTO DiffFileOrderingCache (pr_number, repo, sha, ordering_json, review_ease, updated_at)
+		 VALUES (?, ?, ?, '', ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(pr_number, repo, sha) DO UPDATE SET
+			review_ease = excluded.review_ease,
+			updated_at = excluded.updated_at`,
+		prNumber, repo, sha, ease,
 	)
 	return err
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,24 @@ merged
 
 The returned string is stored and exposed as the `release_status` field in PR metadata.
 
+## Experimental LLM Features
+
+These root-level flags enable LLM-powered helpers. Both are off by default and require a Gemini API key:
+
+```bash
+export GEMINI_API_KEY="Gemini API Key"
+```
+
+```toml
+ExperimentalLLMFileOrdering = true
+ExperimentalLLMReviewEase = true
+```
+
+- **ExperimentalLLMFileOrdering**: Orders the files in a PR diff via an LLM so the PR reads top-to-bottom (integration points first, then implementation, then styling, then tests) instead of the default test-files-last sort.
+- **ExperimentalLLMReviewEase**: Rates how easy each PR is to review — `easy`, `medium`, or `hard` — in the same LLM call used for the file ordering. The rating is exposed as the `review_ease` field in PR metadata (`GetPR`) and in review list items (`GetAllReviews`), and is appended as a tag (e.g. `:easy:`) on PR headlines in the rendered org content.
+
+Results are cached in the database per PR head SHA, so the LLM is queried at most once per PR revision.
+
 ## Example Config
 
 ```toml

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -51,9 +51,28 @@ Fetches all review sections from the local database, rendered as org-mode format
 ```
 
 **Reply** (`GetReviewsReply`):
-| Field     | Type   | Description                                      |
-|-----------|--------|--------------------------------------------------|
-| `Content` | string | Org-mode formatted string of all review sections |
+| Field     | Type         | Description                                       |
+|-----------|--------------|---------------------------------------------------|
+| `content` | string       | Org-mode formatted string of all review sections  |
+| `items`   | []ReviewItem | Structured metadata for each PR in the list       |
+
+#### ReviewItem Object
+
+| Field              | Type   | Description                                                       |
+|--------------------|--------|-------------------------------------------------------------------|
+| `section`          | string | Title of the section the PR belongs to                            |
+| `section_priority` | int    | Priority of the section (lower sorts first)                       |
+| `status`           | string | Item status (`TODO`, `WAITING`, `DONE`)                           |
+| `tags`             | string | Item tags (e.g. `merged`)                                         |
+| `title`            | string | PR title                                                          |
+| `owner`            | string | Repository owner                                                  |
+| `repo`             | string | Repository name                                                   |
+| `number`           | int    | Pull request number                                               |
+| `author`           | string | PR author login                                                   |
+| `url`              | string | GitHub HTML URL                                                   |
+| `release_status`   | string | Release status from the configured release check command, if any  |
+| `review_ease`      | string | LLM rating of how easy the PR is to review: `easy`, `medium`, or `hard`. Empty unless `ExperimentalLLMReviewEase` is enabled in the config and a rating has been computed |
+| `created_at`       | Time   | PR creation timestamp                                             |
 
 ---
 
@@ -103,6 +122,8 @@ Fetches a pull request from GitHub and returns it as rendered content (including
 | `body`                 | string   | PR description body                                       |
 | `url`                  | string   | GitHub HTML URL                                           |
 | `worktree_path`        | string   | Absolute path to the local git worktree (if managed by server) |
+| `release_status`       | string   | Release status from the configured release check command, if any |
+| `review_ease`          | string   | LLM rating of how easy the PR is to review: `easy`, `medium`, or `hard`. Empty unless `ExperimentalLLMReviewEase` is enabled in the config and a rating has been computed |
 
 #### Using the Worktree
 

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -8,23 +8,25 @@ import (
 
 // RunPostUpdatePRHooks runs the side-effecting work that should happen after a
 // PR is fetched or updated: configured plugins, plus the experimental LLM diff
-// file ordering when enabled. Each hook is dispatched in its own goroutine so
-// they run in parallel and the call returns immediately.
+// analysis (file ordering and review-ease rating) when enabled. Each hook is
+// dispatched in its own goroutine so they run in parallel and the call returns
+// immediately.
 //
 // This is the central post-update hook. Callers that just need to trigger
 // plugins should still go through here so any new side effects (like the
 // ordering) stay in lockstep with plugin runs.
 func RunPostUpdatePRHooks(owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string) {
 	go RunPlugins(owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch)
-	go ensureDiffFileOrdering(repo, number, sha, diff)
+	go ensureDiffAnalysis(repo, number, sha, diff)
 }
 
-// ensureDiffFileOrdering pre-computes and caches the LLM diff file ordering
-// for a PR SHA so subsequent renders hit the cache. The underlying ordering
-// function is cache-first and SHA-keyed, so repeated calls for the same SHA
-// are cheap.
-func ensureDiffFileOrdering(repo string, prNumber int, sha, diff string) {
-	if !config.C().ExperimentalLLMFileOrdering {
+// ensureDiffAnalysis pre-computes and caches the LLM diff analysis (file
+// ordering and review-ease rating, per the enabled config flags) for a PR SHA
+// so subsequent renders hit the cache. The underlying analysis is cache-first
+// and SHA-keyed, so repeated calls for the same SHA are cheap.
+func ensureDiffAnalysis(repo string, prNumber int, sha, diff string) {
+	cfg := config.C()
+	if !cfg.ExperimentalLLMFileOrdering && !cfg.ExperimentalLLMReviewEase {
 		return
 	}
 	if sha == "" || diff == "" {
@@ -32,8 +34,8 @@ func ensureDiffFileOrdering(repo string, prNumber int, sha, diff string) {
 	}
 	parsed, err := utils.Parse(diff)
 	if err != nil || parsed == nil {
-		slog.Warn("Failed to parse diff for file ordering hook", "repo", repo, "pr", prNumber, "error", err)
+		slog.Warn("Failed to parse diff for LLM diff analysis hook", "repo", repo, "pr", prNumber, "error", err)
 		return
 	}
-	orderDiffFiles(parsed.Files, repo, prNumber, sha)
+	ensureLLMDiffAnalysis(parsed.Files, repo, prNumber, sha)
 }

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -216,7 +216,11 @@ type ReviewItem struct {
 	Author        string    `json:"author"`
 	URL           string    `json:"url"`
 	ReleaseStatus string    `json:"release_status"`
-	CreatedAt     time.Time `json:"created_at"`
+	// ReviewEase is the LLM rating of how easy the PR is to review ("easy",
+	// "medium", or "hard"). Empty unless ExperimentalLLMReviewEase is enabled
+	// and a rating has been computed.
+	ReviewEase string    `json:"review_ease"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 // GetAllReviewItems returns structured review items from all sections
@@ -310,6 +314,13 @@ func (r *OrgRenderer) parseItemToReviewItem(item *database.Item, sectionName str
 		}
 	}
 
+	// Look up the LLM review-ease rating when the feature is enabled
+	if config.C().ExperimentalLLMReviewEase && reviewItem.Repo != "" && reviewItem.Number > 0 {
+		if ease, err := r.db.GetLatestReviewEase(reviewItem.Number, reviewItem.Repo); err == nil && ease != "" {
+			reviewItem.ReviewEase = ease
+		}
+	}
+
 	return reviewItem
 }
 
@@ -365,6 +376,17 @@ func (r *OrgRenderer) buildItemLines(item *database.Item, indentLevel int) []str
 		tags = []string{}
 	}
 
+	// Append the LLM review-ease rating as a headline tag when enabled
+	if config.C().ExperimentalLLMReviewEase {
+		if repo, number := itemPRRef(item); repo != "" && number > 0 {
+			if ease, err := r.db.GetLatestReviewEase(number, repo); err == nil {
+				if tag := reviewEaseOrgTag(ease); tag != "" {
+					tags = append(tags, tag)
+				}
+			}
+		}
+	}
+
 	// Build the title line
 	indentStars := strings.Repeat("*", indentLevel)
 	titleLine := fmt.Sprintf("%s %s %s", indentStars, item.Status, item.Title)
@@ -383,6 +405,45 @@ func (r *OrgRenderer) buildItemLines(item *database.Item, indentLevel int) []str
 	}
 
 	return lines
+}
+
+// itemPRRef extracts the PR number and short repo name from an item's detail
+// lines (the same encoding parseItemToReviewItem reads). It returns ("", 0)
+// when the item does not reference a PR.
+func itemPRRef(item *database.Item) (repo string, number int) {
+	details, err := item.GetDetails()
+	if err != nil {
+		return "", 0
+	}
+	for _, line := range details {
+		line = strings.TrimSpace(line)
+		if number == 0 {
+			var num int
+			if _, err := fmt.Sscanf(line, "%d", &num); err == nil && num > 0 {
+				number = num
+				continue
+			}
+		}
+		if strings.HasPrefix(line, "Repo:") {
+			repoStr := strings.TrimSpace(strings.TrimPrefix(line, "Repo:"))
+			parts := strings.Split(repoStr, "/")
+			repo = parts[len(parts)-1]
+		}
+	}
+	return repo, number
+}
+
+// reviewEaseOrgTag converts a stored review-ease rating into an org headline
+// tag. It centralizes the rating -> tag mapping so a future change to the
+// rating scheme (e.g. a numeric score) only needs to be handled here. It
+// returns an empty string when there is no usable rating, in which case no
+// tag should be added.
+func reviewEaseOrgTag(ease string) string {
+	switch ease {
+	case "easy", "medium", "hard":
+		return ease
+	}
+	return ""
 }
 
 func renderPullRequest(diff string, comments []PRComment) string {
@@ -469,9 +530,13 @@ type PRMetadata struct {
 	RepoPath           string   `json:"repo_path"`
 	WorktreePath       string   `json:"worktree_path"`
 	ReleaseStatus      string   `json:"release_status"`
-	ChangedFiles       int      `json:"changed_files"`
-	Additions          int      `json:"additions"`
-	Deletions          int      `json:"deletions"`
+	// ReviewEase is the LLM rating of how easy the PR is to review ("easy",
+	// "medium", or "hard"). Empty unless ExperimentalLLMReviewEase is enabled
+	// and a rating has been computed.
+	ReviewEase   string `json:"review_ease"`
+	ChangedFiles int    `json:"changed_files"`
+	Additions    int    `json:"additions"`
+	Deletions    int    `json:"deletions"`
 }
 
 type PRDetails struct {
@@ -960,6 +1025,13 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 	// Load release status from DB
 	if releaseStatus, err := config.C().DB.GetReleaseStatus(owner, repo, number); err == nil && releaseStatus != "" {
 		metadata.ReleaseStatus = releaseStatus
+	}
+
+	// Load the LLM review-ease rating from DB when the feature is enabled
+	if config.C().ExperimentalLLMReviewEase {
+		if ease, err := config.C().DB.GetLatestReviewEase(number, repo); err == nil && ease != "" {
+			metadata.ReviewEase = ease
+		}
 	}
 
 	// 3. Fetch Diff (with caching)

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -1019,6 +1019,191 @@ func TestOrderDiffFilesUsesCachedOrdering(t *testing.T) {
 	}
 }
 
+func TestParseDiffAnalysisText(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		wantEase string
+		wantOrd  []string
+	}{
+		{
+			name:     "ordering only",
+			text:     "main.go\nhelper.go\nmain_test.go\n",
+			wantEase: "",
+			wantOrd:  []string{"main.go", "helper.go", "main_test.go"},
+		},
+		{
+			name:     "ease line first",
+			text:     "REVIEW_EASE: medium\nmain.go\nmain_test.go\n",
+			wantEase: "medium",
+			wantOrd:  []string{"main.go", "main_test.go"},
+		},
+		{
+			name:     "ease line with decoration",
+			text:     "  **REVIEW_EASE: Easy**  \nmain.go\n",
+			wantEase: "easy",
+			wantOrd:  []string{"main.go"},
+		},
+		{
+			name:     "invalid rating dropped",
+			text:     "REVIEW_EASE: trivial\nmain.go\n",
+			wantEase: "",
+			wantOrd:  []string{"main.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffAnalysisText(tt.text)
+			if got.reviewEase != tt.wantEase {
+				t.Errorf("reviewEase = %q, want %q", got.reviewEase, tt.wantEase)
+			}
+			if len(got.ordering) != len(tt.wantOrd) {
+				t.Fatalf("ordering = %v, want %v", got.ordering, tt.wantOrd)
+			}
+			for i, w := range tt.wantOrd {
+				if got.ordering[i] != w {
+					t.Errorf("ordering[%d] = %q, want %q", i, got.ordering[i], w)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildAnalysisPromptEaseInstruction(t *testing.T) {
+	orderingOnly := buildAnalysisPrompt("- main.go\n", "diff text", true, false)
+	if strings.Contains(orderingOnly, "REVIEW_EASE") {
+		t.Error("ordering-only prompt must not mention REVIEW_EASE")
+	}
+	if !strings.Contains(orderingOnly, "ordering the files") {
+		t.Error("ordering-only prompt must include the ordering instructions")
+	}
+
+	both := buildAnalysisPrompt("- main.go\n", "diff text", true, true)
+	if !strings.Contains(both, "REVIEW_EASE: <rating>") {
+		t.Error("combined prompt must instruct the REVIEW_EASE response line")
+	}
+	if !strings.Contains(both, "ordering the files") {
+		t.Error("combined prompt must include the ordering instructions")
+	}
+
+	easeOnly := buildAnalysisPrompt("- main.go\n", "diff text", false, true)
+	if !strings.Contains(easeOnly, "REVIEW_EASE: <rating>") {
+		t.Error("ease-only prompt must instruct the REVIEW_EASE response line")
+	}
+	if strings.Contains(easeOnly, "ordering the files") || strings.Contains(easeOnly, "file paths") {
+		t.Error("ease-only prompt must not ask for a file ordering")
+	}
+}
+
+func TestReviewEaseCacheRoundtrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Missing entry returns empty string, no error.
+	got, err := db.GetReviewEase(1, "code-review-server", "sha1")
+	if err != nil {
+		t.Fatalf("unexpected error on cache miss: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty result on cache miss, got %q", got)
+	}
+
+	// Storing an ease rating must not clobber an existing ordering, and
+	// vice versa.
+	if err := db.UpsertDiffFileOrdering(1, "code-review-server", "sha1", `["a","b"]`); err != nil {
+		t.Fatalf("ordering upsert failed: %v", err)
+	}
+	if err := db.UpsertReviewEase(1, "code-review-server", "sha1", "hard"); err != nil {
+		t.Fatalf("ease upsert failed: %v", err)
+	}
+	if err := db.UpsertDiffFileOrdering(1, "code-review-server", "sha1", `["b","a"]`); err != nil {
+		t.Fatalf("ordering re-upsert failed: %v", err)
+	}
+
+	gotEase, err := db.GetReviewEase(1, "code-review-server", "sha1")
+	if err != nil {
+		t.Fatalf("get ease failed: %v", err)
+	}
+	if gotEase != "hard" {
+		t.Errorf("got ease %q, want %q", gotEase, "hard")
+	}
+	gotOrdering, err := db.GetDiffFileOrdering(1, "code-review-server", "sha1")
+	if err != nil {
+		t.Fatalf("get ordering failed: %v", err)
+	}
+	if gotOrdering != `["b","a"]` {
+		t.Errorf("got ordering %q, want %q", gotOrdering, `["b","a"]`)
+	}
+}
+
+func TestGetLatestReviewEaseSkipsUnratedRows(t *testing.T) {
+	db := setupTestDB(t)
+
+	// No rows at all: empty, no error.
+	got, err := db.GetLatestReviewEase(9, "code-review-server")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty rating, got %q", got)
+	}
+
+	// A newer ordering-only row must not shadow the rated row.
+	if err := db.UpsertReviewEase(9, "code-review-server", "sha-old", "easy"); err != nil {
+		t.Fatalf("ease upsert failed: %v", err)
+	}
+	if err := db.UpsertDiffFileOrdering(9, "code-review-server", "sha-new", `["a"]`); err != nil {
+		t.Fatalf("ordering upsert failed: %v", err)
+	}
+
+	got, err = db.GetLatestReviewEase(9, "code-review-server")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "easy" {
+		t.Errorf("got rating %q, want %q", got, "easy")
+	}
+}
+
+func TestBuildItemLinesIncludesReviewEaseTag(t *testing.T) {
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db, ExperimentalLLMReviewEase: true})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	section, err := db.GetOrCreateSection("Test Section", 0)
+	if err != nil {
+		t.Fatalf("failed to create section: %v", err)
+	}
+	details := []string{
+		"83",
+		"Repo: C-Hipple/code-review-server",
+		"https://github.com/C-Hipple/code-review-server/pull/83",
+	}
+	item, err := db.UpsertItem(section.ID, "83", "TODO", "Debug PR", details, []string{"code-review-server"}, 0)
+	if err != nil {
+		t.Fatalf("failed to create item: %v", err)
+	}
+	if err := db.UpsertReviewEase(83, "code-review-server", "sha-1", "medium"); err != nil {
+		t.Fatalf("failed to seed review ease: %v", err)
+	}
+
+	r := NewOrgRenderer(db)
+	lines := r.buildItemLines(item, 2)
+	if len(lines) == 0 {
+		t.Fatal("no lines rendered")
+	}
+	if !strings.Contains(lines[0], ":code-review-server:medium:") {
+		t.Errorf("title line %q missing review-ease tag", lines[0])
+	}
+
+	// With the flag off, the headline keeps only the stored tags.
+	config.SetC(config.Config{DB: db})
+	lines = r.buildItemLines(item, 2)
+	if !strings.Contains(lines[0], ":code-review-server:") || strings.Contains(lines[0], "medium") {
+		t.Errorf("title line %q should not include review-ease tag when disabled", lines[0])
+	}
+}
+
 func TestDiffFileOrderingCacheRoundtrip(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/server/server.go
+++ b/server/server.go
@@ -986,7 +986,7 @@ func (h *RPCHandler) RerunPlugins(args *RerunPluginsArgs, reply *RerunPluginsRep
 	return nil
 }
 
-// Experimental: LLM-based diff file ordering.
+// Experimental: LLM-based diff analysis (file ordering + review ease).
 //
 // When config.ExperimentalLLMFileOrdering is enabled, the files in a PR diff
 // are ordered by an LLM so a reviewer can read the PR top-to-bottom: the
@@ -994,12 +994,27 @@ func (h *RPCHandler) RerunPlugins(args *RerunPluginsArgs, reply *RerunPluginsRep
 // then styling changes, then tests last. When the flag is off (the default),
 // or if the LLM call fails for any reason, ordering falls back to
 // sortFilesTestsLast.
+//
+// When config.ExperimentalLLMReviewEase is enabled, the same LLM call also
+// rates how easy the PR is to review ("easy", "medium", or "hard"). The
+// rating is cached alongside the file ordering and exposed as the
+// review_ease field in PR metadata and review list items.
 
 const (
 	llmOrderingModel       = "gemini-2.5-flash"
 	llmOrderingMaxDiffSize = 200000
 	llmOrderingTimeout     = 30 * time.Second
+
+	reviewEaseLinePrefix = "REVIEW_EASE:"
 )
+
+// llmDiffAnalysis holds the results of the single LLM call made per PR SHA:
+// the display ordering of the diff files and, when enabled, the review-ease
+// rating.
+type llmDiffAnalysis struct {
+	ordering   []string
+	reviewEase string
+}
 
 type geminiPart struct {
 	Text string `json:"text"`
@@ -1039,14 +1054,40 @@ func orderDiffFiles(files []*utils.DiffFile, repo string, prNumber int, sha stri
 		return reorderFilesByNames(files, names)
 	}
 
-	names, err := llmFileOrdering(files)
+	analysis, err := llmAnalyzeDiff(files, true, config.C().ExperimentalLLMReviewEase)
 	if err != nil {
-		slog.Warn("LLM diff file ordering failed, falling back to default sort", "error", err)
+		slog.Warn("LLM diff analysis failed, falling back to default sort", "error", err)
 		return sortFilesTestsLast(files)
 	}
 
-	storeFileOrdering(repo, prNumber, sha, names)
-	return reorderFilesByNames(files, names)
+	storeDiffAnalysis(repo, prNumber, sha, analysis)
+	return reorderFilesByNames(files, analysis.ordering)
+}
+
+// ensureLLMDiffAnalysis makes sure the LLM-derived values enabled in config
+// (the diff file ordering and the review-ease rating) are cached for the PR
+// SHA, calling the LLM at most once if anything is missing.
+func ensureLLMDiffAnalysis(files []*utils.DiffFile, repo string, prNumber int, sha string) {
+	cfg := config.C()
+	needOrdering := cfg.ExperimentalLLMFileOrdering && len(files) >= 2 &&
+		cachedFileOrdering(repo, prNumber, sha) == nil
+	needEase := cfg.ExperimentalLLMReviewEase && cachedReviewEase(repo, prNumber, sha) == ""
+	if !needOrdering && !needEase {
+		return
+	}
+
+	analysis, err := llmAnalyzeDiff(files, needOrdering, needEase)
+	if err != nil {
+		slog.Warn("LLM diff analysis failed", "repo", repo, "pr", prNumber, "error", err)
+		return
+	}
+	storeDiffAnalysis(repo, prNumber, sha, analysis)
+}
+
+// storeDiffAnalysis persists the LLM analysis results keyed by PR SHA.
+func storeDiffAnalysis(repo string, prNumber int, sha string, analysis *llmDiffAnalysis) {
+	storeFileOrdering(repo, prNumber, sha, analysis.ordering)
+	storeReviewEase(repo, prNumber, sha, analysis.reviewEase)
 }
 
 // cachedFileOrdering returns a previously cached LLM file ordering for the
@@ -1075,9 +1116,10 @@ func cachedFileOrdering(repo string, prNumber int, sha string) []string {
 	return names
 }
 
-// storeFileOrdering persists an LLM file ordering keyed by PR SHA.
+// storeFileOrdering persists an LLM file ordering keyed by PR SHA. Empty
+// orderings (e.g. from an ease-only analysis) are not stored.
 func storeFileOrdering(repo string, prNumber int, sha string, names []string) {
-	if sha == "" {
+	if sha == "" || len(names) == 0 {
 		return
 	}
 	db := config.C().DB
@@ -1094,6 +1136,39 @@ func storeFileOrdering(repo string, prNumber int, sha string, names []string) {
 	}
 }
 
+// cachedReviewEase returns a previously cached review-ease rating for the
+// given PR SHA, or an empty string when there is no cached rating.
+func cachedReviewEase(repo string, prNumber int, sha string) string {
+	if sha == "" {
+		return ""
+	}
+	db := config.C().DB
+	if db == nil {
+		return ""
+	}
+	ease, err := db.GetReviewEase(prNumber, repo, sha)
+	if err != nil {
+		slog.Warn("failed to read review ease cache", "error", err)
+		return ""
+	}
+	return ease
+}
+
+// storeReviewEase persists a review-ease rating keyed by PR SHA. Empty
+// ratings (feature disabled, or unusable LLM output) are not stored.
+func storeReviewEase(repo string, prNumber int, sha string, ease string) {
+	if sha == "" || ease == "" {
+		return
+	}
+	db := config.C().DB
+	if db == nil {
+		return
+	}
+	if err := db.UpsertReviewEase(prNumber, repo, sha, ease); err != nil {
+		slog.Warn("failed to write review ease cache", "error", err)
+	}
+}
+
 // diffFileName returns the path used to identify a diff file, preferring the
 // new name and falling back to the original name for deleted files.
 func diffFileName(file *utils.DiffFile) string {
@@ -1103,19 +1178,21 @@ func diffFileName(file *utils.DiffFile) string {
 	return file.OrigName
 }
 
-// llmFileOrdering asks an LLM to order the diff files so the PR reads
-// top-to-bottom from integration points through implementation to tests.
-func llmFileOrdering(files []*utils.DiffFile) ([]string, error) {
+// llmAnalyzeDiff asks an LLM for the requested analysis values: the file
+// ordering that makes the PR read top-to-bottom from integration points
+// through implementation to tests, and/or the rating of how easy the PR is to
+// review. The prompt only asks for what the caller needs.
+func llmAnalyzeDiff(files []*utils.DiffFile, includeOrdering, includeEase bool) (*llmDiffAnalysis, error) {
 	token := os.Getenv("GEMINI_API_KEY")
 	if token == "" {
 		return nil, fmt.Errorf("GEMINI_API_KEY not set")
 	}
-	return requestFileOrdering(files, token)
+	return requestDiffAnalysis(files, token, includeOrdering, includeEase)
 }
 
-// requestFileOrdering sends the diff to the LLM and returns the ordered list of
-// file paths it responds with.
-func requestFileOrdering(files []*utils.DiffFile, token string) ([]string, error) {
+// requestDiffAnalysis sends the diff to the LLM and returns the requested
+// values (ordered file paths and/or review-ease rating) it responds with.
+func requestDiffAnalysis(files []*utils.DiffFile, token string, includeOrdering, includeEase bool) (*llmDiffAnalysis, error) {
 	var fileList strings.Builder
 	for _, f := range files {
 		fileList.WriteString("- " + diffFileName(f) + "\n")
@@ -1126,22 +1203,7 @@ func requestFileOrdering(files []*utils.DiffFile, token string) ([]string, error
 		diffText = diffText[:llmOrderingMaxDiffSize] + "\n... (diff truncated)\n"
 	}
 
-	prompt := fmt.Sprintf(`You are ordering the files of a pull request diff so a reviewer can read the PR from top to bottom and understand it.
-
-Order the files by this priority:
-1. The most important and relevant changes first: the entry points where the change is integrated (call sites, public APIs, top-level wiring).
-2. Then helper functions and implementation details: how the change actually works.
-3. Then styling changes such as CSS: after code, but before tests.
-4. Then test files, last.
-
-A reviewer should be able to read top to bottom: starting where the change is integrated, then into how it works, then the tests.
-
-Files in this diff:
-%s
-Full diff:
-%s
-
-Respond with ONLY the file paths, one per line, in the order they should be displayed. Use the exact file paths listed above. Do not include numbering, bullets, commentary, or code fences.`, fileList.String(), diffText)
+	prompt := buildAnalysisPrompt(fileList.String(), diffText, includeOrdering, includeEase)
 
 	reqBody := geminiRequest{
 		Contents: []geminiContent{
@@ -1174,16 +1236,99 @@ Respond with ONLY the file paths, one per line, in the order they should be disp
 		return nil, fmt.Errorf("no content in Gemini response")
 	}
 
-	var names []string
-	for _, line := range strings.Split(geminiResp.Candidates[0].Content.Parts[0].Text, "\n") {
-		if cleaned := cleanLLMFileName(line); cleaned != "" {
-			names = append(names, cleaned)
-		}
-	}
-	if len(names) == 0 {
+	analysis := parseDiffAnalysisText(geminiResp.Candidates[0].Content.Parts[0].Text)
+	if includeOrdering && len(analysis.ordering) == 0 {
 		return nil, fmt.Errorf("Gemini response contained no file paths")
 	}
-	return names, nil
+	if includeEase && analysis.reviewEase == "" {
+		if !includeOrdering {
+			return nil, fmt.Errorf("Gemini response contained no usable review-ease rating")
+		}
+		slog.Warn("Gemini response contained no usable review-ease rating")
+	}
+	return analysis, nil
+}
+
+// buildAnalysisPrompt builds the prompt for the diff analysis LLM call,
+// asking only for the values the caller requested: the file ordering, the
+// review-ease rating, or both.
+func buildAnalysisPrompt(fileList, diffText string, includeOrdering, includeEase bool) string {
+	var b strings.Builder
+	if includeOrdering {
+		b.WriteString(`You are ordering the files of a pull request diff so a reviewer can read the PR from top to bottom and understand it.
+
+Order the files by this priority:
+1. The most important and relevant changes first: the entry points where the change is integrated (call sites, public APIs, top-level wiring).
+2. Then helper functions and implementation details: how the change actually works.
+3. Then styling changes such as CSS: after code, but before tests.
+4. Then test files, last.
+
+A reviewer should be able to read top to bottom: starting where the change is integrated, then into how it works, then the tests.
+`)
+	} else {
+		b.WriteString(`You are rating a pull request diff for a code reviewer.
+`)
+	}
+	if includeEase {
+		b.WriteString(`
+Rate how easy this pull request is to review: "easy" for small, mechanical, or repetitive changes; "medium" for typical changes that need a careful read; "hard" for large, subtle, or high-risk changes (tricky logic, concurrency, security, many interacting files).
+`)
+	}
+	b.WriteString(fmt.Sprintf(`
+Files in this diff:
+%s
+Full diff:
+%s
+`, fileList, diffText))
+	switch {
+	case includeOrdering && includeEase:
+		b.WriteString(`
+Respond with a first line of exactly "REVIEW_EASE: <rating>" where <rating> is easy, medium, or hard, followed by the file paths, one per line, in the order they should be displayed. Use the exact file paths listed above. Do not include numbering, bullets, commentary, or code fences.`)
+	case includeOrdering:
+		b.WriteString(`
+Respond with ONLY the file paths, one per line, in the order they should be displayed. Use the exact file paths listed above. Do not include numbering, bullets, commentary, or code fences.`)
+	default:
+		b.WriteString(`
+Respond with ONLY a single line of exactly "REVIEW_EASE: <rating>" where <rating> is easy, medium, or hard. Do not include anything else.`)
+	}
+	return b.String()
+}
+
+// parseDiffAnalysisText parses the LLM response text into the ordered file
+// paths and the optional REVIEW_EASE rating line.
+func parseDiffAnalysisText(text string) *llmDiffAnalysis {
+	analysis := &llmDiffAnalysis{}
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.Trim(strings.TrimSpace(line), "`*")
+		trimmed = strings.TrimSpace(trimmed)
+		if rest, ok := strings.CutPrefix(trimmed, reviewEaseLinePrefix); ok {
+			if ease := normalizeReviewEase(rest); ease != "" {
+				analysis.reviewEase = ease
+			}
+			continue
+		}
+		if cleaned := cleanLLMFileName(line); cleaned != "" {
+			analysis.ordering = append(analysis.ordering, cleaned)
+		}
+	}
+	return analysis
+}
+
+// normalizeReviewEase maps an LLM rating string onto one of the canonical
+// ratings ("easy", "medium", or "hard"); it returns an empty string for
+// anything else.
+func normalizeReviewEase(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "\"'`*")
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "easy":
+		return "easy"
+	case "medium":
+		return "medium"
+	case "hard":
+		return "hard"
+	}
+	return ""
 }
 
 // buildDiffForLLM renders the diff files into a plain-text form for the LLM,


### PR DESCRIPTION
## Summary

Extends the experimental LLM diff analysis feature to rate how easy each PR is to review ("easy", "medium", or "hard") in addition to ordering the diff files. The rating is computed in a single LLM call, cached per PR SHA, and surfaced in the API and in both clients when `ExperimentalLLMReviewEase` is enabled.

### Backend

- **New config flag `ExperimentalLLMReviewEase`**: Enables the review-ease rating feature (off by default, requires `GEMINI_API_KEY`)
- **Unified LLM analysis**: Refactored `llmFileOrdering()` → `llmAnalyzeDiff()` to compute both file ordering and review-ease rating in a single call; the prompt only asks for what the caller actually needs (ease-only when the ordering is already cached or its flag is off)
- **Database schema**: Added `review_ease` column to `DiffFileOrderingCache` table with migration support
- **Database API**: New methods `GetReviewEase()`, `GetLatestReviewEase()`, and `UpsertReviewEase()` for caching ratings; ordering and ease writes never clobber each other
- **API exposure**: Added `review_ease` field to `ReviewItem` (`GetAllReviews`) and `PRMetadata` (`GetPR` and related methods)
- **Org rendering**: The rating is appended as a headline tag (e.g. `:code-review-server:medium:`) in the rendered org content via `reviewEaseOrgTag()`
- **Robustness**: Handles missing or invalid ratings gracefully; normalizes rating strings (case-insensitive, strips decoration)

### Web client (`bun_client`)

- PR list rows show the rating as a colored badge (EASY=green, MEDIUM=orange, HARD=red) to the left of the status badge; hidden when no rating is available
- Rating interpretation is centralized in `mapReviewEase()` in the design system so a future rating-scheme change (e.g. a 0-100 score) only needs handling in one place

### Emacs client (`client.el`)

- The rating tag arrives via the server-rendered org content; `crs-list-mode` fontifies `:easy:`/`:medium:`/`:hard:` tags with green/yellow/red faces so difficulty reads at a glance

### Documentation

- protocol.md: documented `review_ease` in `PRMetadata`, added the previously undocumented `items` field and `ReviewItem` object for `GetAllReviews`, fixed `content` field casing
- configuration.md: new "Experimental LLM Features" section covering both flags and `GEMINI_API_KEY`

## Test Plan

- [x] `go build ./...` and `go test ./...` pass — includes unit tests for `parseDiffAnalysisText()`, `buildAnalysisPrompt()` (ordering-only / combined / ease-only), review-ease cache roundtrip, `GetLatestReviewEase()` behavior, and the org headline tag rendering
- [x] `bun run type-check`, `lint`, `format:check`, and `test` pass in `bun_client`
- [ ] Manual check of the `:easy:`/`:medium:`/`:hard:` faces in Emacs (not installed in the dev environment; paren balance verified)

https://claude.ai/code/session_01BnMR2khbN791KeJY9t29yv