### PR TITLE
Make ReviewDiscussion collapsible to keep diff near top

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -105,8 +105,8 @@ export default function Review({
         });
     };
     const [activeOutdatedFile, setActiveOutdatedFile] = useState<string | null>(null);
-    // Description starts collapsed so the diff dominates the viewport.
-    const [descCollapsed, setDescCollapsed] = useState(true);
+    // Description starts expanded — it's the context for everything below it.
+    const [descCollapsed, setDescCollapsed] = useState(false);
     // On phones, wrap long diff lines by default so they read without
     // horizontal scrolling; keep `pre` (scroll) as the default on desktop where
     // column alignment matters more.

--- a/bun_client/frontend/src/components/review/ReviewDiscussion.tsx
+++ b/bun_client/frontend/src/components/review/ReviewDiscussion.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react';
 import Markdown from 'react-markdown';
 import { colors } from '../../design';
 import { type ReviewData, stripHtmlComments } from './types';
 
 // Chronological list of submitted reviews that carry a body.
 export default function ReviewDiscussion({ reviews }: { reviews: ReviewData[] }) {
+    // Starts collapsed so the diff stays close to the top of the page.
+    const [collapsed, setCollapsed] = useState(true);
     const withBody = reviews.filter(r => r.body && r.body.trim());
     if (withBody.length === 0) return null;
 
@@ -17,19 +20,57 @@ export default function ReviewDiscussion({ reviews }: { reviews: ReviewData[] })
                 overflow: 'hidden',
             }}
         >
-            <div
+            <button
+                type="button"
+                onClick={() => setCollapsed(c => !c)}
+                aria-expanded={!collapsed}
                 style={{
+                    width: '100%',
                     padding: '12px 16px',
-                    borderBottom: '1px solid var(--border)',
+                    borderTop: 'none',
+                    borderLeft: 'none',
+                    borderRight: 'none',
+                    borderBottom: collapsed ? 'none' : '1px solid var(--border)',
                     background: 'var(--bg-primary)',
                     fontSize: '13px',
                     fontWeight: 500,
                     color: 'var(--text-secondary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    cursor: 'pointer',
+                    textAlign: 'left',
                 }}
             >
+                <span
+                    style={{
+                        display: 'inline-block',
+                        transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
+                        transition: 'transform 0.15s ease',
+                        fontSize: '10px',
+                    }}
+                >
+                    ▼
+                </span>
                 Review Discussion ({withBody.length})
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
+                {collapsed && (
+                    <span
+                        style={{
+                            fontSize: '11px',
+                            color: 'var(--text-tertiary)',
+                            fontWeight: 400,
+                        }}
+                    >
+                        — click to expand
+                    </span>
+                )}
+            </button>
+            <div
+                style={{
+                    display: collapsed ? 'none' : 'flex',
+                    flexDirection: 'column',
+                }}
+            >
                 {withBody
                     .sort(
                         (a, b) =>


### PR DESCRIPTION
## Summary

Makes the ReviewDiscussion section collapsible by default so the diff stays closer to the top of the page, improving navigation on review pages. Also changes the PR description to start expanded since it provides important context.

### Changes

- **ReviewDiscussion.tsx**: Convert header from static div to interactive button with collapse/expand toggle
  - Starts collapsed to keep the diff prominent
  - Shows a rotating chevron indicator and "click to expand" hint when collapsed
  - Hides review content when collapsed, shows border only when expanded
  
- **Review.tsx**: Change PR description initial state from collapsed to expanded
  - Updated comment to reflect that description provides context for everything below it

## Test Plan

- [ ] `bun run type-check` passes
- [ ] `bun run lint` passes
- [ ] Manual verification: ReviewDiscussion collapses/expands on click with smooth animation
- [ ] Manual verification: Diff appears near top of page on initial load

https://claude.ai/code/session_017dWbfQR6HkY9TCJybUAwqZ