### PR TITLE
Add plugin annotation support to code review diff rendering

### DIFF
--- a/client.el/crs-client.el
+++ b/client.el/crs-client.el
@@ -57,6 +57,7 @@
   "D" #'crs-run-on-demand-plugin
   "R" #'crs-rerun-plugin
   "H" #'crs-toggle-comments
+  "A" #'crs-toggle-annotations
   "f" #'crs-set-review-feedback
   "RET" #'crs-visit-file
   "<return>" #'crs-visit-file
@@ -120,6 +121,7 @@
     "D" #'crs-run-on-demand-plugin
     "R" #'crs-rerun-plugin
     "H" #'crs-toggle-comments
+    "A" #'crs-toggle-annotations
     "f" #'crs-set-review-feedback
     (kbd "RET") #'crs-visit-file
     "O" #'crs-expand-hunk-before
@@ -146,6 +148,7 @@
     "D" #'crs-run-on-demand-plugin
     "R" #'crs-rerun-plugin
     "H" #'crs-toggle-comments
+    "A" #'crs-toggle-annotations
     "f" #'crs-set-review-feedback
     (kbd "RET") #'crs-visit-file
     "O" #'crs-expand-hunk-before

--- a/client.el/crs-plugins.el
+++ b/client.el/crs-plugins.el
@@ -14,6 +14,46 @@
 (declare-function crs--render-and-update "crs-render")
 (declare-function crs--get-current-review-info "crs-review")
 
