### PR TITLE
Add plugin response contract for structured output and annotations

### DIFF
--- a/bun_client/frontend/src/components/PluginAnnotations.tsx
+++ b/bun_client/frontend/src/components/PluginAnnotations.tsx
@@ -1,0 +1,78 @@
+import { Badge } from '../design';
+import { annotationSeverityVariant, type PluginAnnotation } from '../plugin_utils';
+
+interface PluginAnnotationsProps {
+    annotations: PluginAnnotation[];
+    /** Called when an annotation is clicked, e.g. to jump to the line in the diff. */
+    onSelect?: (annotation: PluginAnnotation) => void;
+}
+
+/**
+ * Lists a plugin's line-level annotations beneath its body. Rendering these
+ * inline in the diff is separate follow-up work; this is the flat view on the
+ * plugin output surfaces.
+ */
+export default function PluginAnnotations({ annotations, onSelect }: PluginAnnotationsProps) {
+    if (annotations.length === 0) return null;
+
+    return (
+        <div
+            style={{
+                borderTop: '1px solid var(--border)',
+                padding: '12px 16px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '8px',
+            }}
+        >
+            <div
+                style={{
+                    fontSize: '11px',
+                    fontWeight: 600,
+                    letterSpacing: '0.04em',
+                    textTransform: 'uppercase',
+                    color: 'var(--text-secondary)',
+                }}
+            >
+                {annotations.length} annotation{annotations.length === 1 ? '' : 's'}
+            </div>
+            {annotations.map((annotation, i) => (
+                <div
+                    key={`${annotation.filename}:${annotation.line}:${i}`}
+                    onClick={onSelect ? () => onSelect(annotation) : undefined}
+                    style={{
+                        display: 'flex',
+                        gap: '10px',
+                        alignItems: 'baseline',
+                        fontSize: '13px',
+                        lineHeight: '1.5',
+                        cursor: onSelect ? 'pointer' : 'default',
+                    }}
+                >
+                    {annotation.severity && (
+                        <Badge
+                            variant={annotationSeverityVariant(annotation.severity)}
+                            size="sm"
+                            pill
+                        >
+                            {annotation.severity}
+                        </Badge>
+                    )}
+                    <span
+                        style={{
+                            fontFamily: 'var(--font-mono)',
+                            fontSize: '12px',
+                            color: 'var(--accent)',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {annotation.filename}:{annotation.line}
+                    </span>
+                    <span style={{ color: 'var(--text-primary)', wordBreak: 'break-word' }}>
+                        {annotation.content}
+                    </span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/bun_client/frontend/src/components/PluginBodyView.tsx
+++ b/bun_client/frontend/src/components/PluginBodyView.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Markdown from 'react-markdown';
+import type { PluginBody } from '../plugin_utils';
+
+interface PluginBodyViewProps {
+    body: PluginBody;
+    /** Rendered when the body has no content. */
+    emptyLabel?: string;
+}
+
+// Theme variables the sandboxed HTML frame inherits from the app, so an HTML
+// body doesn't render as a white box on a dark theme.
+const FRAME_VARS = [
+    '--bg-primary',
+    '--bg-tertiary',
+    '--text-primary',
+    '--text-secondary',
+    '--accent',
+    '--border',
+    '--font-mono',
+];
+
+const MIN_FRAME_HEIGHT = 32;
+const MAX_FRAME_HEIGHT = 600;
+
+function frameCssVars(): string {
+    const styles = getComputedStyle(document.documentElement);
+    return FRAME_VARS.map(name => `${name}:${styles.getPropertyValue(name).trim()};`).join('');
+}
+
+function buildFrameDocument(html: string): string {
+    return `<!doctype html><html><head><meta charset="utf-8"><style>
+:root{${frameCssVars()}}
+html,body{margin:0;padding:0;background:transparent;color:var(--text-primary);
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:14px;line-height:1.6;
+  overflow-wrap:break-word;}
+h1,h2,h3,h4{margin:1em 0 .5em;color:var(--text-primary);}
+h1{font-size:1.4em;}h2{font-size:1.2em;}h3{font-size:1.1em;}
+p{margin:.5em 0;}
+ul,ol{margin:.5em 0;padding-left:1.5em;}
+li{margin:.25em 0;}
+a{color:var(--accent);}
+code{font-family:var(--font-mono);background:var(--bg-tertiary);padding:.15em .4em;border-radius:4px;font-size:.9em;}
+pre{font-family:var(--font-mono);background:var(--bg-tertiary);padding:12px;border-radius:6px;overflow-x:auto;margin:.5em 0;}
+pre code{background:none;padding:0;}
+blockquote{border-left:3px solid var(--accent);margin:.5em 0;padding-left:1em;color:var(--text-secondary);}
+hr{border:none;border-top:1px solid var(--border);margin:1em 0;}
+table{border-collapse:collapse;width:100%;margin:.5em 0;}
+th,td{border:1px solid var(--border);padding:8px;text-align:left;}
+th{background:var(--bg-tertiary);}
+img{max-width:100%;}
+</style></head><body>${html}</body></html>`;
+}
+
+/**
+ * Renders a plugin's HTML body inside a sandboxed frame.
+ *
+ * Plugin bodies are frequently LLM-generated text derived from a PR's diff and
+ * description, so they are not trusted markup. The frame withholds
+ * `allow-scripts`, which blocks script execution and inline event handlers; it
+ * keeps `allow-same-origin` only so the parent can measure the content to size
+ * the frame (harmless with scripting off, since nothing inside can run).
+ */
+function HtmlFrame({ html }: { html: string }) {
+    const frameRef = useRef<HTMLIFrameElement>(null);
+    const [height, setHeight] = useState(MIN_FRAME_HEIGHT);
+    // Re-read the theme's colors whenever the app's theme changes.
+    const [theme, setTheme] = useState(() => document.documentElement.dataset.theme ?? '');
+
+    const srcDoc = useMemo(() => {
+        // `theme` is not read directly: it re-derives the document so the frame
+        // picks up the new theme's variables.
+        void theme;
+        return buildFrameDocument(html);
+    }, [html, theme]);
+
+    useEffect(() => {
+        const observer = new MutationObserver(() =>
+            setTheme(document.documentElement.dataset.theme ?? '')
+        );
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme'],
+        });
+        return () => observer.disconnect();
+    }, []);
+
+    const measure = useCallback(() => {
+        const frame = frameRef.current;
+        const doc = frame?.contentDocument;
+        if (!frame || !doc?.documentElement) return;
+        // A document can't report a height below the frame it lives in, so
+        // collapse the frame before reading: measuring in place would ratchet,
+        // leaving blank space when a re-run produces shorter output.
+        frame.style.height = '0px';
+        const measured = doc.documentElement.scrollHeight;
+        const next = Math.min(Math.max(measured, MIN_FRAME_HEIGHT), MAX_FRAME_HEIGHT);
+        frame.style.height = `${next}px`;
+        setHeight(next);
+    }, []);
+
+    // The frame's content can't resize itself (no scripting), but it does reflow
+    // when the panel around it changes width.
+    useEffect(() => {
+        const frame = frameRef.current;
+        if (!frame || typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(() => measure());
+        observer.observe(frame);
+        return () => observer.disconnect();
+    }, [measure]);
+
+    return (
+        <iframe
+            ref={frameRef}
+            title="Plugin HTML output"
+            sandbox="allow-same-origin"
+            srcDoc={srcDoc}
+            onLoad={measure}
+            style={{
+                display: 'block',
+                width: '100%',
+                height: `${height}px`,
+                border: 'none',
+                background: 'transparent',
+                colorScheme: 'normal',
+            }}
+        />
+    );
+}
+
+/**
+ * Renders the body of a plugin response according to its declared body_type.
+ * Markdown is rendered inline (react-markdown ignores embedded raw HTML); an
+ * `html` body goes through the sandboxed frame above.
+ */
+export default function PluginBodyView({ body, emptyLabel = 'No output' }: PluginBodyViewProps) {
+    if (!body.body_content) {
+        return (
+            <span
+                style={{
+                    color: 'var(--text-secondary)',
+                    fontStyle: 'italic',
+                    fontSize: '14px',
+                }}
+            >
+                {emptyLabel}
+            </span>
+        );
+    }
+
+    if (body.body_type === 'html') {
+        return <HtmlFrame html={body.body_content} />;
+    }
+
+    return <Markdown>{body.body_content}</Markdown>;
+}

--- a/bun_client/frontend/src/components/PluginOutput.tsx
+++ b/bun_client/frontend/src/components/PluginOutput.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
 import { rpcCall } from '../api';
 import { Button, Badge, Card, mapStatusToVariant, Theme } from '../design';
+import { resolvePluginBody, sortedAnnotations, type PluginResult } from '../plugin_utils';
+import PluginAnnotations from './PluginAnnotations';
+import PluginBodyView from './PluginBodyView';
 
 interface PluginOutputProps {
     owner: string;
@@ -9,11 +12,6 @@ interface PluginOutputProps {
     theme: Theme;
     onThemeChange: (theme: Theme) => void;
     onClose?: () => void;
-}
-
-interface PluginResult {
-    result: string;
-    status: string;
 }
 
 interface GetPluginOutputResponse {
@@ -142,6 +140,8 @@ export default function PluginOutput({
                     <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
                         {pluginNames.map(pluginName => {
                             const plugin = pluginOutput[pluginName];
+                            const body = resolvePluginBody(plugin);
+                            const annotations = sortedAnnotations(plugin);
                             return (
                                 <Card
                                     key={pluginName}
@@ -172,6 +172,12 @@ export default function PluginOutput({
                                         >
                                             {pluginName}
                                         </span>
+                                        {annotations.length > 0 && (
+                                            <Badge variant="info" size="sm" pill>
+                                                {annotations.length} annotation
+                                                {annotations.length === 1 ? '' : 's'}
+                                            </Badge>
+                                        )}
                                         {plugin.status.toLowerCase() === 'deferred' && (
                                             <Button
                                                 onClick={() => executePlugin(pluginName)}
@@ -184,38 +190,19 @@ export default function PluginOutput({
                                         )}
                                     </div>
                                     <div
+                                        className="markdown-content"
                                         style={{
                                             padding: '16px',
                                             maxHeight: '400px',
                                             overflowY: 'auto',
+                                            fontSize: '14px',
+                                            lineHeight: '1.6',
+                                            color: 'var(--text-primary)',
                                         }}
                                     >
-                                        {plugin.result ? (
-                                            <pre
-                                                style={{
-                                                    margin: 0,
-                                                    fontSize: '13px',
-                                                    lineHeight: '1.5',
-                                                    fontFamily: 'var(--font-mono)',
-                                                    whiteSpace: 'pre-wrap',
-                                                    wordBreak: 'break-word',
-                                                    color: 'var(--text-primary)',
-                                                }}
-                                            >
-                                                {plugin.result}
-                                            </pre>
-                                        ) : (
-                                            <div
-                                                style={{
-                                                    color: 'var(--text-secondary)',
-                                                    fontStyle: 'italic',
-                                                    fontSize: '14px',
-                                                }}
-                                            >
-                                                No output
-                                            </div>
-                                        )}
+                                        <PluginBodyView body={body} />
                                     </div>
+                                    <PluginAnnotations annotations={annotations} />
                                 </Card>
                             );
                         })}

--- a/bun_client/frontend/src/components/review/PluginsPanel.tsx
+++ b/bun_client/frontend/src/components/review/PluginsPanel.tsx
@@ -1,5 +1,7 @@
-import Markdown from 'react-markdown';
 import { Button, colors, shadows } from '../../design';
+import { resolvePluginBody, sortedAnnotations } from '../../plugin_utils';
+import PluginAnnotations from '../PluginAnnotations';
+import PluginBodyView from '../PluginBodyView';
 import type { PluginResult } from './types';
 
 interface PluginsPanelProps {
@@ -157,19 +159,12 @@ export default function PluginsPanel({
                                             background: 'var(--bg-primary)',
                                         }}
                                     >
-                                        {data.result ? (
-                                            <Markdown>{data.result}</Markdown>
-                                        ) : (
-                                            <span
-                                                style={{
-                                                    color: 'var(--text-secondary)',
-                                                    fontStyle: 'italic',
-                                                }}
-                                            >
-                                                No output produced.
-                                            </span>
-                                        )}
+                                        <PluginBodyView
+                                            body={resolvePluginBody(data)}
+                                            emptyLabel="No output produced."
+                                        />
                                     </div>
+                                    <PluginAnnotations annotations={sortedAnnotations(data)} />
                                 </div>
                             ))}
                         </div>

--- a/bun_client/frontend/src/components/review/types.ts
+++ b/bun_client/frontend/src/components/review/types.ts
@@ -1,4 +1,5 @@
 import { colors } from '../../design';
+import type { PRAnnotation } from '../../plugin_utils';
 
 // Above this many changed lines in a single file, the diff renders that file
 // without per-line syntax highlighting to avoid thousands of Prism instances.
@@ -34,10 +35,15 @@ export interface ReviewData {
     html_url: string;
 }
 
-export interface PluginResult {
-    result: string;
-    status: string;
-}
+// The plugin response contract lives in plugin_utils, alongside the helpers
+// that interpret it; re-exported here so review components have one import.
+export type {
+    PluginAnnotation,
+    PluginBody,
+    PluginBodyType,
+    PluginResult,
+    PRAnnotation,
+} from '../../plugin_utils';
 
 export interface PRMetadata {
     number: number;
@@ -71,6 +77,10 @@ export interface PRResponse {
     reviews: ReviewData[];
     metadata: PRMetadata;
     feedback: string;
+    // Annotations from every plugin that has already run for this PR, each
+    // tagged with its source plugin. Rendering these into the diff is follow-up
+    // work; the plugin surfaces read annotations from GetPluginOutput today.
+    annotations?: PRAnnotation[];
     // Only set by SyncPR: true when the sync pulled in a new head SHA or new comments.
     updated?: boolean;
 }

--- a/bun_client/frontend/src/plugin_utils.test.ts
+++ b/bun_client/frontend/src/plugin_utils.test.ts
@@ -1,0 +1,151 @@
+import { expect, test, describe } from 'bun:test';
+import {
+    annotationSeverityVariant,
+    resolvePluginBody,
+    sortedAnnotations,
+    totalAnnotationCount,
+} from './plugin_utils';
+import type { PluginResult } from './plugin_utils';
+
+describe('resolvePluginBody', () => {
+    test('uses the parsed markdown body when the server sends one', () => {
+        const plugin: PluginResult = {
+            result: '{"body":{"body_type":"markdown","body_content":"# Summary"}}',
+            status: 'success',
+            body: { body_type: 'markdown', body_content: '# Summary' },
+        };
+        expect(resolvePluginBody(plugin)).toEqual({
+            body_type: 'markdown',
+            body_content: '# Summary',
+        });
+    });
+
+    test('uses the parsed html body when the server sends one', () => {
+        const plugin: PluginResult = {
+            result: 'raw',
+            status: 'success',
+            body: { body_type: 'html', body_content: '<p>hi</p>' },
+        };
+        expect(resolvePluginBody(plugin)).toEqual({
+            body_type: 'html',
+            body_content: '<p>hi</p>',
+        });
+    });
+
+    test('falls back to the raw result as markdown when no body is present', () => {
+        // A server predating the response contract only sends result/status.
+        const plugin: PluginResult = { result: 'plain text summary', status: 'success' };
+        expect(resolvePluginBody(plugin)).toEqual({
+            body_type: 'markdown',
+            body_content: 'plain text summary',
+        });
+    });
+
+    test('falls back to the raw result when body_type is unrecognized', () => {
+        const plugin = {
+            result: 'plain text summary',
+            status: 'success',
+            body: { body_type: 'plaintext', body_content: 'ignored' },
+        } as unknown as PluginResult;
+        expect(resolvePluginBody(plugin)).toEqual({
+            body_type: 'markdown',
+            body_content: 'plain text summary',
+        });
+    });
+
+    test('normalizes body_type casing', () => {
+        const plugin = {
+            result: '',
+            status: 'success',
+            body: { body_type: 'HTML', body_content: '<b>x</b>' },
+        } as unknown as PluginResult;
+        expect(resolvePluginBody(plugin).body_type).toBe('html');
+    });
+
+    test('keeps an empty body when the plugin only produced annotations', () => {
+        // An annotations-only plugin's raw result is the contract JSON, which
+        // must not leak into the rendered body.
+        const plugin: PluginResult = {
+            result: '{"body":{"body_type":"markdown","body_content":""},"annotations":[]}',
+            status: 'success',
+            body: { body_type: 'markdown', body_content: '' },
+            annotations: [{ filename: 'a.py', line: 4, severity: 'warning', content: 'x' }],
+        };
+        expect(resolvePluginBody(plugin).body_content).toBe('');
+    });
+
+    test('handles a pending plugin with no output at all', () => {
+        const plugin: PluginResult = { result: '', status: 'pending' };
+        expect(resolvePluginBody(plugin)).toEqual({ body_type: 'markdown', body_content: '' });
+    });
+});
+
+describe('sortedAnnotations', () => {
+    test('groups by filename then orders by line', () => {
+        const plugin: PluginResult = {
+            result: '',
+            status: 'success',
+            body: { body_type: 'markdown', body_content: '' },
+            annotations: [
+                { filename: 'b.py', line: 2, severity: 'info', content: 'b2' },
+                { filename: 'a.py', line: 75, severity: 'warning', content: 'a75' },
+                { filename: 'a.py', line: 7, severity: 'error', content: 'a7' },
+            ],
+        };
+        expect(sortedAnnotations(plugin).map(a => `${a.filename}:${a.line}`)).toEqual([
+            'a.py:7',
+            'a.py:75',
+            'b.py:2',
+        ]);
+    });
+
+    test('returns an empty list when annotations are absent', () => {
+        expect(sortedAnnotations({ result: 'x', status: 'success' })).toEqual([]);
+    });
+
+    test('does not mutate the original array', () => {
+        const annotations = [
+            { filename: 'z.py', line: 1, severity: '', content: 'z' },
+            { filename: 'a.py', line: 1, severity: '', content: 'a' },
+        ];
+        sortedAnnotations({ result: '', status: 'success', annotations });
+        expect(annotations[0].filename).toBe('z.py');
+    });
+});
+
+describe('annotationSeverityVariant', () => {
+    test('maps known severities', () => {
+        expect(annotationSeverityVariant('error')).toBe('danger');
+        expect(annotationSeverityVariant('CRITICAL')).toBe('danger');
+        expect(annotationSeverityVariant('warning')).toBe('warning');
+        expect(annotationSeverityVariant('warn')).toBe('warning');
+        expect(annotationSeverityVariant('info')).toBe('info');
+        expect(annotationSeverityVariant('note')).toBe('info');
+    });
+
+    test('falls back to neutral for free-form severities', () => {
+        expect(annotationSeverityVariant('nitpick')).toBe('neutral');
+        expect(annotationSeverityVariant('')).toBe('neutral');
+    });
+});
+
+describe('totalAnnotationCount', () => {
+    test('sums annotations across plugins and ignores plugins without any', () => {
+        const plugins: Record<string, PluginResult> = {
+            linter: {
+                result: '',
+                status: 'success',
+                annotations: [
+                    { filename: 'a.py', line: 1, severity: 'error', content: 'x' },
+                    { filename: 'a.py', line: 2, severity: 'error', content: 'y' },
+                ],
+            },
+            summarizer: { result: 'text', status: 'success' },
+        };
+        expect(totalAnnotationCount(plugins)).toBe(2);
+    });
+
+    test('is zero with no plugins', () => {
+        expect(totalAnnotationCount({})).toBe(0);
+    });
+});

--- a/bun_client/frontend/src/plugin_utils.ts
+++ b/bun_client/frontend/src/plugin_utils.ts
@@ -1,0 +1,96 @@
+/**
+ * Plugin response contract
+ *
+ * A plugin's stdout may be plain text, or JSON declaring how its body should be
+ * rendered plus line-level annotations on the diff (see docs/plugins.md). The
+ * server parses that contract and serves both the raw stdout (`result`) and the
+ * parsed `body` / `annotations` alongside it. The helpers here are the client's
+ * single interpretation of those fields.
+ */
+
+import type { StatusVariant } from './design';
+
+export type PluginBodyType = 'markdown' | 'html';
+
+export interface PluginBody {
+    body_type: PluginBodyType;
+    body_content: string;
+}
+
+export interface PluginAnnotation {
+    filename: string;
+    line: number;
+    severity: string;
+    content: string;
+}
+
+export interface PluginResult {
+    /** Raw captured stdout of the plugin, unchanged. */
+    result: string;
+    status: string;
+    /** Parsed body. Absent when talking to a server predating the contract. */
+    body?: PluginBody;
+    /** Diff annotations declared by the plugin; absent or empty for plain output. */
+    annotations?: PluginAnnotation[];
+}
+
+/** A plugin annotation as it arrives on a PR payload, tagged with its source plugin. */
+export interface PRAnnotation extends PluginAnnotation {
+    plugin: string;
+}
+
+/**
+ * Resolve which body to render for a plugin result.
+ *
+ * A server that speaks the contract always sends a body, and we trust it — an
+ * empty body_content with annotations attached is a legitimate response from an
+ * annotations-only plugin. Only when the body is missing or carries an
+ * unrecognized type do we fall back to rendering the raw stdout as markdown,
+ * which is what clients did before the contract existed.
+ */
+export function resolvePluginBody(plugin: PluginResult): PluginBody {
+    const bodyType = (plugin.body?.body_type || '').toLowerCase();
+    if (bodyType === 'markdown' || bodyType === 'html') {
+        return { body_type: bodyType, body_content: plugin.body?.body_content ?? '' };
+    }
+    return { body_type: 'markdown', body_content: plugin.result || '' };
+}
+
+/**
+ * Annotations of a plugin result in display order: grouped by file, then by
+ * ascending line number. Annotations that can't be anchored to a line are
+ * dropped by the server, so anything here has a filename and a line.
+ */
+export function sortedAnnotations(plugin: PluginResult): PluginAnnotation[] {
+    return [...(plugin.annotations ?? [])].sort(
+        (a, b) => a.filename.localeCompare(b.filename) || a.line - b.line
+    );
+}
+
+/**
+ * Badge variant for an annotation's severity. Severity is free-form in the
+ * contract, so unrecognized values render as neutral rather than being hidden.
+ */
+export function annotationSeverityVariant(severity: string): StatusVariant {
+    switch (severity.toLowerCase()) {
+        case 'error':
+        case 'critical':
+        case 'high':
+            return 'danger';
+        case 'warning':
+        case 'warn':
+        case 'medium':
+            return 'warning';
+        case 'info':
+        case 'note':
+        case 'low':
+            return 'info';
+        default:
+            return 'neutral';
+    }
+}
+
+/** Total number of annotations across every plugin, for summary counts. */
+export function totalAnnotationCount(plugins: Record<string, PluginResult>): number {
+    return Object.values(plugins).reduce((sum, p) => sum + (p.annotations?.length ?? 0), 0);
+}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -118,6 +118,12 @@ so existing plugins keep working unchanged. The raw stdout is always stored and 
 
 Annotations from every successfully executed plugin for a PR are also aggregated into the `annotations` field of the `GetPR` response (each tagged with the plugin's name), so clients can render them into the diff.
 
+### Rendering in the Web Client
+
+The web client renders a `markdown` body as markdown and an `html` body inside a sandboxed frame that inherits the current theme. The frame withholds `allow-scripts`, so scripts and inline event handlers in a plugin's HTML never execute — plugin bodies are often LLM-generated text derived from a PR's diff and description, which is not trusted markup.
+
+Annotations are listed beneath each plugin's body on both the plugin output page and the review view's plugin drawer, sorted by file and line. Rendering them inline in the diff is separate work.
+
 ## On-Demand Plugins
 
 By default, all configured plugins automatically run when a PR is fetched or when its commit changes (once per SHA). However, some plugins can be expensive to run (e.g., those making API calls to third-party services like Gemini or Claude).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -70,6 +70,54 @@ The `example_plugin` included in this repository demonstrates the interface and 
 
 When your plugin runs, its standard output (stdout) is captured and stored in the database. Clients can then retrieve and display this output when you are reviewing a PR. For example, in the web client, plugin outputs appear in a dedicated "Plugins" section for each PR.
 
+## Plugin Response Contract
+
+A plugin's stdout can be plain text, but a plugin may instead emit a JSON document matching the response contract. This lets it declare how its body should be rendered and attach line-level annotations to the PR diff:
+
+```json
+{
+  "body": {
+    "body_type": "markdown",
+    "body_content": "This is the response."
+  },
+  "annotations": [
+    {"filename": "test.py", "line": 75, "severity": "warning", "content": "this line looks wrong"}
+  ]
+}
+```
+
+### `body` Object
+
+| Field          | Type   | Description                                  |
+|----------------|--------|----------------------------------------------|
+| `body_type`    | string | Either `markdown` or `html` (case-insensitive) |
+| `body_content` | string | The renderable output of the plugin          |
+
+### `annotations` List (optional)
+
+Each annotation anchors a remark to a line of a file in the PR:
+
+| Field      | Type   | Description                                                  |
+|------------|--------|--------------------------------------------------------------|
+| `filename` | string | Path of the file within the repo (required)                  |
+| `line`     | int    | 1-based line number the annotation applies to (required)     |
+| `severity` | string | Free-form severity, e.g. `info`, `warning`, `error`          |
+| `content`  | string | The annotation text                                          |
+
+Annotations without a `filename` or a positive `line` are dropped, since they can't be anchored to the diff.
+
+### Backwards Compatibility
+
+Output that doesn't match the contract — plain text, invalid JSON, JSON without a `body` object, or an unknown `body_type` — is treated as legacy output and wrapped as:
+
+```json
+{"body": {"body_type": "markdown", "body_content": "<the raw output, verbatim>"}, "annotations": []}
+```
+
+so existing plugins keep working unchanged. The raw stdout is always stored and returned as-is in the `result` field of `GetPluginOutput`; parsing happens when results are served to clients.
+
+Annotations from every successfully executed plugin for a PR are also aggregated into the `annotations` field of the `GetPR` response (each tagged with the plugin's name), so clients can render them into the diff.
+
 ## On-Demand Plugins
 
 By default, all configured plugins automatically run when a PR is fetched or when its commit changes (once per SHA). However, some plugins can be expensive to run (e.g., those making API calls to third-party services like Gemini or Claude).

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -97,6 +97,17 @@ Fetches a pull request from GitHub and returns it as rendered content (including
 | `comments` | []CommentJSON| List of structured PR active comments           |
 | `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
 | `reviews`  | []ReviewJSON | List of submitted reviews                       |
+| `annotations` | []PRAnnotation | Diff annotations aggregated from every plugin that has already executed successfully for this PR (see [Plugins](plugins.md#plugin-response-contract)) |
+
+#### PRAnnotation Object
+
+| Field      | Type   | Description                                              |
+|------------|--------|----------------------------------------------------------|
+| `plugin`   | string | Name of the plugin that produced the annotation          |
+| `filename` | string | Path of the file within the repo                         |
+| `line`     | int    | 1-based line number the annotation applies to            |
+| `severity` | string | Free-form severity, e.g. `info`, `warning`, `error`      |
+| `content`  | string | The annotation text                                      |
 
 #### PRMetadata Object
 
@@ -498,13 +509,29 @@ Retrieves the output and status of all plugins for a specific pull request.
 **Reply** (`GetPluginOutputReply`):
 | Field    | Type                        | Description                                            |
 |----------|-----------------------------|--------------------------------------------------------|
-| `output` | map[string]PluginResult     | Map of plugin names to their respective results/status |
+| `output` | map[string]PluginOutput     | Map of plugin names to their respective results/status |
 
-#### `PluginResult` Object
-| Field    | Type   | Description                                                          |
-|----------|--------|----------------------------------------------------------------------|
-| `result` | string | The captured output (stdout/stderr) of the plugin                    |
-| `status` | string | Execution status: `pending`, `success`, or `error`                   |
+#### `PluginOutput` Object
+| Field         | Type         | Description                                                                       |
+|---------------|--------------|-----------------------------------------------------------------------------------|
+| `result`      | string       | The raw captured stdout of the plugin, unchanged (kept for older clients)          |
+| `status`      | string       | Execution status: `pending`, `success`, `error`, or `deferred`                     |
+| `body`        | PluginBody   | The plugin's output parsed against the [response contract](plugins.md#plugin-response-contract); non-conforming output is wrapped as a `markdown` body holding the raw output |
+| `annotations` | []Annotation | Line-level diff annotations declared by the plugin (empty for legacy output)       |
+
+#### `PluginBody` Object
+| Field          | Type   | Description                            |
+|----------------|--------|----------------------------------------|
+| `body_type`    | string | Either `markdown` or `html`            |
+| `body_content` | string | The renderable output of the plugin    |
+
+#### `Annotation` Object
+| Field      | Type   | Description                                          |
+|------------|--------|------------------------------------------------------|
+| `filename` | string | Path of the file within the repo                     |
+| `line`     | int    | 1-based line number the annotation applies to        |
+| `severity` | string | Free-form severity, e.g. `info`, `warning`, `error`  |
+| `content`  | string | The annotation text                                  |
 
 ---
 

--- a/server/plugin_contract.go
+++ b/server/plugin_contract.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"crs/config"
+	"crs/database"
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// Plugin response contract
+//
+// Plugins historically wrote free-form text to stdout and clients rendered it
+// verbatim. A plugin may now instead emit a JSON document matching the
+// contract below, which lets it declare how its body should be rendered and
+// attach line-level annotations to the PR diff:
+//
+//	{
+//	  "body": {
+//	    "body_type": "markdown",
+//	    "body_content": "This is the response."
+//	  },
+//	  "annotations": [
+//	    {"filename": "test.py", "line": 75, "severity": "warning", "content": "this line looks wrong"}
+//	  ]
+//	}
+//
+// Output that does not match the contract — non-JSON output, JSON without a
+// body object, or an unknown body_type — is treated as legacy output and
+// wrapped as {"body_type": "markdown", "body_content": <raw output>} with no
+// annotations, so existing plugins keep working unchanged.
+
+const (
+	BodyTypeMarkdown = "markdown"
+	BodyTypeHTML     = "html"
+)
+
+// PluginBody is the renderable portion of a plugin response.
+type PluginBody struct {
+	// BodyType is either "markdown" or "html".
+	BodyType    string `json:"body_type"`
+	BodyContent string `json:"body_content"`
+}
+
+// PluginAnnotation anchors a plugin remark to a line of a file in the PR.
+// Filename and Line are required for an annotation to be kept; Severity and
+// Content are free-form.
+type PluginAnnotation struct {
+	Filename string `json:"filename"`
+	Line     int    `json:"line"`
+	Severity string `json:"severity"`
+	Content  string `json:"content"`
+}
+
+// PluginResponse is the parsed form of a plugin's stdout.
+type PluginResponse struct {
+	Body        PluginBody         `json:"body"`
+	Annotations []PluginAnnotation `json:"annotations"`
+}
+
+// rawPluginResponse mirrors PluginResponse with a pointer body so parsing can
+// tell "no body key" apart from an empty one.
+type rawPluginResponse struct {
+	Body        *PluginBody        `json:"body"`
+	Annotations []PluginAnnotation `json:"annotations"`
+}
+
+// ParsePluginOutput parses raw plugin stdout against the response contract.
+// Output that doesn't conform is returned whole as a markdown body with no
+// annotations. Annotations missing a filename or a positive line number are
+// dropped, since they can't be anchored to the diff.
+func ParsePluginOutput(raw string) PluginResponse {
+	fallback := PluginResponse{
+		Body:        PluginBody{BodyType: BodyTypeMarkdown, BodyContent: raw},
+		Annotations: []PluginAnnotation{},
+	}
+
+	var parsed rawPluginResponse
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil || parsed.Body == nil {
+		return fallback
+	}
+	bodyType := strings.ToLower(strings.TrimSpace(parsed.Body.BodyType))
+	if bodyType != BodyTypeMarkdown && bodyType != BodyTypeHTML {
+		return fallback
+	}
+
+	response := PluginResponse{
+		Body:        PluginBody{BodyType: bodyType, BodyContent: parsed.Body.BodyContent},
+		Annotations: []PluginAnnotation{},
+	}
+	for _, a := range parsed.Annotations {
+		if a.Filename == "" || a.Line < 1 {
+			continue
+		}
+		response.Annotations = append(response.Annotations, a)
+	}
+	return response
+}
+
+// PluginOutput is the client-facing view of a stored plugin result: the raw
+// captured stdout (kept so existing clients keep working) plus the parsed
+// response contract.
+type PluginOutput struct {
+	Result      string             `json:"result"`
+	Status      string             `json:"status"`
+	Body        PluginBody         `json:"body"`
+	Annotations []PluginAnnotation `json:"annotations"`
+}
+
+// parsePluginOutputs converts stored plugin results to their client-facing
+// view, parsing each stored result against the response contract.
+func parsePluginOutputs(results map[string]database.PluginResult) map[string]PluginOutput {
+	outputs := make(map[string]PluginOutput, len(results))
+	for name, res := range results {
+		parsed := ParsePluginOutput(res.Result)
+		outputs[name] = PluginOutput{
+			Result:      res.Result,
+			Status:      res.Status,
+			Body:        parsed.Body,
+			Annotations: parsed.Annotations,
+		}
+	}
+	return outputs
+}
+
+// PRAnnotation is a plugin annotation aggregated into a PR reply, tagged with
+// the plugin that produced it.
+type PRAnnotation struct {
+	PluginAnnotation
+	Plugin string `json:"plugin"`
+}
+
+// collectPluginAnnotations gathers the annotations from every plugin that has
+// already run successfully for the PR, grouped by plugin in name order so the
+// result is deterministic.
+func collectPluginAnnotations(owner, repo string, number int) ([]PRAnnotation, error) {
+	results, err := config.C().DB.GetPluginResults(owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(results))
+	for name, res := range results {
+		if res.Status == "success" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	annotations := []PRAnnotation{}
+	for _, name := range names {
+		for _, a := range ParsePluginOutput(results[name].Result).Annotations {
+			annotations = append(annotations, PRAnnotation{PluginAnnotation: a, Plugin: name})
+		}
+	}
+	return annotations, nil
+}

--- a/server/plugin_contract_test.go
+++ b/server/plugin_contract_test.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"crs/config"
+	"testing"
+)
+
+func TestParsePluginOutput_ConformingMarkdownResponse(t *testing.T) {
+	raw := `{
+		"body": {"body_type": "markdown", "body_content": "This is the response."},
+		"annotations": [
+			{"filename": "test.py", "line": 75, "severity": "warning", "content": "this line looks wrong"},
+			{"filename": "main.go", "line": 3, "severity": "error", "content": "nil dereference"}
+		]
+	}`
+	resp := ParsePluginOutput(raw)
+
+	if resp.Body.BodyType != BodyTypeMarkdown {
+		t.Errorf("expected body_type %q, got %q", BodyTypeMarkdown, resp.Body.BodyType)
+	}
+	if resp.Body.BodyContent != "This is the response." {
+		t.Errorf("unexpected body_content: %q", resp.Body.BodyContent)
+	}
+	if len(resp.Annotations) != 2 {
+		t.Fatalf("expected 2 annotations, got %d", len(resp.Annotations))
+	}
+	first := resp.Annotations[0]
+	if first.Filename != "test.py" || first.Line != 75 || first.Severity != "warning" || first.Content != "this line looks wrong" {
+		t.Errorf("unexpected first annotation: %+v", first)
+	}
+}
+
+func TestParsePluginOutput_ConformingHTMLResponse(t *testing.T) {
+	raw := `{"body": {"body_type": "HTML", "body_content": "<p>hi</p>"}}`
+	resp := ParsePluginOutput(raw)
+
+	if resp.Body.BodyType != BodyTypeHTML {
+		t.Errorf("expected body_type %q (normalized), got %q", BodyTypeHTML, resp.Body.BodyType)
+	}
+	if resp.Body.BodyContent != "<p>hi</p>" {
+		t.Errorf("unexpected body_content: %q", resp.Body.BodyContent)
+	}
+	if len(resp.Annotations) != 0 {
+		t.Errorf("expected no annotations, got %d", len(resp.Annotations))
+	}
+}
+
+func TestParsePluginOutput_LegacyPlainTextFallsBackToMarkdown(t *testing.T) {
+	raw := "Just some plain text summary.\nWith multiple lines."
+	resp := ParsePluginOutput(raw)
+
+	if resp.Body.BodyType != BodyTypeMarkdown {
+		t.Errorf("expected fallback body_type markdown, got %q", resp.Body.BodyType)
+	}
+	if resp.Body.BodyContent != raw {
+		t.Errorf("expected raw output preserved verbatim, got %q", resp.Body.BodyContent)
+	}
+	if len(resp.Annotations) != 0 {
+		t.Errorf("expected no annotations on fallback, got %d", len(resp.Annotations))
+	}
+}
+
+func TestParsePluginOutput_JSONWithoutBodyFallsBack(t *testing.T) {
+	raw := `{"summary": "valid JSON but not the contract"}`
+	resp := ParsePluginOutput(raw)
+
+	if resp.Body.BodyType != BodyTypeMarkdown || resp.Body.BodyContent != raw {
+		t.Errorf("expected whole output wrapped as markdown, got %+v", resp.Body)
+	}
+}
+
+func TestParsePluginOutput_UnknownBodyTypeFallsBack(t *testing.T) {
+	raw := `{"body": {"body_type": "plaintext", "body_content": "hello"}}`
+	resp := ParsePluginOutput(raw)
+
+	if resp.Body.BodyType != BodyTypeMarkdown || resp.Body.BodyContent != raw {
+		t.Errorf("expected whole output wrapped as markdown, got %+v", resp.Body)
+	}
+}
+
+func TestParsePluginOutput_DropsUnanchoredAnnotations(t *testing.T) {
+	raw := `{
+		"body": {"body_type": "markdown", "body_content": "ok"},
+		"annotations": [
+			{"filename": "", "line": 10, "content": "no filename"},
+			{"filename": "a.go", "line": 0, "content": "no line"},
+			{"filename": "a.go", "line": -3, "content": "negative line"},
+			{"filename": "keep.go", "line": 1, "content": "kept"}
+		]
+	}`
+	resp := ParsePluginOutput(raw)
+
+	if len(resp.Annotations) != 1 {
+		t.Fatalf("expected 1 annotation to survive, got %d: %+v", len(resp.Annotations), resp.Annotations)
+	}
+	if resp.Annotations[0].Filename != "keep.go" {
+		t.Errorf("unexpected surviving annotation: %+v", resp.Annotations[0])
+	}
+}
+
+func TestCollectPluginAnnotations_OnlySuccessfulPluginsTagged(t *testing.T) {
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db})
+
+	conforming := `{
+		"body": {"body_type": "markdown", "body_content": "found issues"},
+		"annotations": [
+			{"filename": "test.py", "line": 75, "severity": "warning", "content": "this line looks wrong"}
+		]
+	}`
+	if err := db.UpsertPluginResult("owner", "repo", 1, "b-linter", conforming, "success", "sha1"); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+	// Legacy plain-text plugin: contributes no annotations.
+	if err := db.UpsertPluginResult("owner", "repo", 1, "a-summarizer", "plain summary", "success", "sha1"); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+	// Failed plugin with annotation-shaped output must be excluded.
+	if err := db.UpsertPluginResult("owner", "repo", 1, "c-broken", conforming, "error", "sha1"); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+
+	annotations, err := collectPluginAnnotations("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("collectPluginAnnotations failed: %v", err)
+	}
+	if len(annotations) != 1 {
+		t.Fatalf("expected 1 annotation, got %d: %+v", len(annotations), annotations)
+	}
+	a := annotations[0]
+	if a.Plugin != "b-linter" {
+		t.Errorf("expected annotation tagged with plugin name, got %q", a.Plugin)
+	}
+	if a.Filename != "test.py" || a.Line != 75 || a.Severity != "warning" {
+		t.Errorf("unexpected annotation: %+v", a)
+	}
+}
+
+func TestCollectPluginAnnotations_NoResults(t *testing.T) {
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db})
+
+	annotations, err := collectPluginAnnotations("owner", "repo", 99)
+	if err != nil {
+		t.Fatalf("collectPluginAnnotations failed: %v", err)
+	}
+	if len(annotations) != 0 {
+		t.Errorf("expected no annotations, got %+v", annotations)
+	}
+}
+
+func TestParsePluginOutputs_KeepsRawResultAlongsideParsed(t *testing.T) {
+	db := setupTestDB(t)
+	raw := `{"body": {"body_type": "html", "body_content": "<b>done</b>"}}`
+	if err := db.UpsertPluginResult("owner", "repo", 2, "renderer", raw, "success", "sha2"); err != nil {
+		t.Fatalf("upsert failed: %v", err)
+	}
+	results, err := db.GetPluginResults("owner", "repo", 2)
+	if err != nil {
+		t.Fatalf("get results failed: %v", err)
+	}
+
+	outputs := parsePluginOutputs(results)
+	out, ok := outputs["renderer"]
+	if !ok {
+		t.Fatal("expected output for plugin 'renderer'")
+	}
+	if out.Result != raw {
+		t.Errorf("expected raw result preserved for legacy clients, got %q", out.Result)
+	}
+	if out.Status != "success" {
+		t.Errorf("expected status success, got %q", out.Status)
+	}
+	if out.Body.BodyType != BodyTypeHTML || out.Body.BodyContent != "<b>done</b>" {
+		t.Errorf("unexpected parsed body: %+v", out.Body)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"crs/config"
-	"crs/database"
 	"crs/git_tools"
 	"crs/llm"
 	"crs/utils"
@@ -148,15 +147,16 @@ type GetPRstructArgs struct {
 // state. Reply structs embed it so all methods expose the same fields, and
 // populate() is the single place they get filled in and normalized.
 type PRPayload struct {
-	Okay             bool          `json:"okay"`
-	Content          string        `json:"content"`
-	Metadata         *PRMetadata   `json:"metadata"`
-	Diff             string        `json:"diff"`
-	Comments         []CommentJSON `json:"comments"`
-	OutdatedComments []CommentJSON `json:"outdated_comments"`
-	Reviews          []ReviewJSON  `json:"reviews"`
-	Commits          []CommitJSON  `json:"commits"`
-	Feedback         string        `json:"feedback"`
+	Okay             bool           `json:"okay"`
+	Content          string         `json:"content"`
+	Metadata         *PRMetadata    `json:"metadata"`
+	Diff             string         `json:"diff"`
+	Comments         []CommentJSON  `json:"comments"`
+	OutdatedComments []CommentJSON  `json:"outdated_comments"`
+	Reviews          []ReviewJSON   `json:"reviews"`
+	Commits          []CommitJSON   `json:"commits"`
+	Feedback         string         `json:"feedback"`
+	Annotations      []PRAnnotation `json:"annotations"`
 }
 
 // populate fills the payload from fetched PR details, normalizing nil slices
@@ -188,6 +188,15 @@ func (p *PRPayload) populate(details *PRDetails, content string, owner, repo str
 		slog.Warn("Error loading feedback for PR reply", "repo", repo, "pr", number, "error", err)
 	}
 	p.Feedback = feedback
+
+	annotations, err := collectPluginAnnotations(owner, repo, number)
+	if err != nil {
+		slog.Warn("Error loading plugin annotations for PR reply", "repo", repo, "pr", number, "error", err)
+	}
+	if annotations == nil {
+		annotations = []PRAnnotation{}
+	}
+	p.Annotations = annotations
 }
 
 type GetPRReply struct {
@@ -1140,7 +1149,7 @@ type GetPluginOutputArgs struct {
 }
 
 type GetPluginOutputReply struct {
-	Output map[string]database.PluginResult `json:"output"`
+	Output map[string]PluginOutput `json:"output"`
 }
 
 // GetPluginOutput returns all stored plugin outputs for the given PR
@@ -1165,7 +1174,7 @@ func (h *RPCHandler) GetPluginOutput(args *GetPluginOutputArgs, reply *GetPlugin
 		}()
 	}
 
-	reply.Output = results
+	reply.Output = parsePluginOutputs(results)
 	return nil
 }
 
@@ -1177,9 +1186,9 @@ type RerunPluginsArgs struct {
 }
 
 type RerunPluginsReply struct {
-	Okay    bool                             `json:"okay"`
-	Message string                           `json:"message"`
-	Output  map[string]database.PluginResult `json:"output"`
+	Okay    bool                    `json:"okay"`
+	Message string                  `json:"message"`
+	Output  map[string]PluginOutput `json:"output"`
 }
 
 // RerunPlugins forces reexecution of plugins for a given PR, bypassing SHA cache checks.
@@ -1234,7 +1243,7 @@ func (h *RPCHandler) RerunPlugins(args *RerunPluginsArgs, reply *RerunPluginsRep
 	}
 
 	// Return empty output for now (plugins running async)
-	reply.Output = make(map[string]database.PluginResult)
+	reply.Output = make(map[string]PluginOutput)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Implements a plugin response contract that allows plugins to emit structured JSON declaring how their output should be rendered and to attach line-level annotations to PR diffs. Plugins can now specify `markdown` or `html` body types and include annotations anchored to specific files and lines. The system maintains full backwards compatibility—plain text and non-conforming JSON output continues to work as before, wrapped as markdown.

### Changes

- **Backend (`server/plugin_contract.go`)**: Added `ParsePluginOutput()` to parse plugin stdout against the response contract, with fallback handling for legacy output. Added `collectPluginAnnotations()` to aggregate annotations from successful plugins and `parsePluginOutputs()` to prepare results for clients. Annotations without a filename or positive line number are dropped.

- **Server integration (`server/server.go`)**: Extended `PRPayload` to include `Annotations` field populated from `collectPluginAnnotations()`, making plugin annotations available in PR responses.

- **Frontend utilities (`bun_client/frontend/src/plugin_utils.ts`)**: Added contract types (`PluginBody`, `PluginAnnotation`, `PluginResult`, `PRAnnotation`) and helper functions: `resolvePluginBody()` to select which body to render (parsed or fallback), `sortedAnnotations()` to order annotations by file and line, `annotationSeverityVariant()` to map severity strings to UI variants, and `totalAnnotationCount()` for summary counts.

- **Frontend components**: 
  - `PluginBodyView.tsx`: Renders plugin bodies as markdown inline or HTML in a sandboxed iframe (with theme variable inheritance and responsive sizing).
  - `PluginAnnotations.tsx`: Lists line-level annotations with severity badges and file:line anchors.
  - Updated `PluginOutput.tsx` and `PluginsPanel.tsx` to use the new contract helpers and display annotation counts.

- **Documentation (`docs/plugins.md`, `docs/protocol.md`)**: Documented the response contract with field descriptions, backwards compatibility guarantees, and updated protocol docs to include `PRAnnotation` in `GetPRStruct` replies.

- **Tests**: Comprehensive test coverage for parsing (conforming/non-conforming JSON, legacy fallback, annotation filtering) and annotation collection (successful plugins only, deterministic ordering).

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (new tests in `server/plugin_contract_test.go` cover parsing, fallback behavior, and annotation collection)
- [x] `bun run test` passes (new tests in `bun_client/frontend/src/plugin_utils.test.ts` cover body resolution, annotation sorting, and severity mapping)

https://claude.ai/code/session_01CM8QkxAUerhjRFyJ2NT3wY