### PR TITLE
Pin file headers below toolbar in diff view

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -101,29 +101,42 @@ export default function Review({
     const isMobile = useIsMobile();
     const [wrapLines, setWrapLines] = useState<boolean>(() => isMobile);
 
-    // Measure the sticky toolbar's actual rendered height and publish it as a
-    // CSS variable so sticky hunk headers can pin directly below the toolbar
-    // regardless of font size, button padding, or wrap.
+    // Measure the sticky toolbar and a file header row and publish their
+    // heights as CSS variables, so the file header pins directly below the
+    // toolbar and hunk headers pin directly below the file header —
+    // regardless of font size, button padding, or wrap. Every file header
+    // renders at the same height (see DiffView), so one row is enough.
     const toolbarRef = useRef<HTMLDivElement | null>(null);
     useLayoutEffect(() => {
         const el = toolbarRef.current;
         if (!el) return;
+        // Queried rather than ref'd: DiffView renders one of these per file and
+        // any of them gives the same height.
+        const fileRow = document.querySelector<HTMLElement>('.diff-file-row');
         const sync = () => {
             // Toolbar `top` offset (10px) + rendered height. No extra gap — any
-            // pixel between the toolbar's bottom and the hunk row's top would
-            // expose scrolling content through the seam.
+            // pixel between the toolbar's bottom and the row pinned beneath it
+            // would expose scrolling content through the seam.
             const top = 10 + el.offsetHeight;
-            document.documentElement.style.setProperty('--review-hunk-sticky-top', `${top}px`);
+            const root = document.documentElement;
+            root.style.setProperty('--review-sticky-top', `${top}px`);
+            // Before any file header exists, hunk headers pin under the toolbar.
+            root.style.setProperty(
+                '--review-hunk-sticky-top',
+                `${top + (fileRow?.offsetHeight ?? 0)}px`
+            );
         };
         sync();
         const ro = new ResizeObserver(sync);
         ro.observe(el);
+        if (fileRow) ro.observe(fileRow);
         window.addEventListener('resize', sync);
         return () => {
             ro.disconnect();
             window.removeEventListener('resize', sync);
         };
-    }, []);
+        // Re-run once the diff renders (or changes) so the file row is measured.
+    }, [diff]);
     // Inline review feedback drafting is hidden behind a toggle; the body is also
     // editable in the Submit Review modal.
     const [feedbackCollapsed, setFeedbackCollapsed] = useState(true);

--- a/bun_client/frontend/src/components/review/DiffView.tsx
+++ b/bun_client/frontend/src/components/review/DiffView.tsx
@@ -300,8 +300,13 @@ export default function DiffView({
             const hasOutdated = fileOutdatedComments.length > 0;
 
             return (
-                <div key={idx} id={item.file ? `file-${slugify(item.file)}` : undefined}>
+                // Fragment, not a wrapper div (same reason as hunk rows below):
+                // the header's sticky containing block must be the whole file
+                // section, not a box sized to the header itself, or it would
+                // have no room to stay pinned while the file's lines scroll by.
+                <Fragment key={idx}>
                     <div
+                        id={item.file ? `file-${slugify(item.file)}` : undefined}
                         style={{
                             display: 'flex',
                             alignItems: 'center',
@@ -309,21 +314,27 @@ export default function DiffView({
                             padding: '10px 12px',
                             background:
                                 'linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%)',
-                            borderTop: idx > 0 ? '2px solid var(--border)' : 'none',
+                            // Every file header keeps the same border and no top
+                            // margin so all of them render at an identical height:
+                            // Review.tsx measures one row to offset the sticky hunk
+                            // headers below, and a margin above a pinned row would
+                            // open a seam that scrolling content shows through.
+                            borderTop: '2px solid var(--border)',
                             borderBottom: '1px solid var(--border)',
-                            marginTop: idx > 0 ? '8px' : '0',
                             cursor: 'pointer',
                             borderLeft: isInlineActive
                                 ? '3px solid var(--accent)'
                                 : '3px solid transparent',
-                            position: 'relative',
+                            // `position` is left to .diff-file-row (sticky on
+                            // desktop, static on mobile); an inline value here
+                            // would override the class.
                         }}
                         onClick={() =>
                             item.file &&
                             item.pos !== null &&
                             onCommentClick(idx, item.file, item.pos)
                         }
-                        className="hover-line"
+                        className="hover-line diff-file-row"
                         title={`Add comment to ${item.file}`}
                     >
                         <button
@@ -383,7 +394,15 @@ export default function DiffView({
                                 fontSize: '13px',
                                 fontWeight: 500,
                                 color: 'var(--text-primary)',
+                                // Keep the header exactly one line tall: a wrapped
+                                // path would make this file's row taller than the
+                                // one measured for the sticky hunk offset.
+                                minWidth: 0,
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
                             }}
+                            title={item.file || item.text}
                         >
                             {item.fileStatus === 'renamed' && item.origName
                                 ? `${item.origName} → ${item.text}`
@@ -509,7 +528,7 @@ export default function DiffView({
                             )}
                         </InlineCommentForm>
                     )}
-                </div>
+                </Fragment>
             );
         }
 
@@ -790,6 +809,24 @@ export default function DiffView({
         );
     });
 
+    // Group each file's rows under a section wrapper. That wrapper is the
+    // sticky containing block for the file's header and hunk rows, so they pin
+    // below the toolbar while the file is on screen and scroll away with it —
+    // rather than a header from a file you already passed lingering up there.
+    const sections: React.ReactNode[] = [];
+    let sectionRows: React.ReactNode[] = [];
+    const flushSection = () => {
+        if (sectionRows.length === 0) return;
+        sections.push(<div key={`section-${sections.length}`}>{sectionRows}</div>);
+        sectionRows = [];
+    };
+    lines.forEach((item, idx) => {
+        if (item.lineType === 'file-header') flushSection();
+        const row = rows[idx];
+        if (row) sectionRows.push(row);
+    });
+    flushSection();
+
     // On phones, let the whole diff slide horizontally so long lines can be
     // read in full. `max-content` makes every row as wide as the longest
     // line (so add/del backgrounds extend across the full scroll width),
@@ -807,11 +844,11 @@ export default function DiffView({
                         minWidth: '100%',
                     }}
                 >
-                    {rows}
+                    {sections}
                 </div>
             </div>
         );
     }
 