+(defun crs--insert-plugin-output-entry (name data)
+  "Insert one plugin's entry from a GetPluginOutput reply at point.
+NAME is the plugin name and DATA its output alist.  The parsed response
+contract body is preferred over the raw result (which is JSON for
+contract-emitting plugins); the plugin's annotations, when present, are
+listed beneath the body sorted by file and line."
+  (let* ((status (cdr (assq 'status data)))
+         (body (cdr (assq 'body data)))
+         (body-content (cdr (assq 'body_content body)))
+         (res (cdr (assq 'result data)))
+         (annotations (append (cdr (assq 'annotations data)) nil)))
+    (insert (format "# Plugin: %s (Status: %s)\n" name status))
+    (insert "──────────────────────────────────\n")
+    (insert (or (and body-content
+                     (not (string-empty-p body-content))
+                     body-content)
+                res
+                "No output."))
+    (insert "\n")
+    (when annotations
+      (setq annotations
+            (sort annotations
+                  (lambda (a b)
+                    (let ((file-a (or (cdr (assq 'filename a)) ""))
+                          (file-b (or (cdr (assq 'filename b)) "")))
+                      (if (string= file-a file-b)
+                          (< (or (cdr (assq 'line a)) 0)
+                             (or (cdr (assq 'line b)) 0))
+                        (string< file-a file-b))))))
+      (insert (format "\n## Annotations (%d)\n" (length annotations)))
+      (dolist (annotation annotations)
+        (let ((severity (or (cdr (assq 'severity annotation)) ""))
+              (content (or (cdr (assq 'content annotation)) "")))
+          (insert (format "- %s:%s%s %s\n"
+                          (cdr (assq 'filename annotation))
+                          (cdr (assq 'line annotation))
+                          (if (string-empty-p severity) "" (format " [%s]" severity))
+                          (replace-regexp-in-string "\n" "\n  " content))))))
+    (insert "\n")))
+
 (defun crs-refresh-plugin-output ()
   "Refresh the plugin output in the current buffer."
   (interactive)
@@ -40,15 +80,10 @@
                  (insert "No plugin output available.\n")
                (dolist (plugin-entry (append output nil))
                  (let* ((name (symbol-name (car plugin-entry)))
-                        (data (cdr plugin-entry))
-                        (res (cdr (assq 'result data)))
-                        (status (cdr (assq 'status data))))
+                        (data (cdr plugin-entry)))
                    (puthash name data crs--plugin-output-map)
                    (when (or (null target-plugin) (string= name target-plugin))
-                     (insert (format "# Plugin: %s (Status: %s)\n" name status))
-                     (insert "──────────────────────────────────\n")
-                     (insert (or res "No output."))
-                     (insert "\n\n")))))
+                     (crs--insert-plugin-output-entry name data)))))
              (goto-char (point-min))))
          (message "Plugin output refreshed."))))))
 
@@ -106,14 +141,9 @@ Temporarily disables read-only mode (required when called from
                  (insert "No plugin output available.\n")
                (dolist (plugin-entry (append output nil)) ;; Ensure it's treated as a list of pairs
                  (let* ((name (symbol-name (car plugin-entry)))
-                        (data (cdr plugin-entry))
-                        (res (cdr (assq 'result data)))
-                        (status (cdr (assq 'status data))))
+                        (data (cdr plugin-entry)))
                    (puthash name data plugin-map)
-                   (insert (format "# Plugin: %s (Status: %s)\n" name status))
-                   (insert "──────────────────────────────────\n")
-                   (insert (or res "No output."))
-                   (insert "\n\n"))))
+                   (crs--insert-plugin-output-entry name data))))
              (goto-char (point-min))
              (crs-plugin-output-mode)
              (setq crs--plugin-output-map plugin-map)
@@ -164,12 +194,7 @@ Uses cached data from the general plugin output buffer if available."
               (with-current-buffer buffer
                 (let ((inhibit-read-only t))
                   (erase-buffer)
-                  (let* ((status (cdr (assq 'status cached-data)))
-                         (res (cdr (assq 'result cached-data))))
-                    (insert (format "# Plugin: %s (Status: %s)\n" plugin status))
-                    (insert "──────────────────────────────────\n")
-                    (insert (or res "No output."))
-                    (insert "\n\n"))
+                  (crs--insert-plugin-output-entry plugin cached-data)
                   (goto-char (point-min))
                   (crs-plugin-output-mode)
                   ;; Store context
@@ -198,15 +223,10 @@ Uses cached data from the general plugin output buffer if available."
                        (insert "No plugin output available.\n")
                      (dolist (plugin-entry (append output nil))
                        (let* ((name (symbol-name (car plugin-entry)))
-                              (data (cdr plugin-entry))
-                              (res (cdr (assq 'result data)))
-                              (status (cdr (assq 'status data))))
+                              (data (cdr plugin-entry)))
                          (puthash name data plugin-map)
                          (when (string= name plugin)
-                           (insert (format "# Plugin: %s (Status: %s)\n" name status))
-                           (insert "──────────────────────────────────\n")
-                           (insert (or res "No output."))
-                           (insert "\n\n")))))
+                           (crs--insert-plugin-output-entry name data)))))
                    (goto-char (point-min))
                    (crs-plugin-output-mode)
                    (setq crs--plugin-output-map plugin-map)

--- a/client.el/crs-render.el
+++ b/client.el/crs-render.el
@@ -116,36 +116,48 @@ not the buffer has been washed by git-delta:
 
 (defun crs-toggle-comments ()
   "Toggle visibility of all comments in the current review buffer.
-Re-renders the buffer with or without comments based on the toggle state."
+Re-renders the buffer with or without comments based on the toggle state.
+Plugin annotations follow the same state: uncollapsing comments also
+uncollapses annotations."
   (interactive)
   (unless crs--buffer-diff
     (error "No stored PR data. Please reload the review first"))
   (setq crs--buffer-show-comments (not crs--buffer-show-comments))
+  (setq crs--buffer-show-annotations crs--buffer-show-comments)
   (let ((current-line (line-number-at-pos)))
     (crs--render-and-update (current-buffer) nil current-line))
   (message "Comments %s" (if crs--buffer-show-comments "shown" "hidden")))
 
 
 (defun crs--maybe-show-collapsed-comments ()
-  "Show collapsed comments in minibuffer if cursor is on a line with compact indicator."
-  (when (and (eq major-mode 'my-code-review-mode)
-             (not crs--buffer-show-comments)
-             crs--buffer-comments)
-    (let ((line (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
-      (when (string-match "<C: [^>]+>" line)
-        ;; Extract file and position from context
-        (let* ((ctx (crs--get-comment-context))
-               (file (nth 3 ctx))
-               (pos (nth 4 ctx)))
-          (when (and file pos)
-            (let* ((comment-map (crs--index-comments crs--buffer-comments))
-                   (key (format "%s:%s" file pos))
-                   (comments (gethash key comment-map)))
-              (when comments
-                (crs--display-comments-in-minibuffer comments)))))))))
+  "Preview collapsed comments and annotations for the line at point.
+Shows a one-line echo-area summary when the cursor sits on a line with a
+compact <C: ...> comment indicator or <A: ...> annotation indicator."
+  (when (eq major-mode 'my-code-review-mode)
+    (let* ((line (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
+           (comments
+            (when (and (not crs--buffer-show-comments)
+                       crs--buffer-comments
+                       (string-match "<C: [^>]+>" line))
+              ;; Extract file and position from context
+              (let* ((ctx (crs--get-comment-context))
+                     (file (nth 3 ctx))
+                     (pos (nth 4 ctx)))
+                (when (and file pos)
+                  (gethash (format "%s:%s" file pos)
+                           (crs--index-comments crs--buffer-comments))))))
+           (annotations (unless crs--buffer-show-annotations
+                          (crs--annotations-on-current-line)))
+           (parts (delq nil
+                        (list (when comments
+                                (crs--comments-minibuffer-summary comments))
+                              (when annotations
+                                (crs--annotations-minibuffer-summary annotations))))))
+      (when parts
+        (message "%s" (string-join parts " ‖ "))))))
 
-(defun crs--display-comments-in-minibuffer (comments)
-  "Display COMMENTS in the minibuffer as a one-line summary."
+(defun crs--comments-minibuffer-summary (comments)
+  "Format COMMENTS as a one-line echo-area summary."
   (let* ((count (length comments))
          (summary
           (mapconcat
@@ -159,7 +171,7 @@ Re-renders the buffer with or without comments based on the toggle state."
                    (format "[%s]: %s" author first-line)))))
            comments
            " | ")))
-    (message "%d comment%s: %s" count (if (= count 1) "" "s") summary)))
+    (format "%d comment%s: %s" count (if (= count 1) "" "s") summary)))
 
 ;; Override evil-mode keybindings - define keys for normal and visual states
 
@@ -229,6 +241,224 @@ If LINE extends past MIN-COLUMN, place indicator one space after LINE ends."
          (target-column (max min-column (1+ line-length)))
          (padding (- target-column line-length)))
     (concat line (make-string padding ?\s) indicator)))
+
+;;; Plugin annotations
+;;
+;; Plugins can attach line-level annotations to the PR diff (see
+;; docs/plugins.md).  Each annotation carries a filename and a 1-based line
+;; number on the PR's HEAD side, so it anchors to an added or unchanged line
+;; of the diff.  Like comments, annotations are inserted into the buffer
+;; AFTER delta-wash has painted the diff, so the washer never sees them.
+
+(defun crs--normalize-annotation-path (path)
+  "Return PATH with a tolerated leading \"./\" stripped."
+  (if (and path (string-prefix-p "./" path))
+      (substring path 2)
+    path))
+
+(defun crs--index-annotations (annotations)
+  "Index ANNOTATIONS into a hash table keyed by \"file:line\".
+ANNOTATIONS is the list (or vector) of annotation alists from a GetPR
+reply.  Each value is the list of annotations for that head-side line, in
+the server's plugin-name order."
+  (let ((map (make-hash-table :test 'equal)))
+    (seq-do (lambda (annotation)
+              (let* ((file (crs--normalize-annotation-path
+                            (cdr (assq 'filename annotation))))
+                     (line (cdr (assq 'line annotation)))
+                     (key (format "%s:%s" file line)))
+                (puthash key (cons annotation (gethash key map)) map)))
+            (or annotations []))
+    (maphash (lambda (k v) (puthash k (nreverse v) map)) map)
+    map))
+
+(defun crs--format-compact-annotation-indicator (annotations)
+  "Format a compact annotation indicator for ANNOTATIONS.
+Returns a string like <A: plugin1, plugin2>."
+  (let ((plugins (seq-uniq
+                  (seq-map (lambda (a)
+                             (or (cdr (assq 'plugin a)) "plugin"))
+                           annotations))))
+    (format "<A: %s>" (string-join plugins ", "))))
+
+(defun crs--render-annotation-block (annotations &optional show-line)
+  "Render ANNOTATIONS (a list anchored to one spot) into a block string.
+When SHOW-LINE is non-nil each entry names the line it points at, for
+annotations that could not be anchored to a visible diff line."
+  (let ((lines (list "    ┌─ PLUGIN ANNOTATION ────────────")))
+    (dolist (annotation annotations)
+      (let* ((severity (or (cdr (assq 'severity annotation)) ""))
+             (plugin (or (cdr (assq 'plugin annotation)) "plugin"))
+             (line (cdr (assq 'line annotation)))
+             (content (or (cdr (assq 'content annotation)) "")))
+        (push (format "    │ %s%s%s"
+                      (if (string-empty-p severity) "" (format "[%s] " severity))
+                      plugin
+                      (if (and show-line line) (format " @ line %s" line) ""))
+              lines)
+        (dolist (content-line (split-string content "\n"))
+          (push (concat "    │   " content-line) lines))))
+    (push "    └──────────────────────────────────" lines)
+    (push "" lines)
+    (mapconcat #'identity (nreverse lines) "\n")))
+
+(defun crs--insert-annotations-into-buffer (annotations show-full)
+  "Insert plugin ANNOTATIONS into the current buffer's washed diff.
+An annotation anchors to the line matching its head-side line number, so
+it lands on an added or unchanged line.  Annotations for a file in the
+diff whose line is not visible attach to that file's first hunk header
+instead; annotations for files not in the diff are dropped (they remain
+visible in the plugin output buffers).
+
+SHOW-FULL non-nil inserts full annotation blocks beneath each annotated
+line; otherwise a compact <A: plugin> indicator is appended to the line,
+carrying the annotation list in a `crs-annotations' text property so the
+echo-area preview can find it.  Must run after `delta-wash' and after
+`crs--insert-comments-into-buffer' so line positions are final and the
+washer's painting is untouched."
+  (when (> (length (or annotations [])) 0)
+    (let ((annotation-map (crs--index-annotations annotations))
+          (anchored (make-hash-table :test 'equal))
+          (first-hunks (make-hash-table :test 'equal))
+          (insertions nil)
+          (current-file nil)
+          (head-line nil)
+          (in-hunk nil))
+      (save-excursion
+        (goto-char (point-min))
+        (while (not (eobp))
+          (let* ((line-start (point))
+                 (line-end (line-end-position))
+                 (line (buffer-substring-no-properties line-start line-end)))
+            (cond
+             ;; Simplified file header
+             ((string-match "^\\(modified\\|deleted\\|new file\\|renamed\\)[[:space:]]+\\(.*\\)$" line)
+              (setq current-file (string-trim (match-string 2 line)))
+              (setq in-hunk nil))
+
+             ;; Raw diff headers
+             ((string-prefix-p "diff " line)
+              (setq current-file nil)
+              (setq in-hunk nil))
+
+             ((string-match "^\\+\\+\\+ b/\\(.*\\)" line)
+              (setq current-file (match-string 1 line))
+              (setq in-hunk nil))
+
+             ;; Hunk header: reset the head-side line counter
+             ((string-match "^@@ -[0-9]+\\(?:,[0-9]+\\)? \\+\\([0-9]+\\)\\(?:,[0-9]+\\)? @@" line)
+              (setq head-line (string-to-number (match-string 1 line)))
+              (setq in-hunk t)
+              (when (and current-file (not (gethash current-file first-hunks)))
+                (puthash current-file (cons line-start line-end) first-hunks)))
+
+             ;; Skip interleaved comment/annotation blocks
+             ((string-match-p "^[[:cntrl:][:space:]]*[│┌└]" line)
+              nil)
+
+             ;; Content line (raw or delta-washed).  Only added and context
+             ;; lines exist on the head side, so removed lines neither match
+             ;; an annotation nor advance the head-line counter.
+             ((and in-hunk current-file head-line (crs--diff-line-marker line))
+              (unless (eq (crs--diff-line-marker line) ?-)
+                (let* ((key (format "%s:%d" current-file head-line))
+                       (line-annotations (gethash key annotation-map)))
+                  (when line-annotations
+                    (puthash key t anchored)
+                    (push (cons line-end
+                                (if show-full
+                                    (concat "\n" (string-trim-right
+                                                  (crs--render-annotation-block line-annotations)))
+                                  (list 'indicator line-annotations)))
+                          insertions)))
+                (setq head-line (1+ head-line))))))
+          (forward-line 1)))
+
+      ;; Annotations the diff can't show a row for hang off their file's
+      ;; first hunk header instead of disappearing, like file-level comments.
+      (let ((leftovers (make-hash-table :test 'equal)))
+        (seq-do (lambda (annotation)
+                  (let* ((file (crs--normalize-annotation-path
+                                (cdr (assq 'filename annotation))))
+                         (key (format "%s:%s" file (cdr (assq 'line annotation)))))
+                    (when (and (not (gethash key anchored))
+                               (gethash file first-hunks))
+                      (puthash file (cons annotation (gethash file leftovers)) leftovers))))
+                (or annotations []))
+        (maphash
+         (lambda (file annotation-list)
+           (let ((sorted (sort (nreverse annotation-list)
+                               (lambda (a b)
+                                 (< (or (cdr (assq 'line a)) 0)
+                                    (or (cdr (assq 'line b)) 0)))))
+                 (hunk-pos (gethash file first-hunks)))
+             (push (if show-full
+                       (cons (car hunk-pos) (crs--render-annotation-block sorted t))
+                     (cons (cdr hunk-pos) (list 'indicator sorted)))
+                   insertions)))
+         leftovers))
+
+      ;; Execute insertions (sorted by point descending).  Indicators are
+      ;; inserted at line end without touching the line itself, so text
+      ;; properties applied by the washer survive.
+      (setq insertions (sort insertions (lambda (a b) (> (car a) (car b)))))
+      (save-excursion
+        (dolist (ins insertions)
+          (goto-char (car ins))
+          (let ((content (cdr ins)))
+            (if (and (listp content) (eq (car content) 'indicator))
+                (let* ((line-annotations (cadr content))
+                       (indicator (propertize
+                                   (crs--format-compact-annotation-indicator line-annotations)
+                                   'crs-annotations line-annotations))
+                       (line-length (- (point) (line-beginning-position)))
+                       (padding (max (- 120 line-length) 1)))
+                  (insert (make-string padding ?\s) indicator))
+              (insert content))))))))
+
+(defun crs--annotations-on-current-line ()
+  "Return the plugin annotations attached to the current line, or nil.
+Compact annotation indicators carry their annotation list in a
+`crs-annotations' text property."
+  (let* ((beg (line-beginning-position))
+         (end (line-end-position))
+         (found (get-text-property beg 'crs-annotations))
+         (pos beg))
+    (while (and (not found)
+                (setq pos (next-single-property-change pos 'crs-annotations nil end))
+                (< pos end))
+      (setq found (get-text-property pos 'crs-annotations)))
+    found))
+
+(defun crs--annotations-minibuffer-summary (annotations)
+  "Format ANNOTATIONS as a one-line echo-area summary."
+  (let ((count (length annotations)))
+    (format "%d annotation%s: %s" count (if (= count 1) "" "s")
+            (mapconcat
+             (lambda (annotation)
+               (let* ((severity (or (cdr (assq 'severity annotation)) ""))
+                      (plugin (or (cdr (assq 'plugin annotation)) "plugin"))
+                      (content (or (cdr (assq 'content annotation)) ""))
+                      (first-line (car (split-string content "\n")))
+                      (first-line (if (> (length first-line) 60)
+                                      (concat (substring first-line 0 57) "...")
+                                    first-line)))
+                 (if (string-empty-p severity)
+                     (format "[%s]: %s" plugin first-line)
+                   (format "[%s/%s]: %s" plugin severity first-line))))
+             annotations " | "))))
+
+(defun crs-toggle-annotations ()
+  "Toggle visibility of plugin annotations in the current review buffer.
+Collapsed annotations show as compact <A: plugin> indicators; expanded
+ones render full blocks beneath the annotated lines."
+  (interactive)
+  (unless crs--buffer-diff
+    (error "No stored PR data. Please reload the review first"))
+  (setq crs--buffer-show-annotations (not crs--buffer-show-annotations))
+  (let ((current-line (line-number-at-pos)))
+    (crs--render-and-update (current-buffer) nil current-line))
+  (message "Annotations %s" (if crs--buffer-show-annotations "shown" "hidden")))
 
 (defun crs--render-diff (diff-content comment-map &optional show-full-comments)
   "Render the diff string with interleaved comments.
@@ -713,12 +943,19 @@ for more robust position restoration."
           (new-reviews nil)
           (new-commits nil)
           (new-preamble nil)
+          (new-annotations nil)
           (new-show-comments (if (local-variable-p 'crs--buffer-show-comments)
                                  crs--buffer-show-comments
                                t))
+          ;; Annotations start collapsed; `crs-toggle-comments' and
+          ;; `crs-toggle-annotations' flip this buffer-locally.
+          (new-show-annotations (if (local-variable-p 'crs--buffer-show-annotations)
+                                    crs--buffer-show-annotations
+                                  nil))
           ;; Preserve existing data for re-render case
           (existing-diff crs--buffer-diff)
           (existing-comments crs--buffer-comments)
+          (existing-annotations crs--buffer-annotations)
           (existing-outdated-comments crs--buffer-outdated-comments)
           (existing-metadata crs--buffer-metadata)
           (existing-reviews crs--buffer-reviews)
@@ -756,7 +993,8 @@ for more robust position restoration."
           (setq new-metadata metadata)
           (setq new-reviews reviews)
           (setq new-commits commits)
-          (setq new-preamble preamble)))
+          (setq new-preamble preamble)
+          (setq new-annotations (cdr (assq 'annotations content)))))
 
       ;; Temporarily set for rendering (before mode change wipes them)
       (setq crs--buffer-diff (or new-diff existing-diff))
@@ -767,6 +1005,8 @@ for more robust position restoration."
       (setq crs--buffer-commits (or new-commits existing-commits))
       (setq crs--buffer-preamble (or new-preamble existing-preamble))
       (setq crs--buffer-show-comments new-show-comments)
+      (setq crs--buffer-annotations (or new-annotations existing-annotations))
+      (setq crs--buffer-show-annotations new-show-annotations)
       (setq crs--buffer-review-feedback existing-review-feedback)
 
       (erase-buffer)
@@ -792,6 +1032,10 @@ for more robust position restoration."
 
         ;; 4. Insert Comments (only regular comments in-line with diff)
         (crs--insert-comments-into-buffer crs--buffer-comments crs--buffer-show-comments)
+
+        ;; 4.5. Insert plugin annotations (after comments so their line
+        ;; positions account for the interleaved comment blocks)
+        (crs--insert-annotations-into-buffer crs--buffer-annotations crs--buffer-show-annotations)
 
         ;; 5. Insert Preamble & Feedback at TOP
         (let* ((header (crs--render-header-from-metadata crs--buffer-metadata))
@@ -841,6 +1085,8 @@ for more robust position restoration."
       (setq crs--buffer-commits (or new-commits existing-commits))
       (setq crs--buffer-preamble (or new-preamble existing-preamble))
       (setq crs--buffer-show-comments new-show-comments)
+      (setq crs--buffer-annotations (or new-annotations existing-annotations))
+      (setq crs--buffer-show-annotations new-show-annotations)
       (setq crs--buffer-review-feedback existing-review-feedback)
 
       (let ((final-pos

--- a/client.el/crs-tests.el
+++ b/client.el/crs-tests.el
@@ -35,6 +35,7 @@
                 crs-submit-review crs-approve-review crs-comment-review
                 crs-request-changes-review crs-set-review-feedback
                 crs-expand-hunk-before crs-expand-hunk-after
+                crs-toggle-annotations
                 crs-sync-pr crs-checkout-current-project
                 crs-get-plugin-output crs-rerun-plugin crs-run-on-demand-plugin
                 crs-get-rate-limit-status))
@@ -47,7 +48,13 @@
                 crs--get-comment-context crs--get-current-review-info
                 crs--review-buffer-name crs--parse-hunk-header
                 crs--ensure-html crs--make-html-placeholder
-                crs--process-html-placeholders crs--strip-comments-tree))
+                crs--process-html-placeholders crs--strip-comments-tree
+                crs--index-annotations crs--render-annotation-block
+                crs--insert-annotations-into-buffer
+                crs--format-compact-annotation-indicator
+                crs--annotations-on-current-line
+                crs--annotations-minibuffer-summary
+                crs--insert-plugin-output-entry))
     (should (fboundp fn))))
 
 (ert-deftest crs-test-buffer-local-state-declared ()
@@ -55,6 +62,7 @@
   (dolist (var '(crs--process crs--pending-requests crs-reviews-buffer-name
                  crs--buffer-owner crs--buffer-diff crs--buffer-comments
                  crs--buffer-metadata crs--buffer-show-comments
+                 crs--buffer-annotations crs--buffer-show-annotations
                  crs--comment-owner crs--comment-filename crs--comment-position
                  crs--plugin-owner crs--plugin-name crs--plugin-output-map))
     (should (boundp var))))
@@ -117,6 +125,133 @@
     (should-not (string-match-p "a comment" stripped))
     (should (string-match-p "PR one" stripped))
     (should (string-match-p "PR two" stripped))))
+
+;;; --- Plugin annotations ---
+
+(defconst crs-test--annotation-diff
+  (concat "diff --git a/test.py b/test.py\n"
+          "--- a/test.py\n"
+          "+++ b/test.py\n"
+          "@@ -1,3 +1,4 @@\n"
+          " line one\n"
+          "+line two\n"
+          " line three\n"
+          " line four\n")
+  "A raw single-file diff; head-side lines 1-4 are visible.")
+
+(defconst crs-test--annotations
+  (vector '((filename . "./test.py") (line . 2) (severity . "warning")
+            (content . "this line looks wrong") (plugin . "Security Check"))
+          '((filename . "test.py") (line . 99) (severity . "info")
+            (content . "outside the hunk") (plugin . "Style"))
+          '((filename . "missing.py") (line . 1) (severity . "error")
+            (content . "not in the diff") (plugin . "Style")))
+  "Annotations as decoded from a GetPR reply: one anchorable, one whose
+line the diff does not show, and one for a file outside the diff.")
+
+(ert-deftest crs-test-index-annotations ()
+  "Annotations index by \"file:line\" with a leading ./ normalized away."
+  (let ((map (crs--index-annotations crs-test--annotations)))
+    (should (= (hash-table-count map) 3))
+    (should (= (length (gethash "test.py:2" map)) 1))
+    (should (gethash "test.py:99" map))
+    (should (gethash "missing.py:1" map))))
+
+(ert-deftest crs-test-compact-annotation-indicator ()
+  (should (equal (crs--format-compact-annotation-indicator
+                  '(((plugin . "A")) ((plugin . "B")) ((plugin . "A"))))
+                 "<A: A, B>")))
+
+(ert-deftest crs-test-insert-annotations-collapsed ()
+  "Collapsed annotations append <A: ...> indicators without touching the diff lines."
+  (with-temp-buffer
+    (insert crs-test--annotation-diff)
+    (crs--insert-annotations-into-buffer crs-test--annotations nil)
+    ;; The head-line-2 annotation lands on \"+line two\"...
+    (goto-char (point-min))
+    (search-forward "+line two")
+    (should (string-match-p "<A: Security Check>"
+                            (buffer-substring-no-properties
+                             (line-beginning-position) (line-end-position))))
+    ;; ...carrying its annotations in a text property for the echo-area preview.
+    (let ((found (crs--annotations-on-current-line)))
+      (should found)
+      (should (equal (cdr (assq 'content (car found))) "this line looks wrong")))
+    ;; The out-of-hunk annotation attaches to the file's first hunk header.
+    (goto-char (point-min))
+    (search-forward "@@ -1,3 +1,4 @@")
+    (should (string-match-p "<A: Style>"
+                            (buffer-substring-no-properties
+                             (line-beginning-position) (line-end-position))))
+    ;; The annotation for a file not in the diff is dropped.
+    (should-not (string-match-p "<A: [^>]*>[^\n]*not in the diff" (buffer-string)))
+    (should-not (text-property-any (point-min) (point-max)
+                                   'crs-annotations
+                                   (list (aref crs-test--annotations 2))))))
+
+(ert-deftest crs-test-insert-annotations-expanded ()
+  "Expanded annotations render full blocks beneath the annotated lines."
+  (with-temp-buffer
+    (insert crs-test--annotation-diff)
+    (crs--insert-annotations-into-buffer crs-test--annotations t)
+    (goto-char (point-min))
+    (search-forward "+line two")
+    (forward-line 1)
+    (should (string-match-p "┌─ PLUGIN ANNOTATION"
+                            (buffer-substring-no-properties
+                             (line-beginning-position) (line-end-position))))
+    (let ((text (buffer-string)))
+      (should (string-match-p "\\[warning\\] Security Check" text))
+      (should (string-match-p "this line looks wrong" text))
+      ;; The unanchorable annotation renders before the hunk header, naming its line.
+      (should (string-match-p "\\[info\\] Style @ line 99" text))
+      (should (< (string-match "Style @ line 99" text)
+                 (string-match "@@ -1,3 \\+1,4 @@" text)))
+      (should-not (string-match-p "not in the diff" text)))))
+
+(ert-deftest crs-test-annotations-do-not-shift-comment-positions ()
+  "Expanded annotation blocks are invisible to diff-position counting."
+  (with-temp-buffer
+    (insert crs-test--annotation-diff)
+    (crs--insert-annotations-into-buffer crs-test--annotations t)
+    ;; \" line three\" is diff position 3 (line one=1, +line two=2).
+    (let ((found (crs--find-position-in-diff "test.py" 3)))
+      (should found)
+      (goto-char (point-min))
+      (forward-line (1- found))
+      (should (string-match-p "line three"
+                              (buffer-substring-no-properties
+                               (line-beginning-position) (line-end-position)))))))
+
+(ert-deftest crs-test-annotations-minibuffer-summary ()
+  (should (equal (crs--annotations-minibuffer-summary
+                  '(((plugin . "Sec") (severity . "warning")
+                     (content . "bad line\nsecond line"))))
+                 "1 annotation: [Sec/warning]: bad line")))
+
+(ert-deftest crs-test-insert-plugin-output-entry ()
+  "Plugin output entries prefer the parsed body and list annotations sorted."
+  ;; Contract output: parsed body shown instead of the raw JSON result.
+  (with-temp-buffer
+    (crs--insert-plugin-output-entry
+     "Security Check"
+     '((result . "{\"body\":{\"body_type\":\"markdown\",\"body_content\":\"All clear.\"}}")
+       (status . "success")
+       (body . ((body_type . "markdown") (body_content . "All clear.")))
+       (annotations . [((filename . "b.py") (line . 2) (severity . "warning") (content . "hm"))
+                       ((filename . "a.py") (line . 5) (severity . "") (content . "note"))])))
+    (let ((text (buffer-string)))
+      (should (string-match-p (regexp-quote "# Plugin: Security Check (Status: success)") text))
+      (should (string-match-p (regexp-quote "All clear.") text))
+      (should-not (string-match-p "body_type" text))
+      (should (string-match-p (regexp-quote "## Annotations (2)") text))
+      (should (< (string-match (regexp-quote "a.py:5") text)
+                 (string-match (regexp-quote "b.py:2 [warning]") text)))))
+  ;; Legacy output: no body object, the raw result is shown verbatim.
+  (with-temp-buffer
+    (crs--insert-plugin-output-entry
+     "Legacy" '((result . "plain text output") (status . "success")))
+    (should (string-match-p "plain text output" (buffer-string)))))
 
 (provide 'crs-tests)
 ;;; crs-tests.el ends here

--- a/client.el/crs-vars.el
+++ b/client.el/crs-vars.el
@@ -89,6 +89,13 @@ Set to nil to disable the timeout."
   "The preamble content (header + conversation) for the current PR.")
 (defvar-local crs--buffer-show-comments t
   "Whether to show comments in the buffer. Toggle with `crs-toggle-comments'.")
+(defvar-local crs--buffer-annotations nil
+  "The plugin annotations for the current PR, from the GetPR reply.")
+(defvar-local crs--buffer-show-annotations nil
+  "Whether to show full plugin annotation blocks in the buffer.
+Annotations start collapsed to compact indicators; uncollapsing comments
+with `crs-toggle-comments' also uncollapses annotations, and
+`crs-toggle-annotations' toggles them on their own.")
 (defvar-local crs--buffer-review-feedback nil
   "The review feedback for the current PR.")
 (defvar-local crs--buffer-commits nil

--- a/client.el/washer.el
+++ b/client.el/washer.el
@@ -62,6 +62,26 @@
   "Face for commit entries in the conversation timeline."
   :group 'my-custom-highlights)
 
+(defface washer-annotation-face
+  '((t (:foreground "#af87d7" :weight bold)))
+  "Face for compact plugin annotation indicators <A: plugin>."
+  :group 'my-custom-highlights)
+
+(defface washer-annotation-error-face
+  '((t (:foreground "#dc322f" :weight bold)))
+  "Face for [error] severity tags in plugin annotation blocks."
+  :group 'my-custom-highlights)
+
+(defface washer-annotation-warning-face
+  '((t (:foreground "#b58900" :weight bold)))
+  "Face for [warning] severity tags in plugin annotation blocks."
+  :group 'my-custom-highlights)
+
+(defface washer-annotation-info-face
+  '((t (:foreground "#268bd2" :weight bold)))
+  "Face for [info] severity tags in plugin annotation blocks."
+  :group 'my-custom-highlights)
+
 (defun highlight-review-comments ()
   "Highlight review comment blocks and file headers."
   (interactive)
@@ -80,7 +100,11 @@
                             ("^\\(Description\\|Your Review Feedback\\|Conversation\\|Commits .*\\|Files changed .*\\)$" 0 'washer-section-heading-face t)
                             ("^Commit by .*$" 0 'washer-commit-face t)
                             ("^PR contains [0-9]+ \\(outdated comments\\)$" 1 'washer-outdated-face t)
-                            ("<C: [^>]+>" 0 'washer-compact-comment-face t)))
+                            ("<C: [^>]+>" 0 'washer-compact-comment-face t)
+                            ("<A: [^>]+>" 0 'washer-annotation-face t)
+                            ("^    │ \\(\\[error\\]\\)" 1 'washer-annotation-error-face t)
+                            ("^    │ \\(\\[warning\\]\\)" 1 'washer-annotation-warning-face t)
+                            ("^    │ \\(\\[info\\]\\)" 1 'washer-annotation-info-face t)))
   (goto-address-mode 1)
   (font-lock-flush))
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -128,7 +128,15 @@ They also render inline in the diff, collapsed the same way review comments are.
 
 An annotation anchors to the line matching its `line` on the PR's **head** side, so it lands on an added or unchanged line of the diff. Annotations the diff can't show a row for — a line outside any hunk, or one that only exists on the base side — collapse onto that file's header instead, labelled with the line they point at, rather than disappearing. Annotations naming a file that isn't in the diff at all are only listed in the plugins drawer. Paths must match the diff's repo-relative paths (a leading `./` is tolerated).
 
-The diff reads annotations from the plugin results it has loaded, so rerunning a plugin from the drawer updates the diff without reloading the PR. Only successfully executed plugins contribute, matching the `annotations` aggregate on the PR reply. The Emacs client does not render annotations inline.
+The diff reads annotations from the plugin results it has loaded, so rerunning a plugin from the drawer updates the diff without reloading the PR. Only successfully executed plugins contribute, matching the `annotations` aggregate on the PR reply.
+
+### Rendering in the Emacs Client
+
+Plugin output buffers show each plugin's parsed body (instead of its raw stdout, which is JSON for contract-emitting plugins), with the plugin's annotations listed beneath the body sorted by file and line.
+
+Annotations also render inline in the review buffer's diff, from the `annotations` aggregate on the `GetPR` reply. They are inserted after the diff has been washed with git-delta — the same way review comments are — so the washer's syntax highlighting is unaffected. Annotations start collapsed: an annotated line carries a right-aligned `<A: plugin>` indicator, and placing the cursor on such a line previews the annotations in the echo area. Toggling comments open with `H` expands annotations along with them; `A` toggles annotations on their own.
+
+As in the web client, an annotation anchors to the line matching its `line` on the PR's head side, landing on an added or unchanged line of the diff. Annotations the diff can't show a row for attach to their file's first hunk header, labelled with the line they point at. Annotations naming a file that isn't in the diff at all appear only in the plugin output buffers.
 
 ## On-Demand Plugins
 


### PR DESCRIPTION
## Summary

Adds support for rendering plugin annotations in the code review diff buffer. Annotations are line-level metadata attached by plugins (e.g., security checks, linting) that anchor to specific lines in the PR's HEAD side. They render as compact `<A: plugin>` indicators when collapsed, or full annotation blocks when expanded, similar to how comments work.

### Changes

- **Annotation data model**: New buffer-local variables `crs--buffer-annotations` and `crs--buffer-show-annotations` track annotation state; annotations start collapsed by default
- **Annotation rendering**: 
  - `crs--insert-annotations-into-buffer` inserts annotations into the washed diff, anchoring to HEAD-side lines
  - Annotations for lines outside visible hunks attach to the file's first hunk header instead
  - Annotations for files not in the diff are dropped (remain visible only in plugin output)
  - Compact indicators carry annotation data in a `crs-annotations` text property for echo-area preview
- **Toggle UI**: New `crs-toggle-annotations` command (bound to `A`) expands/collapses all annotations; toggling comments also syncs annotation visibility
- **Echo-area preview**: `crs--maybe-show-collapsed-comments` refactored to preview both comments and annotations when hovering over compact indicators
- **Plugin output**: `crs--insert-plugin-output-entry` (new) centralizes plugin output formatting and lists annotations sorted by file and line
- **Syntax highlighting**: New washer faces for annotation indicators and severity tags (`washer-annotation-{face,error,warning,info}-face`)
- **Documentation**: Updated `docs/plugins.md` with annotation rendering behavior

### Test Plan

- Added 7 new unit tests covering annotation indexing, compact/expanded rendering, position preservation, and minibuffer summaries
- Existing tests pass; new functions exported in test allowlist
- Manual verification: toggle annotations in review buffer, verify compact indicators appear on annotated lines, expand to see full blocks, check echo-area preview on hover

https://claude.ai/code/session_01AX28EsRRuZrRKfyR6yHmrT