### PR TITLE
Improve cache miss logging and fix reviews cache handling

### DIFF
--- a/server/cache_miss_test.go
+++ b/server/cache_miss_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"crs/config"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readCacheMissLog runs writeCacheMissLog against a temporary CRS_HOME and
+// returns whatever it wrote.
+func readCacheMissLog(t *testing.T, state cacheMissState) string {
+	t.Helper()
+	crsHome := t.TempDir()
+	t.Setenv("CRS_HOME", crsHome)
+
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	writeCacheMissLog(state)
+
+	body, err := os.ReadFile(filepath.Join(crsHome, "cache_miss.log"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("reading cache miss log: %v", err)
+	}
+	return string(body)
+}
+
+func TestWriteCacheMissLogSeparatesForcedRefreshes(t *testing.T) {
+	// A SyncPR-driven refresh bypasses the caches on purpose. It must not be
+	// filed under "Cache Miss Report", or grepping the log for real misses
+	// drowns in entries the user asked for.
+	forced := readCacheMissLog(t, cacheMissState{
+		owner:        "multimediallc",
+		repo:         "chaturbate",
+		number:       30321,
+		skipCache:    true,
+		missedFields: []string{"metadata", "diff", "comments", "commits"},
+		metadataHit:  true,
+		diffHit:      true,
+	})
+
+	if strings.Contains(forced, "=== Cache Miss Report ===") {
+		t.Errorf("forced refresh filed as a cache miss:\n%s", forced)
+	}
+	if !strings.Contains(forced, "=== Forced Refresh Report ===") {
+		t.Errorf("missing forced refresh header:\n%s", forced)
+	}
+	if !strings.Contains(forced, "Fetched:  metadata, diff, comments, commits") {
+		t.Errorf("forced refresh should report refetched fields:\n%s", forced)
+	}
+	// The probed state is reported as-is rather than blanket MISS.
+	if !strings.Contains(forced, "metadata  (PRMetadataCache):  HIT") {
+		t.Errorf("forced refresh should report the real pre-request cache state:\n%s", forced)
+	}
+	if !strings.Contains(forced, "reviews   (PRReviews):        MISS") {
+		t.Errorf("forced refresh should report reviews as genuinely absent:\n%s", forced)
+	}
+}
+
+func TestWriteCacheMissLogReportsFetchError(t *testing.T) {
+	// GetPRDetails aborts on a GitHub error before it reaches the diff/comments
+	// blocks, so the field list alone understates what happened.
+	body := readCacheMissLog(t, cacheMissState{
+		owner:        "multimediallc",
+		repo:         "chaturbate",
+		number:       30321,
+		missedFields: []string{"metadata"},
+		fetchErr:     errors.New("GET https://api.github.com/...: 403 API rate limit exceeded"),
+	})
+
+	if !strings.Contains(body, "Error:    GET https://api.github.com/...: 403 API rate limit exceeded") {
+		t.Errorf("fetch error missing from report:\n%s", body)
+	}
+	if !strings.Contains(body, "request aborted here") {
+		t.Errorf("report should explain that later fields were never reached:\n%s", body)
+	}
+}
+
+func TestWriteCacheMissLogSkipsCleanRequests(t *testing.T) {
+	if body := readCacheMissLog(t, cacheMissState{
+		owner:  "multimediallc",
+		repo:   "chaturbate",
+		number: 30306,
+	}); body != "" {
+		t.Errorf("nothing missed, but a report was written:\n%s", body)
+	}
+}
+
+func TestGetPRReviewsCachedEmptyIsNotNil(t *testing.T) {
+	const (
+		repo  = "chaturbate"
+		owner = "multimediallc"
+	)
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	// "null" is what rows written before reviews were cached as "[]" hold. Both
+	// spellings must come back as an empty, non-nil slice so callers can tell
+	// "this PR has no reviews" from "reviews were never loaded".
+	for _, cached := range []string{"null", "[]"} {
+		if err := db.UpsertPRReviews(30306, repo, cached); err != nil {
+			t.Fatalf("seeding %q: %v", cached, err)
+		}
+		reviews, err := GetPRReviews(owner, repo, 30306, false)
+		if err != nil {
+			t.Fatalf("GetPRReviews with cached %q: %v", cached, err)
+		}
+		if reviews == nil {
+			t.Errorf("cached %q returned a nil slice; a zero-review PR would be re-fetched from GitHub", cached)
+		}
+		if len(reviews) != 0 {
+			t.Errorf("cached %q returned %d reviews, want 0", cached, len(reviews))
+		}
+	}
+}

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -669,6 +669,10 @@ type cacheMissState struct {
 	number       int
 	skipCache    bool
 	missedFields []string
+	// fetchErr is set when GetPRDetails bailed out on a GitHub API error rather
+	// than on missing cache data. Without it, a failed request lands in the log
+	// looking like an ordinary miss on whichever field it died at.
+	fetchErr error
 	// per-field: true = data was present in DB, false = cache miss
 	metadataHit bool
 	diffHit     bool
@@ -711,15 +715,28 @@ func writeCacheMissLog(state cacheMissState) {
 	now := time.Now().UTC()
 
 	var sb strings.Builder
-	sb.WriteString("=== Cache Miss Report ===\n")
+	// A forced refresh (SyncPR) bypasses every cache on purpose, so its fields
+	// are not misses. Keeping it under a separate header means grepping for
+	// "Cache Miss Report" turns up only the entries worth investigating.
+	if state.skipCache {
+		sb.WriteString("=== Forced Refresh Report ===\n")
+	} else {
+		sb.WriteString("=== Cache Miss Report ===\n")
+	}
 	sb.WriteString(fmt.Sprintf("Time:     %s\n", now.Format("2006-01-02 15:04:05 UTC")))
 	sb.WriteString(fmt.Sprintf("PR:       #%d  (owner: %s, repo: %s)\n", state.number, state.owner, state.repo))
-	sb.WriteString(fmt.Sprintf("Missed:   %s\n", strings.Join(state.missedFields, ", ")))
 	if state.skipCache {
-		sb.WriteString("Forced:   yes (skipCache=true — all caches bypassed)\n")
+		sb.WriteString(fmt.Sprintf("Fetched:  %s\n", strings.Join(state.missedFields, ", ")))
+		sb.WriteString("Forced:   yes (skipCache=true — caches bypassed by request, not missing)\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("Missed:   %s\n", strings.Join(state.missedFields, ", ")))
+	}
+	if state.fetchErr != nil {
+		sb.WriteString(fmt.Sprintf("Error:    %v\n", state.fetchErr))
+		sb.WriteString("          (request aborted here — fields below this point were never reached)\n")
 	}
 
-	sb.WriteString("\nCache State (at time of request):\n")
+	sb.WriteString("\nCache State (before this request):\n")
 	hitStr := func(hit bool) string {
 		if hit {
 			return "HIT"
@@ -773,23 +790,24 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 
 	// Probe all caches upfront to record hit/miss state for the log.
 	// This happens before the existing cache logic so we capture the true pre-fetch state.
+	// The probes run even under skipCache: a forced refresh doesn't consult the
+	// caches, but reporting every field as MISS just because we chose not to
+	// read them tells us nothing about whether the warm path is working.
 	missState := cacheMissState{owner: owner, repo: repo, number: number, skipCache: skipCache}
-	if !skipCache {
-		if v, _ := config.C().DB.GetPRMetadataCache(owner, repo, number); v != "" {
-			missState.metadataHit = true
-		}
-		if v, _, _ := config.C().DB.GetPullRequest(number, repo); v != "" {
-			missState.diffHit = true
-		}
-		if v, _ := config.C().DB.GetPRComments(number, repo); v != "" {
-			missState.commentsHit = true
-		}
-		if v, _ := config.C().DB.GetPRReviews(number, repo); v != "" {
-			missState.reviewsHit = true
-		}
-		if v, _ := config.C().DB.GetPRCommits(number, repo); v != "" {
-			missState.commitsHit = true
-		}
+	if v, _ := config.C().DB.GetPRMetadataCache(owner, repo, number); v != "" {
+		missState.metadataHit = true
+	}
+	if v, _, _ := config.C().DB.GetPullRequest(number, repo); v != "" {
+		missState.diffHit = true
+	}
+	if v, _ := config.C().DB.GetPRComments(number, repo); v != "" {
+		missState.commentsHit = true
+	}
+	if v, _ := config.C().DB.GetPRReviews(number, repo); v != "" {
+		missState.reviewsHit = true
+	}
+	if v, _ := config.C().DB.GetPRCommits(number, repo); v != "" {
+		missState.commitsHit = true
 	}
 	defer func() { writeCacheMissLog(missState) }()
 
@@ -797,6 +815,11 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 	var headSHA string
 	var baseSHA string
 	var reviews []ReviewJSON
+	// Tracked separately from `reviews != nil` because a PR with no reviews
+	// loads as an empty slice — indistinguishable from "never loaded" if we go
+	// by nil-ness, which used to cost a duplicate ListReviews call and a
+	// phantom "reviews" entry in the cache miss log on every fresh fetch.
+	reviewsLoaded := false
 	needsFreshFetch := skipCache
 
 	// 1. Try to load metadata from cache first (unless skipCache)
@@ -825,7 +848,9 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 			// If we have cached data, return that instead of failing
 			if metadata.Number != 0 {
 				slog.Warn("GitHub API error, falling back to cached metadata", "error", err)
+				missState.fetchErr = err
 			} else {
+				missState.fetchErr = err
 				return nil, err
 			}
 		} else {
@@ -851,7 +876,9 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 			}
 
 			// Fetch reviews (with caching)
-			reviews, _ = GetPRReviews(owner, repo, number, skipCache)
+			var reviewsErr error
+			reviews, reviewsErr = GetPRReviews(owner, repo, number, skipCache)
+			reviewsLoaded = reviewsErr == nil
 
 			approvedBy := []string{}
 			changesRequestedBy := []string{}
@@ -1066,7 +1093,7 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 	commentJSONs, outdatedCommentJSONs := splitComments(comments)
 
 	// 5. Load Reviews (with caching)
-	if reviews == nil {
+	if !reviewsLoaded {
 		if !missState.reviewsHit {
 			missState.missedFields = append(missState.missedFields, "reviews")
 		}
@@ -2045,6 +2072,10 @@ func GetPRReviews(owner, repo string, number int, skipCache bool) ([]ReviewJSON,
 			if err := json.Unmarshal([]byte(cachedReviewsJSON), &reviews); err != nil {
 				slog.Error("Error unmarshaling cached reviews", "error", err)
 			} else {
+				if reviews == nil {
+					// Rows written before reviews were cached as "[]" hold "null".
+					reviews = []ReviewJSON{}
+				}
 				return reviews, nil
 			}
 		}
@@ -2056,7 +2087,9 @@ func GetPRReviews(owner, repo string, number int, skipCache bool) ([]ReviewJSON,
 		return nil, err
 	}
 
-	var reviews []ReviewJSON
+	// Non-nil so a PR with no reviews serializes as "[]" instead of "null", and
+	// so callers can tell "loaded, none found" from "not loaded".
+	reviews := []ReviewJSON{}
 	for _, r := range ghReviews {
 		var submittedAt time.Time
 		if r.SubmittedAt != nil {

--- a/workflows/cache_warm_test.go
+++ b/workflows/cache_warm_test.go
@@ -72,3 +72,54 @@ func TestPRNeedsCacheWarm(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyCacheWarmRequirements(t *testing.T) {
+	const (
+		prNumber = 100
+		repo     = "code-review-server"
+	)
+	key := PRKey{Owner: "owner", Repo: repo, Number: prNumber}
+
+	t.Run("warms every field GetPRDetails reads", func(t *testing.T) {
+		db := warmTestDB(t)
+		prObjects := map[PRKey]*github.PullRequest{key: prWithHeadSHA("sha1")}
+		reqs := map[PRKey]AuxDataRequirement{}
+
+		applyCacheWarmRequirements(db, prObjects, reqs)
+
+		got := reqs[key]
+		// Reviews and comments especially: a draft or closed PR gets no other
+		// chance at a PRReviews row, and that shows up as a "reviews" miss.
+		want := AuxDataRequirement{Diff: true, Commits: true, Reviews: true, Comments: true}
+		if got != want {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("preserves requirements the filters already asked for", func(t *testing.T) {
+		db := warmTestDB(t)
+		prObjects := map[PRKey]*github.PullRequest{key: prWithHeadSHA("sha1")}
+		reqs := map[PRKey]AuxDataRequirement{key: {CIStatus: true}}
+
+		applyCacheWarmRequirements(db, prObjects, reqs)
+
+		if !reqs[key].CIStatus {
+			t.Error("cache warm cleared a requirement set by the workflow's filters")
+		}
+	})
+
+	t.Run("leaves an unchanged PR alone", func(t *testing.T) {
+		db := warmTestDB(t)
+		if err := db.UpsertPullRequest(prNumber, repo, "sha1", "", "cached diff"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		prObjects := map[PRKey]*github.PullRequest{key: prWithHeadSHA("sha1")}
+		reqs := map[PRKey]AuxDataRequirement{}
+
+		applyCacheWarmRequirements(db, prObjects, reqs)
+
+		if got := reqs[key]; got != (AuxDataRequirement{}) {
+			t.Errorf("unchanged PR should not be warmed, got %+v", got)
+		}
+	})
+}

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -655,6 +655,17 @@ func (ms *ManagerService) Initialize() {
 	}
 }
 
+// prefetchConcurrency caps how many PRs have their aux data fetched at once.
+// Each PR fans out to as many as six concurrent GitHub calls, so an unbounded
+// loop over a repo's open PR list (up to 200, see git_tools.GetPRs) can put
+// well over a thousand requests in flight simultaneously. GitHub answers that
+// with secondary rate-limit errors, and every call that fails silently leaves
+// its cache row unwritten — which is what a later "reviews: MISS" in
+// ~/.crs/cache_miss.log looks like from the outside. Keeping a lid on the
+// fan-out costs wall-clock time in the background cycle but makes the writes
+// land.
+const prefetchConcurrency = 8
+
 // prefetchAuxData gathers auxiliary data for all PRs that need it
 func (ms ManagerService) prefetchAuxData(client *github.Client,
 	apiCalls *apiCallCounter,
@@ -711,25 +722,11 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 		}
 	}
 
-	// Warm the diff + commits caches whenever a PR is newly added or its head
-	// commit changed. These two fields are the ones a reviewer needs to open the
-	// PR, and both go stale on every push (the diff is keyed to the head SHA).
-	// If we only fetched what a section's filters strictly require, a freshly
-	// added or just-updated PR would be a guaranteed cache miss the moment the
-	// user opened it. We deliberately gate this on an actual change — we do NOT
-	// pre-fetch diffs for unchanged PRs we may never look at.
-	db := config.C().DB
-	for key, pr := range prObjects {
-		if prNeedsCacheWarm(db, key, pr) {
-			req := prRequirements[key]
-			req.Diff = true
-			req.Commits = true
-			prRequirements[key] = req
-		}
-	}
+	applyCacheWarmRequirements(config.C().DB, prObjects, prRequirements)
 
-	// Fetch aux data in parallel
+	// Fetch aux data in parallel, but bounded (see prefetchConcurrency).
 	var wg sync.WaitGroup
+	sem := make(chan struct{}, prefetchConcurrency)
 	for key, auxReq := range prRequirements {
 		// Skip if no aux data is needed
 		if !auxReq.Comments && !auxReq.CIStatus && !auxReq.Diff && !auxReq.Reviews && !auxReq.Commits {
@@ -739,6 +736,8 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 		wg.Add(1)
 		go func(key PRKey, auxReq AuxDataRequirement, pr *github.PullRequest) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			auxData := fetchAuxDataForPR(client, apiCalls, key, auxReq, pr)
 			store.Set(key, auxData)
 		}(key, auxReq, prObjects[key])
@@ -749,8 +748,37 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 	return store
 }
 
-// prNeedsCacheWarm reports whether we should proactively fetch the diff and
-// commits for a PR because it was just added or updated. It returns true when:
+// applyCacheWarmRequirements turns on the aux fields a reviewer needs to open a
+// PR for every PR that was newly added or just pushed to. Those fields all go
+// stale on a push (the diff is keyed to the head SHA) and all of them are read
+// by GetPRDetails, so if we only fetched what a section's filters strictly
+// require, a freshly added or just-updated PR would be a guaranteed cache miss
+// the moment the user opened it. The warm is gated on an actual change — we do
+// NOT pre-fetch for unchanged PRs we may never look at.
+//
+// Reviews and comments are included even though prefetchAuxData separately
+// forces Reviews on for open non-draft PRs: that override skips drafts and
+// closed PRs, so without this pass those PRs never get a PRReviews row written
+// by a workflow and every open of one logs a "reviews" cache miss.
+func applyCacheWarmRequirements(db *database.DB,
+	prObjects map[PRKey]*github.PullRequest,
+	prRequirements map[PRKey]AuxDataRequirement) {
+
+	for key, pr := range prObjects {
+		if !prNeedsCacheWarm(db, key, pr) {
+			continue
+		}
+		req := prRequirements[key]
+		req.Diff = true
+		req.Commits = true
+		req.Reviews = true
+		req.Comments = true
+		prRequirements[key] = req
+	}
+}
+
+// prNeedsCacheWarm reports whether we should proactively warm the caches for a
+// PR because it was just added or updated. It returns true when:
 //   - the PR is brand new to us (no diff row cached yet),
 //   - its head SHA changed since we last cached it (new commits pushed), or
 //   - we only have a SHA-only placeholder row with no real diff body (e.g. an
@@ -878,7 +906,10 @@ func fetchAuxDataForPR(client *github.Client,
 			reviews, _, err := client.PullRequests.ListReviews(
 				context.Background(), key.Owner, key.Repo, key.Number, nil)
 			if err != nil {
-				slog.Warn("Failed to fetch reviews for pre-fetch", "pr", key.Number, "error", err)
+				// Nothing gets written to PRReviews when this fails, so the next
+				// time the UI opens this PR it logs a "reviews" cache miss.
+				slog.Warn("Failed to fetch reviews for pre-fetch, PRReviews cache left unwritten",
+					"pr", key.Number, "repo", key.Repo, "error", err)
 				return
 			}
 			ghReviews = reviews
@@ -985,7 +1016,10 @@ func persistPRCacheData(key PRKey, pr *github.PullRequest,
 			SubmittedAt time.Time `json:"submitted_at"`
 			HTMLURL     string    `json:"html_url"`
 		}
-		var rvs []reviewJSON
+		// Start from an empty (non-nil) slice so a PR with no reviews caches as
+		// "[]" rather than "null". Readers unmarshal "null" back into a nil
+		// slice, which is indistinguishable from "not loaded yet".
+		rvs := []reviewJSON{}
 		for _, r := range reviews {
 			var submittedAt time.Time
 			if r.SubmittedAt != nil {

--- a/workflows/workflows.go
+++ b/workflows/workflows.go
@@ -250,6 +250,7 @@ func prefetchAuxDataForPRs(client *github.Client, owner, repo string, prs []*git
 	}
 	apiCalls := &apiCallCounter{}
 	var wg sync.WaitGroup
+	sem := make(chan struct{}, prefetchConcurrency)
 	for _, pr := range prs {
 		if pr == nil || pr.Number == nil {
 			continue
@@ -257,6 +258,8 @@ func prefetchAuxDataForPRs(client *github.Client, owner, repo string, prs []*git
 		wg.Add(1)
 		go func(pr *github.PullRequest) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			key := PRKey{Owner: owner, Repo: repo, Number: *pr.Number}
 			data := fetchAuxDataForPR(client, apiCalls, key, auxReq, pr)
 			store.Set(key, data)


### PR DESCRIPTION
## Summary

This change improves cache miss diagnostics and fixes a subtle bug where PRs with no reviews would be re-fetched on every access. It also adds concurrency limits to background prefetch operations to prevent GitHub secondary rate-limit errors.

### Changes

- **Cache miss logging improvements:**
  - Separate "Forced Refresh Report" from "Cache Miss Report" so forced refreshes (SyncPR) don't pollute cache miss diagnostics
  - Report actual cache state even under `skipCache`, so forced refreshes show which fields were genuinely present vs. absent
  - Add error reporting to cache miss logs when GitHub API errors occur, with a note that later fields were never reached
  - Skip writing cache miss logs entirely for clean requests with no misses

- **Reviews cache handling fix:**
  - Initialize reviews as empty non-nil slice (`[]ReviewJSON{}`) instead of nil, so a PR with zero reviews is distinguishable from "reviews never loaded"
  - Unmarshal cached "null" values (from rows written before reviews were cached) back into empty slices
  - Track `reviewsLoaded` separately from `reviews != nil` to avoid duplicate ListReviews calls and phantom "reviews" cache misses

- **Concurrency limiting:**
  - Add `prefetchConcurrency` constant (8) to cap concurrent GitHub API calls during background prefetch
  - Apply semaphore-based rate limiting in both `manager.go` and `workflows.go` to prevent secondary rate-limit errors
  - Update log message when reviews prefetch fails to clarify that the cache row remains unwritten

- **Cache warm improvements:**
  - Extract `applyCacheWarmRequirements()` function to centralize cache warming logic
  - Ensure drafts and closed PRs get Reviews and Comments cached (previously only open non-drafts got Reviews)
  - Add comprehensive tests for cache warming behavior

### Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- Added `cache_miss_test.go` with tests for:
  - Forced refresh separation from cache miss reports
  - Fetch error reporting in logs
  - Skipping logs for clean requests
  - Reviews cache handling for empty and null values
- Added `TestApplyCacheWarmRequirements` to verify cache warming covers all required fields

https://claude.ai/code/session_011XteBEReRyjMjAmMHQmfGo