### PR TITLE
Add sync change detection and toast notifications

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -13,7 +13,7 @@ import {
     nightOwl,
 } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { rpcCall, getHunkContext } from '../api';
-import { Button, Modal, TextArea, colors, shadows, Theme } from '../design';
+import { Button, Modal, TextArea, Toast, colors, shadows, Theme, StatusVariant } from '../design';
 import { useLsp } from '../hooks/useLsp';
 import { useIsMobile } from '../hooks/useMediaQuery';
 import { getClickColumn } from '../utils/dom';
@@ -139,6 +139,8 @@ interface PRResponse {
     reviews: ReviewData[];
     metadata: PRMetadata;
     feedback: string;
+    // Only set by SyncPR: true when the sync pulled in a new head SHA or new comments.
+    updated?: boolean;
 }
 
 // Map file extensions to Prism language identifiers
@@ -246,6 +248,14 @@ export default function Review({
     const [pluginOutputs, setPluginOutputs] = useState<Record<string, PluginResult>>({});
     const [executingPlugins, setExecutingPlugins] = useState<Set<string>>(new Set());
     const [loading, setLoading] = useState(false);
+    // Transient toast notification; keyed by id so a new message restarts the timer.
+    const [toast, setToast] = useState<{
+        id: number;
+        message: string;
+        variant: StatusVariant;
+    } | null>(null);
+    const showToast = (message: string, variant: StatusVariant = 'info') =>
+        setToast({ id: Date.now(), message, variant });
 
     // UI State
     const [showCommentModal, setShowCommentModal] = useState(false); // For general comments
@@ -446,8 +456,14 @@ export default function Review({
             setMetadata(res.metadata || null);
             setFeedbackBody(res.feedback || '');
             loadPluginOutputs();
+            if (res.updated) {
+                showToast('Synced — new commits or comments pulled in', 'success');
+            } else {
+                showToast('Synced — already up to date', 'info');
+            }
         } catch (e) {
             console.error(e);
+            showToast('Sync failed — see console for details', 'danger');
         } finally {
             setLoading(false);
         }
@@ -4290,6 +4306,17 @@ export default function Review({
                         </button>
                     ))}
                 </div>
+            )}
+
+            {/* Transient notifications (e.g., sync result) */}
+            {toast && (
+                <Toast
+                    key={toast.id}
+                    message={toast.message}
+                    variant={toast.variant}
+                    bottomOffset={isMobile ? 84 : 24}
+                    onDismiss={() => setToast(null)}
+                />
             )}
         </div>
     );

