### PR TITLE
Fix evil leader key bindings using evil-global-set-key

### DIFF
--- a/client.el/crs-client.el
+++ b/client.el/crs-client.el
@@ -84,10 +84,13 @@
 
 (with-eval-after-load 'evil
   ;; Global normal-state leader bindings: available in any buffer/mode,
-  ;; not only crs-list-mode.
-  (evil-define-key 'normal 'global
-    (kbd ", r s") #'crs-start-review-at-point
-    (kbd ", r b") #'crs-get-reviews)
+  ;; not only crs-list-mode.  Use `evil-global-set-key' rather than
+  ;; `evil-define-key' with the `global' pseudo-keymap: the latter targets
+  ;; a specific mode keymap and is unreliable for truly global bindings
+  ;; across evil versions, which is why the `, r s' / `, r b' leaders
+  ;; silently failed to bind.
+  (evil-global-set-key 'normal (kbd ", r s") #'crs-start-review-at-point)
+  (evil-global-set-key 'normal (kbd ", r b") #'crs-get-reviews)
   ;; crs-list-mode: normal state.  Without these, evil's normal-state
   ;; bindings shadow the plain `crs-list-mode-map' bindings, so the PR
   ;; list keys silently do nothing for evil users.


### PR DESCRIPTION
## Summary

Replace `evil-define-key` with the `global` pseudo-keymap with `evil-global-set-key` for truly global leader key bindings. The previous approach was unreliable across evil versions and caused the `, r s` and `, r b` leader keys to silently fail to bind.

### Changes

- Replace `evil-define-key 'normal 'global` with `evil-global-set-key 'normal` for the `, r s` (start review) and `, r b` (get reviews) leader bindings
- Add explanatory comment clarifying why `evil-global-set-key` is the correct approach for global bindings across evil versions

## Test Plan

- [ ] Verify `, r s` and `, r b` leader keys bind and function correctly in evil normal state
- [ ] Test in multiple evil versions if available

https://claude.ai/code/session_01DmbnoAB2JqbqAFUqHvunJe