### PR TITLE
Fix diff cache poisoning by preventing empty bodies from clobbering cached diffs

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -1085,8 +1085,13 @@ func (db *DB) DeleteLocalComment(id int64) error {
 func (db *DB) GetPullRequest(prNumber int, repo string) (string, string, error) {
 	var body string
 	var sha string
+	// A PR accumulates one row per head SHA it has ever had (the UNIQUE key
+	// includes latest_sha). Order by rowid DESC so we return the most recently
+	// written row — i.e. the current head SHA — rather than an arbitrary (often
+	// stale) one. Without this, a bare LIMIT 1 could hand back an old SHA's diff
+	// or an empty placeholder row.
 	err := db.conn.QueryRow(
-		"SELECT body, latest_sha FROM PullRequests WHERE pr_number = ? AND repo = ? LIMIT 1",
+		"SELECT body, latest_sha FROM PullRequests WHERE pr_number = ? AND repo = ? ORDER BY rowid DESC LIMIT 1",
 		prNumber, repo,
 	).Scan(&body, &sha)
 
@@ -1102,7 +1107,7 @@ func (db *DB) GetPullRequest(prNumber int, repo string) (string, string, error) 
 // GetPullRequestSHAs returns both the head and base SHAs for a cached PR.
 func (db *DB) GetPullRequestSHAs(prNumber int, repo string) (headSHA, baseSHA string, err error) {
 	err = db.conn.QueryRow(
-		"SELECT latest_sha, COALESCE(base_sha, '') FROM PullRequests WHERE pr_number = ? AND repo = ? LIMIT 1",
+		"SELECT latest_sha, COALESCE(base_sha, '') FROM PullRequests WHERE pr_number = ? AND repo = ? ORDER BY rowid DESC LIMIT 1",
 		prNumber, repo,
 	).Scan(&headSHA, &baseSHA)
 
@@ -1113,11 +1118,16 @@ func (db *DB) GetPullRequestSHAs(prNumber int, repo string) (headSHA, baseSHA st
 }
 
 func (db *DB) UpsertPullRequest(prNumber int, repo, latestSha, baseSha, body string) error {
+	// Never overwrite a cached diff with an empty body. The workflow writes a
+	// SHA-only placeholder row (empty body) for PRs whose section doesn't need
+	// the diff, purely so CI/SHA lookups work. Clobbering the real diff with ""
+	// here would silently poison the cache and force a miss on the next review
+	// open, so keep the existing body when the incoming one is empty.
 	_, err := db.conn.Exec(
 		`INSERT INTO PullRequests (pr_number, repo, latest_sha, base_sha, body)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(pr_number, repo, latest_sha) DO UPDATE SET
-			body = excluded.body,
+			body = CASE WHEN excluded.body != '' THEN excluded.body ELSE body END,
 			base_sha = excluded.base_sha`,
 		prNumber, repo, latestSha, baseSha, body,
 	)

--- a/database/pullrequest_cache_test.go
+++ b/database/pullrequest_cache_test.go
@@ -1,0 +1,111 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := NewDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	return db
+}
+
+// A SHA-only placeholder write (empty body) must not wipe a real diff that was
+// already cached for the same head SHA. This is the cache-poisoning bug that
+// caused diff cache misses: the workflow writes an empty body for PRs whose
+// section doesn't need the diff, which previously overwrote the cached diff.
+func TestUpsertPullRequest_EmptyBodyDoesNotClobberDiff(t *testing.T) {
+	db := newTestDB(t)
+
+	const (
+		prNumber = 42
+		repo     = "code-review-server"
+		sha      = "abc123"
+		diff     = "diff --git a/foo b/foo\n+bar\n"
+	)
+
+	if err := db.UpsertPullRequest(prNumber, repo, sha, "base", diff); err != nil {
+		t.Fatalf("seed diff: %v", err)
+	}
+
+	// Simulate the workflow's SHA-only placeholder write for the same SHA.
+	if err := db.UpsertPullRequest(prNumber, repo, sha, "base", ""); err != nil {
+		t.Fatalf("placeholder write: %v", err)
+	}
+
+	got, gotSHA, err := db.GetPullRequest(prNumber, repo)
+	if err != nil {
+		t.Fatalf("GetPullRequest: %v", err)
+	}
+	if got != diff {
+		t.Fatalf("diff was clobbered: got %q, want %q", got, diff)
+	}
+	if gotSHA != sha {
+		t.Fatalf("sha = %q, want %q", gotSHA, sha)
+	}
+}
+
+// A non-empty body must still overwrite a previous body for the same SHA
+// (e.g. a diff refetch), so the no-clobber guard only protects against empties.
+func TestUpsertPullRequest_NonEmptyBodyOverwrites(t *testing.T) {
+	db := newTestDB(t)
+
+	const (
+		prNumber = 7
+		repo     = "code-review-server"
+		sha      = "deadbeef"
+	)
+
+	if err := db.UpsertPullRequest(prNumber, repo, sha, "", "old"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := db.UpsertPullRequest(prNumber, repo, sha, "", "new"); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+
+	got, _, err := db.GetPullRequest(prNumber, repo)
+	if err != nil {
+		t.Fatalf("GetPullRequest: %v", err)
+	}
+	if got != "new" {
+		t.Fatalf("body = %q, want %q", got, "new")
+	}
+}
+
+// When a PR gets new commits, a new row is written for the new head SHA. Reads
+// must return the current (latest) SHA's row, not an arbitrary older one.
+func TestGetPullRequest_ReturnsLatestSHA(t *testing.T) {
+	db := newTestDB(t)
+
+	const (
+		prNumber = 99
+		repo     = "code-review-server"
+	)
+
+	if err := db.UpsertPullRequest(prNumber, repo, "sha_old", "base_old", "old diff"); err != nil {
+		t.Fatalf("seed old: %v", err)
+	}
+	if err := db.UpsertPullRequest(prNumber, repo, "sha_new", "base_new", "new diff"); err != nil {
+		t.Fatalf("seed new: %v", err)
+	}
+
+	body, sha, err := db.GetPullRequest(prNumber, repo)
+	if err != nil {
+		t.Fatalf("GetPullRequest: %v", err)
+	}
+	if sha != "sha_new" || body != "new diff" {
+		t.Fatalf("got (%q, %q), want (%q, %q)", body, sha, "new diff", "sha_new")
+	}
+
+	headSHA, baseSHA, err := db.GetPullRequestSHAs(prNumber, repo)
+	if err != nil {
+		t.Fatalf("GetPullRequestSHAs: %v", err)
+	}
+	if headSHA != "sha_new" || baseSHA != "base_new" {
+		t.Fatalf("SHAs = (%q, %q), want (%q, %q)", headSHA, baseSHA, "sha_new", "base_new")
+	}
+}

--- a/workflows/cache_warm_test.go
+++ b/workflows/cache_warm_test.go
@@ -1,0 +1,74 @@
+package workflows
+
+import (
+	"crs/database"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-github/v48/github"
+)
+
+func warmTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.NewDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("failed to create test database: %v", err)
+	}
+	return db
+}
+
+func prWithHeadSHA(sha string) *github.PullRequest {
+	return &github.PullRequest{Head: &github.PullRequestBranch{SHA: github.String(sha)}}
+}
+
+func TestPRNeedsCacheWarm(t *testing.T) {
+	const (
+		prNumber = 100
+		repo     = "code-review-server"
+	)
+	key := PRKey{Owner: "owner", Repo: repo, Number: prNumber}
+
+	t.Run("brand new PR warms", func(t *testing.T) {
+		db := warmTestDB(t)
+		if !prNeedsCacheWarm(db, key, prWithHeadSHA("sha1")) {
+			t.Fatal("expected warm for a PR with nothing cached")
+		}
+	})
+
+	t.Run("head SHA changed warms", func(t *testing.T) {
+		db := warmTestDB(t)
+		if err := db.UpsertPullRequest(prNumber, repo, "sha_old", "", "cached diff"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if !prNeedsCacheWarm(db, key, prWithHeadSHA("sha_new")) {
+			t.Fatal("expected warm when head SHA changed")
+		}
+	})
+
+	t.Run("placeholder row (empty diff) warms", func(t *testing.T) {
+		db := warmTestDB(t)
+		if err := db.UpsertPullRequest(prNumber, repo, "sha1", "", ""); err != nil {
+			t.Fatalf("seed placeholder: %v", err)
+		}
+		if !prNeedsCacheWarm(db, key, prWithHeadSHA("sha1")) {
+			t.Fatal("expected warm when only a SHA-only placeholder is cached")
+		}
+	})
+
+	t.Run("unchanged PR with cached diff does not warm", func(t *testing.T) {
+		db := warmTestDB(t)
+		if err := db.UpsertPullRequest(prNumber, repo, "sha1", "", "cached diff"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if prNeedsCacheWarm(db, key, prWithHeadSHA("sha1")) {
+			t.Fatal("did not expect warm when current-SHA diff is already cached")
+		}
+	})
+
+	t.Run("nil head SHA does not warm", func(t *testing.T) {
+		db := warmTestDB(t)
+		if prNeedsCacheWarm(db, key, &github.PullRequest{}) {
+			t.Fatal("did not expect warm for a PR with no head SHA")
+		}
+	})
+}

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -711,6 +711,23 @@ func (ms ManagerService) prefetchAuxData(log *slog.Logger, client *github.Client
 		}
 	}
 
+	// Warm the diff + commits caches whenever a PR is newly added or its head
+	// commit changed. These two fields are the ones a reviewer needs to open the
+	// PR, and both go stale on every push (the diff is keyed to the head SHA).
+	// If we only fetched what a section's filters strictly require, a freshly
+	// added or just-updated PR would be a guaranteed cache miss the moment the
+	// user opened it. We deliberately gate this on an actual change — we do NOT
+	// pre-fetch diffs for unchanged PRs we may never look at.
+	db := config.C().DB
+	for key, pr := range prObjects {
+		if prNeedsCacheWarm(db, key, pr) {
+			req := prRequirements[key]
+			req.Diff = true
+			req.Commits = true
+			prRequirements[key] = req
+		}
+	}
+
 	// Fetch aux data in parallel
 	var wg sync.WaitGroup
 	for key, auxReq := range prRequirements {
@@ -730,6 +747,29 @@ func (ms ManagerService) prefetchAuxData(log *slog.Logger, client *github.Client
 
 	log.Info("Pre-fetched auxiliary data", "pr_count", len(prRequirements))
 	return store
+}
+
+// prNeedsCacheWarm reports whether we should proactively fetch the diff and
+// commits for a PR because it was just added or updated. It returns true when:
+//   - the PR is brand new to us (no diff row cached yet),
+//   - its head SHA changed since we last cached it (new commits pushed), or
+//   - we only have a SHA-only placeholder row with no real diff body (e.g. an
+//     earlier fetch failed).
+//
+// In all three cases the diff/commits a reviewer needs are missing or stale, so
+// warming them now turns the next review open into a cache hit. For an unchanged
+// PR whose current-SHA diff is already cached, it returns false so we don't pull
+// data we may never use.
+func prNeedsCacheWarm(db *database.DB, key PRKey, pr *github.PullRequest) bool {
+	if pr == nil || pr.Head == nil || pr.Head.SHA == nil {
+		return false
+	}
+	body, cachedSHA, err := db.GetPullRequest(key.Number, key.Repo)
+	if err != nil {
+		// On a lookup error, err on the side of warming.
+		return true
+	}
+	return cachedSHA != *pr.Head.SHA || body == ""
 }
 
 // fetchAuxDataForPR fetches the requested auxiliary data for a single PR


### PR DESCRIPTION
## Summary

Fixes a cache poisoning bug where SHA-only placeholder writes (empty body) were overwriting cached diffs for the same head SHA. This caused diff cache misses when reviewers opened PRs that had been recently updated or added.

The fix involves three coordinated changes:

1. **Database layer**: Prevent empty bodies from overwriting existing diffs during upsert, and ensure queries return the most recent row (by rowid) when multiple rows exist for the same PR.
2. **Workflow layer**: Proactively warm the diff and commits caches for newly added or updated PRs so they're ready when a reviewer opens them.
3. **Test coverage**: Added comprehensive tests for the cache behavior.

### Changes

- **database/database.go**: 
  - Modified `UpsertPullRequest` to use `CASE WHEN excluded.body != '' THEN excluded.body ELSE body END` so empty bodies never overwrite cached diffs
  - Updated `GetPullRequest` and `GetPullRequestSHAs` queries to `ORDER BY rowid DESC LIMIT 1` to return the current (latest) head SHA's row instead of an arbitrary older one
  
- **workflows/manager.go**:
  - Added `prNeedsCacheWarm()` function to detect when a PR needs proactive cache warming (brand new, head SHA changed, or only has a placeholder row)
  - Modified `prefetchAuxData()` to automatically set `Diff` and `Commits` requirements to true for PRs that need warming, ensuring they're fetched before a reviewer opens them

- **database/pullrequest_cache_test.go** (new):
  - `TestUpsertPullRequest_EmptyBodyDoesNotClobberDiff`: Verifies empty bodies don't overwrite cached diffs
  - `TestUpsertPullRequest_NonEmptyBodyOverwrites`: Confirms non-empty bodies still overwrite (e.g., for diff refetches)
  - `TestGetPullRequest_ReturnsLatestSHA`: Ensures queries return the current head SHA's row, not stale ones

- **workflows/cache_warm_test.go** (new):
  - `TestPRNeedsCacheWarm`: Tests all cache warming scenarios (brand new PR, head SHA changed, placeholder row, unchanged PR with cached diff, nil head SHA)

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — new tests cover the cache poisoning fix and cache warming logic

https://claude.ai/code/session_01FzLxu5CZpfsnNNypnuKZEY