### PR TITLE
Add configurable diff font size preference to review UI

### DIFF
--- a/bun_client/frontend/src/App.tsx
+++ b/bun_client/frontend/src/App.tsx
@@ -12,6 +12,11 @@ import {
     THEME_OPTIONS,
     ReviewLocation,
     REVIEW_LOCATION_OPTIONS,
+    DiffFontSize,
+    VALID_DIFF_FONT_SIZES,
+    DEFAULT_DIFF_FONT_SIZE,
+    DIFF_FONT_SIZE_OPTIONS,
+    DIFF_FONT_SIZE_PX,
 } from './design';
 
 interface PRParams {
@@ -36,6 +41,11 @@ function App() {
         if (saved === 'local' || saved === 'github') return saved;
         return 'local';
     });
+    const [diffFontSize, setDiffFontSize] = useState<DiffFontSize>(() => {
+        const saved = localStorage.getItem('diffFontSize') as DiffFontSize;
+        if (saved && VALID_DIFF_FONT_SIZES.includes(saved)) return saved;
+        return DEFAULT_DIFF_FONT_SIZE;
+    });
 
     // Apply theme
     useEffect(() => {
@@ -47,6 +57,17 @@ function App() {
     useEffect(() => {
         localStorage.setItem('reviewLocation', reviewLocation);
     }, [reviewLocation]);
+
+    // Publish the review diff font size as a CSS variable. The diff containers
+    // read `--diff-font-size` and everything inside the diff sizes off it in
+    // `em`, so the whole diff scales from this one value.
+    useEffect(() => {
+        document.documentElement.style.setProperty(
+            '--diff-font-size',
+            `${DIFF_FONT_SIZE_PX[diffFontSize]}px`
+        );
+        localStorage.setItem('diffFontSize', diffFontSize);
+    }, [diffFontSize]);
 
     // Dynamic Title
     useEffect(() => {
@@ -377,6 +398,50 @@ function App() {
                             }}
                         >
                             Determines where to open PRs when clicking their title in the list.
+                        </div>
+                    </div>
+                    <div>
+                        <div
+                            style={{
+                                fontSize: '13px',
+                                fontWeight: 600,
+                                color: 'var(--text-secondary)',
+                                marginBottom: '8px',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.5px',
+                            }}
+                        >
+                            Review Diff Font Size
+                        </div>
+                        <Select
+                            value={diffFontSize}
+                            onChange={e => setDiffFontSize(e.target.value as DiffFontSize)}
+                            options={DIFF_FONT_SIZE_OPTIONS}
+                        />
+                        <div
+                            style={{
+                                fontFamily: 'var(--font-mono)',
+                                fontSize: `${DIFF_FONT_SIZE_PX[diffFontSize]}px`,
+                                color: 'var(--text-secondary)',
+                                background: 'var(--bg-tertiary)',
+                                border: '1px solid var(--border)',
+                                borderRadius: '4px',
+                                padding: '6px 8px',
+                                marginTop: '8px',
+                                whiteSpace: 'pre',
+                                overflowX: 'auto',
+                            }}
+                        >
+                            {'+ func preview(size int) error {'}
+                        </div>
+                        <div
+                            style={{
+                                fontSize: '11px',
+                                color: 'var(--text-tertiary)',
+                                marginTop: '6px',
+                            }}
+                        >
+                            Size of the diff text (and its line numbers) when reviewing a PR.
                         </div>
                     </div>
                 </div>

--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -1159,7 +1159,10 @@ export default function Review({
                                 style={{
                                     padding: '16px',
                                     fontFamily: 'var(--font-mono)',
-                                    fontSize: '13px',
+                                    // Set from the Review Diff Font Size preference; the
+                                    // diff's line numbers, +/- gutter and hunk headers
+                                    // size themselves in `em` off this base.
+                                    fontSize: 'var(--diff-font-size, 13px)',
                                     // No overflow:auto here — it would create a scroll
                                     // container and break sticky positioning of hunk
                                     // headers. Long lines are handled by per-line
@@ -1311,7 +1314,7 @@ export default function Review({
                                             overflowY: 'auto',
                                             padding: '16px',
                                             fontFamily: 'var(--font-mono)',
-                                            fontSize: '13px',
+                                            fontSize: 'var(--diff-font-size, 13px)',
                                         }}
                                     >
                                         {renderDiff(tab.filePath)}

--- a/bun_client/frontend/src/components/review/DiffView.tsx
+++ b/bun_client/frontend/src/components/review/DiffView.tsx
@@ -380,7 +380,7 @@ export default function DiffView({
                         <span
                             style={{
                                 fontFamily: 'var(--font-mono)',
-                                fontSize: '13px',
+                                fontSize: '1em',
                                 fontWeight: 500,
                                 color: 'var(--text-primary)',
                             }}
@@ -530,7 +530,9 @@ export default function DiffView({
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            fontSize: '12px',
+            // Relative to the diff container's font size so the gutter tracks
+            // the Review Diff Font Size preference.
+            fontSize: '0.92em',
         };
 
         // On mobile, unwrapped lines scroll horizontally as a unit (see the
@@ -575,7 +577,7 @@ export default function DiffView({
                 ...lineStyle,
                 color: colors.accent,
                 fontStyle: 'italic',
-                fontSize: '12px',
+                fontSize: '0.92em',
             };
         }
 

--- a/bun_client/frontend/src/design/theme.ts
+++ b/bun_client/frontend/src/design/theme.ts
@@ -52,3 +52,36 @@ export const REVIEW_LOCATION_OPTIONS = [
     { value: 'local', label: '💻 Local (in app)' },
     { value: 'github', label: '🐙 GitHub' },
 ];
+
+/**
+ * Review diff font size preferences
+ */
+export const VALID_DIFF_FONT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+
+export type DiffFontSize = (typeof VALID_DIFF_FONT_SIZES)[number];
+
+export const DEFAULT_DIFF_FONT_SIZE: DiffFontSize = 'md';
+
+// Base font size (px) of the review diff container. Line numbers, the +/-
+// gutter and hunk headers size themselves in `em` off this value, so the whole
+// diff scales together. Published as `--diff-font-size` on the document root.
+export const DIFF_FONT_SIZE_PX: Record<DiffFontSize, number> = {
+    xs: 11,
+    sm: 12,
+    md: 13,
+    lg: 15,
+    xl: 17,
+};
+
+export interface DiffFontSizeOption {
+    value: DiffFontSize;
+    label: string;
+}
+
+export const DIFF_FONT_SIZE_OPTIONS: DiffFontSizeOption[] = [
+    { value: 'xs', label: `Extra Small (${DIFF_FONT_SIZE_PX.xs}px)` },
+    { value: 'sm', label: `Small (${DIFF_FONT_SIZE_PX.sm}px)` },
+    { value: 'md', label: `Medium (${DIFF_FONT_SIZE_PX.md}px)` },
+    { value: 'lg', label: `Large (${DIFF_FONT_SIZE_PX.lg}px)` },
+    { value: 'xl', label: `Extra Large (${DIFF_FONT_SIZE_PX.xl}px)` },
+];

--- a/bun_client/frontend/src/index.css
+++ b/bun_client/frontend/src/index.css
@@ -692,14 +692,18 @@ body {
     box-shadow: var(--shadow-glow);
 }
 
-/* Diff line-number gutters */
+/* Diff line-number gutters.
+   Sized in `em` so the gutter tracks the Review Diff Font Size preference
+   (--diff-font-size, set on the diff container). The gutter keeps its 44px
+   floor at small sizes but grows with its content at larger ones, so wide
+   line numbers never spill over the +/- column. */
 .diff-line-no {
-    width: 44px;
+    flex: 0 0 auto;
     min-width: 44px;
     padding: 0 6px;
     text-align: right;
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: 0.85em;
     color: var(--diff-line-no-color);
     background: var(--diff-line-no-bg);
     border-right: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Adds a user-configurable "Review Diff Font Size" setting to the settings panel, allowing users to adjust the font size of code diffs when reviewing PRs. The preference is persisted to localStorage and applied via a CSS variable that scales the entire diff (line numbers, gutters, and hunk headers) together.

### Changes

- Added `DiffFontSize` type and related constants (`VALID_DIFF_FONT_SIZES`, `DEFAULT_DIFF_FONT_SIZE`, `DIFF_FONT_SIZE_PX`, `DIFF_FONT_SIZE_OPTIONS`) to `design/theme.ts` with five size options (xs: 11px to xl: 17px)
- Added state management in `App.tsx` to load/save the `diffFontSize` preference from localStorage and publish it as a `--diff-font-size` CSS variable on the document root
- Added a new "Review Diff Font Size" dropdown control in the settings panel with a live preview of the selected size
- Updated `Review.tsx` diff containers to use `var(--diff-font-size, 13px)` instead of hardcoded `13px`, allowing the preference to control the base font size
- Refactored `DiffView.tsx` and `index.css` to use relative `em` units for line numbers, gutters, and hunk headers so they scale proportionally with the base diff font size
- Updated `.diff-line-no` styling to use `flex: 0 0 auto` and `0.85em` font size, maintaining a 44px minimum width while growing for wider line numbers

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] `bun run format:check` passes
- [ ] Verify the "Review Diff Font Size" dropdown appears in settings and all five size options are selectable
- [ ] Verify the preview text in settings updates when changing the size selection
- [ ] Verify the diff font size persists across page reloads
- [ ] Verify diffs render at the selected size with proper scaling of line numbers and gutters

https://claude.ai/code/session_01KYKToszcUmvhWXmHwifvZw