### PR TITLE
Fix comment indicator layout in diff view

### DIFF
--- a/bun_client/frontend/src/components/review/DiffView.tsx
+++ b/bun_client/frontend/src/components/review/DiffView.tsx
@@ -622,6 +622,26 @@ export default function DiffView({
                     }}
                     title={undefined}
                 >
+                    {isCodeLine && !isHunkHeader && (
+                        // Fixed-width comment gutter, to the LEFT of the line
+                        // numbers. Always rendered (empty when the line has no
+                        // comment) so a collapsed-comment badge never shifts the
+                        // line numbers or code. A wider multi-comment badge is
+                        // right-aligned here and overflows left into the diff
+                        // padding, never over the line numbers to its right.
+                        <span
+                            style={{
+                                width: '22px',
+                                minWidth: '22px',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'flex-end',
+                                userSelect: 'none',
+                            }}
+                        >
+                            {commentIndicatorForLine(item)}
+                        </span>
+                    )}
                     {isCodeLine && !isHunkHeader && !isMobile && (
                         <>
                             <span
@@ -647,11 +667,6 @@ export default function DiffView({
                                 {item.newLineNo ?? ''}
                             </span>
                         </>
-                    )}
-                    {isCodeLine && !isHunkHeader && (
-                        <span style={{ display: 'flex', alignItems: 'center' }}>
-                            {commentIndicatorForLine(item)}
-                        </span>
                     )}
                     {isCodeLine && !isHunkHeader && (
                         <span


### PR DESCRIPTION
## Summary

Restructures the comment indicator rendering in the diff view to use a fixed-width gutter that prevents layout shifts when comment badges appear or disappear. The comment indicator is now rendered in its own 22px-wide container positioned to the left of line numbers, with proper alignment and overflow handling.

### Changes

- Added a fixed-width (22px) flex container for the comment indicator that is always rendered (empty when no comments exist)
- Positioned the comment indicator gutter to the left of line numbers to prevent shifting
- Right-aligned comment badges within the gutter so multi-comment indicators overflow left into diff padding, never over line numbers
- Moved comment indicator rendering before line number rendering for proper visual stacking

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] Verify comment indicators display correctly on code lines in the diff view
- [ ] Verify line numbers remain stable when toggling comment visibility
- [ ] Verify multi-comment badges don't overlap with line numbers

https://claude.ai/code/session_01AeL7gKfSU1urYXnSpFzz4X