--- a/bun_client/frontend/src/design/components/Toast.tsx
+++ b/bun_client/frontend/src/design/components/Toast.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { colors, borderRadius, spacing, shadows } from '../styles/tokens';
+import { fontSize, fontWeight } from '../styles/typography';
+import { getStatusColor, type StatusVariant } from '../styles/utils';
+
+export interface ToastProps {
+    /** Message to display */
+    message: string;
+    /** Visual variant of the toast */
+    variant?: StatusVariant;
+    /** Called when the toast should be removed (after the timeout or a click) */
+    onDismiss: () => void;
+    /** Auto-dismiss delay in milliseconds */
+    duration?: number;
+    /** Distance from the bottom of the viewport, e.g. to clear a mobile action bar */
+    bottomOffset?: number;
+}
+
+/**
+ * Toast notification that floats at the bottom center of the viewport,
+ * fades in on mount, and auto-dismisses after `duration`. Click to dismiss
+ * early. Render with a changing `key` to restart the timer for a new message.
+ */
+export function Toast({
+    message,
+    variant = 'info',
+    onDismiss,
+    duration = 4000,
+    bottomOffset = 24,
+}: ToastProps) {
+    const [visible, setVisible] = useState(false);
+
+    // Keep the latest onDismiss without re-arming the timers when the parent
+    // re-renders and passes a new function identity.
+    const onDismissRef = useRef(onDismiss);
+    onDismissRef.current = onDismiss;
+
+    const exitMs = 200;
+
+    useEffect(() => {
+        const showTimer = setTimeout(() => setVisible(true), 10);
+        const hideTimer = setTimeout(() => setVisible(false), Math.max(duration - exitMs, 0));
+        const dismissTimer = setTimeout(() => onDismissRef.current(), duration);
+        return () => {
+            clearTimeout(showTimer);
+            clearTimeout(hideTimer);
+            clearTimeout(dismissTimer);
+        };
+    }, [duration]);
+
+    const toastStyle: React.CSSProperties = {
+        position: 'fixed',
+        bottom: `${bottomOffset}px`,
+        left: '50%',
+        transform: visible ? 'translate(-50%, 0)' : 'translate(-50%, 8px)',
+        opacity: visible ? 1 : 0,
+        transition: `opacity ${exitMs}ms ease, transform ${exitMs}ms ease`,
+        zIndex: 1100,
+        display: 'flex',
+        alignItems: 'center',
+        gap: spacing.sm,
+        maxWidth: 'calc(100vw - 32px)',
+        padding: `${spacing.md} ${spacing.lg}`,
+        background: colors.bgSecondary,
+        border: `1px solid ${colors.border}`,
+        borderLeft: `3px solid ${getStatusColor(variant)}`,
+        borderRadius: borderRadius.md,
+        boxShadow: shadows.lg,
+        color: colors.textPrimary,
+        fontSize: fontSize.md,
+        fontWeight: fontWeight.medium,
+        cursor: 'pointer',
+        whiteSpace: 'pre-line',
+    };
+
+    return (
+        <div role="status" aria-live="polite" style={toastStyle} onClick={onDismiss}>
+            {message}
+        </div>
+    );
+}

--- a/bun_client/frontend/src/design/components/index.ts
+++ b/bun_client/frontend/src/design/components/index.ts
@@ -4,3 +4,4 @@ export { Card, type CardProps } from './Card';
 export { Input, TextArea, type InputProps, type TextAreaProps } from './Input';
 export { Select, type SelectProps } from './Select';
 export { Modal, type ModalProps } from './Modal';
+export { Toast, type ToastProps } from './Toast';