-    return <>{rows}</>;
+    return <>{sections}</>;
 }

--- a/bun_client/frontend/src/index.css
+++ b/bun_client/frontend/src/index.css
@@ -9,9 +9,11 @@
     --diff-line-no-bg: rgba(127, 127, 127, 0.04);
     --diff-line-no-color: rgba(127, 127, 127, 0.85);
     --review-toolbar-top: 10px;
-    /* Fallback only — Review.tsx measures the toolbar at runtime and
-       overrides this so the hunk header pins flush below the toolbar. */
-    --review-hunk-sticky-top: 72px;
+    /* Fallbacks only — Review.tsx measures the toolbar and a file header row
+       at runtime and overrides these so the file header pins flush below the
+       toolbar and the hunk header pins flush below the file header. */
+    --review-sticky-top: 72px;
+    --review-hunk-sticky-top: 118px;
 }
 
 /* Default Theme (Dark) */
@@ -709,7 +711,27 @@ body {
     justify-content: flex-end;
 }
 
-/* Sticky hunk headers — slide under the toolbar.
+/* Sticky file headers — the file you are reading stays named in a bar
+   directly under the toolbar, with its hunk header pinned right below it
+   (see .diff-hunk-row). Both are bounded by their file's section wrapper
+   (see DiffView), so they scroll away with the file instead of lingering
+   once you have passed it. Same layering rules as the hunk row: an opaque
+   background so scrolling content can't ghost through, and its own
+   compositor layer so no sliver of the next row bleeds past its edge.
+   The row carries no top margin (see DiffView) — a margin would push the
+   pinned box down and open a seam below the toolbar. */
+.diff-file-row {
+    position: sticky;
+    top: var(--review-sticky-top);
+    z-index: 5;
+    /* Jumping here from the file index leaves room for the toolbar, so the
+       header lands exactly where it pins instead of behind the toolbar. */
+    scroll-margin-top: var(--review-sticky-top);
+    transform: translateZ(0);
+    will-change: transform;
+}
+
+/* Sticky hunk headers — slide under the file header.
    - Layered background (solid base + tint) keeps the row fully opaque
      so scrolling content can't ghost through.
    - min-height + extra bottom padding give a small buffer that
@@ -734,9 +756,10 @@ body {
 }
 
 /* On phones the diff scrolls horizontally inside its own container, which
-   re-anchors `position: sticky` to that scroller and would pin hunk headers
+   re-anchors `position: sticky` to that scroller and would pin the headers
    to the wrong box. Fall back to static positioning so they scroll inline. */
 @media (max-width: 768px) {
+    .diff-file-row,
     .diff-hunk-row {
         position: static;
         top: auto;


### PR DESCRIPTION
## Summary

Adds sticky positioning to file headers in the diff view so they remain visible below the toolbar while scrolling through a file's contents. File headers now pin in place and scroll away with their file, preventing headers from lingering after you've passed them.

### Changes

- **DiffView.tsx**: Restructured file header rendering to use `Fragment` instead of a wrapper `div`, allowing proper sticky positioning. Moved the `id` attribute to the inner div and added the `diff-file-row` class for sticky styling. Removed conditional `borderTop` and `marginTop` to ensure all file headers render at identical heights (required for accurate sticky offset calculation). Added text truncation styles (`nowrap`, `overflow: hidden`, `textOverflow: ellipsis`) to prevent wrapped paths from changing row height.

- **index.css**: Added `.diff-file-row` sticky positioning styles that pin file headers below the toolbar. Introduced `--review-sticky-top` CSS variable for the file header's sticky offset. Updated `--review-hunk-sticky-top` to account for both toolbar and file header heights. Wrapped file rows in section divs to create proper sticky containing blocks (so headers scroll away with their file rather than lingering). Updated media query to apply `position: static` to file headers on mobile.

- **Review.tsx**: Enhanced the toolbar measurement logic to also measure file header row height and publish both `--review-sticky-top` (toolbar offset) and `--review-hunk-sticky-top` (toolbar + file header offset) as CSS variables. Added ResizeObserver for file header rows to recalculate offsets when dimensions change. Updated dependency array to re-run measurement when the diff changes.

- **DiffView.tsx**: Added section wrapper logic that groups each file's rows under a `div` container, creating the sticky containing block needed for proper pinning behavior.

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] Manual verification: File headers remain visible and pinned below the toolbar while scrolling through file contents; headers scroll away when you pass them; hunk headers pin directly below file headers; behavior is correct on both desktop and mobile viewports

https://claude.ai/code/session_016UshZNP5kdeR3qL7A2ERHE