### PR TITLE
Fix sticky hunk headers overlapping content on scroll

### DIFF
--- a/bun_client/frontend/src/components/review/DiffView.tsx
+++ b/bun_client/frontend/src/components/review/DiffView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { Fragment, useMemo } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { colors } from '../../design';
 import { type ParsedLine, sortParsedLinesTestsLast } from '../../diff_utils';
@@ -562,7 +562,15 @@ export default function DiffView({
                 background: colors.diffDelGutterBg,
             };
         } else if (isHunkHeader) {
-            containerStyle = { ...containerStyle, background: colors.diffHunkBg };
+            // Let .diff-hunk-row own `position` (sticky on desktop, static on
+            // mobile). An inline `position: relative` here would override the
+            // class's sticky while its `top` offset still applied, painting
+            // the header below its slot and overlapping the rows beneath it.
+            containerStyle = {
+                ...containerStyle,
+                background: colors.diffHunkBg,
+                position: undefined,
+            };
             lineStyle = {
                 ...lineStyle,
                 color: colors.accent,
@@ -591,8 +599,14 @@ export default function DiffView({
             lineContent = isCodeLine ? line.slice(1) : line;
         }
 
+        // Hunk headers render unwrapped (Fragment adds no DOM node): a
+        // per-row wrapper div would be their sticky containing block, sized
+        // exactly to the row, leaving the header no room to pin under the
+        // toolbar while its hunk scrolls.
+        const RowWrapper = isHunkHeader ? Fragment : 'div';
+
         return (
-            <div key={idx}>
+            <RowWrapper key={idx}>
                 <div
                     className={
                         (item.clickable ? 'hover-line' : '') +
@@ -757,7 +771,7 @@ export default function DiffView({
                         onSubmit={onSubmitInline}
                     />
                 )}
-            </div>
+            </RowWrapper>
         );
     });
 

--- a/bun_client/frontend/src/index.css
+++ b/bun_client/frontend/src/index.css
@@ -1018,11 +1018,14 @@ textarea:focus-visible {
 }
 
 /* Guard against horizontal page scroll on small screens. Individual code/diff
-   blocks opt back into horizontal scrolling via their own overflow-x. */
+   blocks opt back into horizontal scrolling via their own overflow-x.
+   `clip` rather than `hidden`: overflow-x hidden turns <body> into a scroll
+   container, which re-anchors every `position: sticky` descendant (toolbar,
+   hunk headers) to <body> — which never scrolls — so nothing ever pinned. */
 html,
 body {
     max-width: 100%;
-    overflow-x: hidden;
+    overflow-x: clip;
 }
 
 /* Media-friendly defaults. */


### PR DESCRIPTION
## Summary

Fix a layout bug where diff hunk headers were overlapping content below them when scrolling. The issue had two root causes:

1. **Inline `position: relative` override**: Hunk header rows had an inline `position: relative` style that overrode the CSS class's `position: sticky`, causing the header to render in-flow and overlap rows beneath it.
2. **Body overflow-x hidden**: The `<body>` element's `overflow-x: hidden` was converting it into a scroll container, which re-anchored all `position: sticky` descendants (including hunk headers and the toolbar) to `<body>` instead of the viewport, preventing them from pinning correctly.

### Changes

- **DiffView.tsx**: 
  - Import `Fragment` from React
  - Set `position: undefined` on hunk header container styles to avoid overriding the CSS class's sticky positioning
  - Conditionally render hunk header rows without a wrapper `<div>` (using `Fragment`) to prevent the wrapper from becoming a sticky containing block that constrains the header's pinning behavior
  - Add explanatory comments documenting the positioning strategy

- **index.css**:
  - Change `body { overflow-x: hidden }` to `overflow-x: clip` to prevent `<body>` from becoming a scroll container, allowing `position: sticky` descendants to pin to the viewport instead
  - Update comment to explain the `clip` vs `hidden` distinction

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] Manual verification: Scroll through a diff with multiple hunks on both desktop and mobile; hunk headers should remain pinned at the top without overlapping content below them

https://claude.ai/code/session_01BoydZD6E6YfhjuFceHpC6X