--- a/client.el/crs-review.el
+++ b/client.el/crs-review.el
@@ -255,10 +255,15 @@ review buffer."
        (let ((err (cdr (assq 'error result))))
          (if err
              (message "Error syncing review: %s" (if (stringp err) err (cdr (assq 'message err))))
-           (let ((review-buffer (get-buffer (crs--review-buffer-name owner repo number))))
+           (let ((review-buffer (get-buffer (crs--review-buffer-name owner repo number)))
+                 ;; `updated' is t when the sync pulled in a new head SHA or
+                 ;; new comments; json.el decodes false as :json-false.
+                 (updated (eq (cdr (assq 'updated result)) t)))
              (when review-buffer
                (crs--render-and-update review-buffer result))
-             (message "Review synced successfully!"))))))))
+             (message (if updated
+                          "PR synced: new commits or comments pulled in"
+                        "PR synced: already up to date")))))))))
 
 
 (defun crs--switch-and-fetch (project-name branch-name)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -216,6 +216,7 @@ Forces a fresh fetch of the pull request from GitHub, bypassing any cache.
 | Field      | Type         | Description                                     |
 |------------|--------------|-------------------------------------------------|
 | `Okay`     | bool         | `true` if the request succeeded                 |
+| `updated`  | bool         | `true` if the sync pulled in a new head SHA or new comments compared to the previously cached state |
 | `Content`  | string       | Formatted PR response (freshly fetched)         |
 | `metadata` | PRMetadata   | Structured PR metadata                          |
 | `diff`     | string       | Raw diff content                                |

--- a/server/server.go
+++ b/server/server.go
@@ -640,6 +640,7 @@ type SyncPRArgs struct {
 
 type SyncPRReply struct {
 	Okay             bool          `json:"okay"`
+	Updated          bool          `json:"updated"`
 	Content          string        `json:"content"`
 	Metadata         *PRMetadata   `json:"metadata"`
 	Diff             string        `json:"diff"`
@@ -651,10 +652,20 @@ type SyncPRReply struct {
 }
 
 func (h *RPCHandler) SyncPR(args *SyncPRArgs, reply *SyncPRReply) error {
+	// Snapshot the cached state so we can tell the client whether the sync
+	// actually pulled in anything new. The fresh fetch below overwrites these
+	// cache entries.
+	_, oldSHA, _ := config.C().DB.GetPullRequest(args.Number, args.Repo)
+	oldCommentsJSON, _ := config.C().DB.GetPRComments(args.Number, args.Repo)
+
 	details, content, err := h.fetchPRAndRunPlugins(args.Owner, args.Repo, args.Number, true)
 	if err != nil {
 		return err
 	}
+
+	_, newSHA, _ := config.C().DB.GetPullRequest(args.Number, args.Repo)
+	newCommentsJSON, _ := config.C().DB.GetPRComments(args.Number, args.Repo)
+	reply.Updated = syncDetectedChanges(oldSHA, newSHA, oldCommentsJSON, newCommentsJSON)
 
 	reply.Content = content
 	reply.Metadata = &details.Metadata
@@ -668,6 +679,40 @@ func (h *RPCHandler) SyncPR(args *SyncPRArgs, reply *SyncPRReply) error {
 	feedback, _ := config.C().DB.GetFeedback(args.Owner, args.Repo, args.Number)
 	reply.Feedback = feedback
 	return nil
+}
+
+// syncDetectedChanges reports whether a sync brought in a new head SHA or new
+// comments compared to the previously cached state.
+func syncDetectedChanges(oldSHA, newSHA, oldCommentsJSON, newCommentsJSON string) bool {
+	if oldSHA != newSHA {
+		return true
+	}
+	oldIDs := cachedCommentIDs(oldCommentsJSON)
+	for id := range cachedCommentIDs(newCommentsJSON) {
+		if _, ok := oldIDs[id]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+// cachedCommentIDs extracts the GitHub comment IDs from a raw PRComments cache
+// entry. Returns an empty set for empty or malformed JSON.
+func cachedCommentIDs(commentsJSON string) map[int64]struct{} {
+	ids := make(map[int64]struct{})
+	if commentsJSON == "" {
+		return ids
+	}
+	var comments []*github.PullRequestComment
+	if err := json.Unmarshal([]byte(commentsJSON), &comments); err != nil {
+		return ids
+	}
+	for _, c := range comments {
+		if c != nil {
+			ids[c.GetID()] = struct{}{}
+		}
+	}
+	return ids
 }
 
 type ListPluginsArgs struct{}

--- a/server/sync_test.go
+++ b/server/sync_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-github/v48/github"
+)
+
+// commentsJSONWithIDs builds a PRComments cache entry containing comments with
+// the given IDs, matching the format UpsertPRComments stores.
+func commentsJSONWithIDs(t *testing.T, ids ...int64) string {
+	t.Helper()
+	comments := []*github.PullRequestComment{}
+	for _, id := range ids {
+		comments = append(comments, &github.PullRequestComment{
+			ID:   github.Int64(id),
+			Body: github.String("comment body"),
+		})
+	}
+	raw, err := json.Marshal(comments)
+	if err != nil {
+		t.Fatalf("failed to marshal comments: %v", err)
+	}
+	return string(raw)
+}
+
+func TestSyncDetectedChanges(t *testing.T) {
+	tests := []struct {
+		name            string
+		oldSHA          string
+		newSHA          string
+		oldCommentsJSON string
+		newCommentsJSON string
+		expected        bool
+	}{
+		{
+			name:     "no changes and no comments",
+			oldSHA:   "abc123",
+			newSHA:   "abc123",
+			expected: false,
+		},
+		{
+			name:     "new head SHA",
+			oldSHA:   "abc123",
+			newSHA:   "def456",
+			expected: true,
+		},
+		{
+			name:     "no previous cache counts as updated",
+			oldSHA:   "",
+			newSHA:   "abc123",
+			expected: true,
+		},
+		{
+			name:            "new comment",
+			oldSHA:          "abc123",
+			newSHA:          "abc123",
+			oldCommentsJSON: commentsJSONWithIDs(t, 1, 2),
+			newCommentsJSON: commentsJSONWithIDs(t, 1, 2, 3),
+			expected:        true,
+		},
+		{
+			name:            "first comment on PR with empty cache entry",
+			oldSHA:          "abc123",
+			newSHA:          "abc123",
+			oldCommentsJSON: "",
+			newCommentsJSON: commentsJSONWithIDs(t, 1),
+			expected:        true,
+		},
+		{
+			name:            "comment deleted is not an update",
+			oldSHA:          "abc123",
+			newSHA:          "abc123",
+			oldCommentsJSON: commentsJSONWithIDs(t, 1, 2),
+			newCommentsJSON: commentsJSONWithIDs(t, 1),
+			expected:        false,
+		},
+		{
+			name:            "unchanged comments",
+			oldSHA:          "abc123",
+			newSHA:          "abc123",
+			oldCommentsJSON: commentsJSONWithIDs(t, 1, 2),
+			newCommentsJSON: commentsJSONWithIDs(t, 1, 2),
+			expected:        false,
+		},
+		{
+			name:            "new SHA and new comments",
+			oldSHA:          "abc123",
+			newSHA:          "def456",
+			oldCommentsJSON: commentsJSONWithIDs(t, 1),
+			newCommentsJSON: commentsJSONWithIDs(t, 1, 2),
+			expected:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := syncDetectedChanges(tt.oldSHA, tt.newSHA, tt.oldCommentsJSON, tt.newCommentsJSON)
+			if got != tt.expected {
+				t.Errorf("syncDetectedChanges(%q, %q, ...) = %v, want %v", tt.oldSHA, tt.newSHA, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCachedCommentIDs(t *testing.T) {
+	if got := cachedCommentIDs(""); len(got) != 0 {
+		t.Errorf("expected empty set for empty JSON, got %v", got)
+	}
+	if got := cachedCommentIDs("not json"); len(got) != 0 {
+		t.Errorf("expected empty set for malformed JSON, got %v", got)
+	}
+
+	ids := cachedCommentIDs(commentsJSONWithIDs(t, 10, 20))
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 IDs, got %d", len(ids))
+	}
+	for _, want := range []int64{10, 20} {
+		if _, ok := ids[want]; !ok {
+			t.Errorf("expected ID %d in set %v", want, ids)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This change adds change detection to the `SyncPR` RPC method and displays toast notifications to users when syncing pull requests. The server now tracks whether a sync operation actually pulled in new commits or comments, and clients (web UI and Emacs) provide feedback about the sync result.

### Changes

- **Server**: Added `syncDetectedChanges()` and `cachedCommentIDs()` functions to detect whether a sync brought in a new head SHA or new comments by comparing cached state before and after the fetch
- **Server**: Extended `SyncPRReply` with an `Updated` field to communicate sync results to clients
- **Web UI**: Added `Toast` component for transient notifications that auto-dismiss after 4 seconds
- **Web UI**: Integrated toast notifications into the sync flow, showing success/info/danger messages based on sync results
- **Emacs client**: Updated sync handler to display appropriate messages based on the `updated` field
- **Documentation**: Updated `protocol.md` to document the new `Updated` field in `SyncPRReply`

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (added comprehensive unit tests for `syncDetectedChanges()` and `cachedCommentIDs()` covering SHA changes, comment additions, and edge cases)

https://claude.ai/code/session_01SRuaorQgXn7LgjQrkgh1VY