### PR TITLE
Add re-run button for completed plugins

### DIFF
--- a/bun_client/frontend/src/components/PluginOutput.tsx
+++ b/bun_client/frontend/src/components/PluginOutput.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect } from 'react';
 import { rpcCall } from '../api';
 import { Button, Badge, Card, mapStatusToVariant, Theme } from '../design';
-import { resolvePluginBody, sortedAnnotations, type PluginResult } from '../plugin_utils';
+import {
+    canRerunPlugin,
+    resolvePluginBody,
+    sortedAnnotations,
+    type PluginResult,
+} from '../plugin_utils';
 import PluginAnnotations from './PluginAnnotations';
 import PluginBodyView from './PluginBodyView';
 
@@ -159,6 +164,17 @@ export default function PluginOutput({
                                             gap: '10px',
                                         }}
                                     >
+                                        {canRerunPlugin(plugin) && (
+                                            <Button
+                                                onClick={() => executePlugin(pluginName)}
+                                                loading={executingPlugins.has(pluginName)}
+                                                variant="secondary"
+                                                size="sm"
+                                                title={`Re-run ${pluginName}`}
+                                            >
+                                                Re-run
+                                            </Button>
+                                        )}
                                         <Badge variant={mapStatusToVariant(plugin.status)}>
                                             {plugin.status}
                                         </Badge>

--- a/bun_client/frontend/src/components/review/PluginsPanel.tsx
+++ b/bun_client/frontend/src/components/review/PluginsPanel.tsx
@@ -1,5 +1,5 @@
 import { Button, colors, shadows } from '../../design';
-import { resolvePluginBody, sortedAnnotations } from '../../plugin_utils';
+import { canRerunPlugin, resolvePluginBody, sortedAnnotations } from '../../plugin_utils';
 import PluginAnnotations from '../PluginAnnotations';
 import PluginBodyView from '../PluginBodyView';
 import type { PluginResult } from './types';
@@ -115,39 +115,58 @@ export default function PluginsPanel({
                                         <span style={{ fontWeight: 600, fontSize: '14px' }}>
                                             {name}
                                         </span>
-                                        <span
+                                        <div
                                             style={{
-                                                fontSize: '11px',
-                                                padding: '2px 10px',
-                                                borderRadius: '12px',
-                                                fontWeight: 600,
-                                                background:
-                                                    data.status === 'success'
-                                                        ? colors.bgSuccessDim
-                                                        : data.status === 'pending'
-                                                          ? colors.bgWarningDim
-                                                          : colors.bgDangerDim,
-                                                color:
-                                                    data.status === 'success'
-                                                        ? colors.textSuccess
-                                                        : data.status === 'pending'
-                                                          ? colors.textWarning
-                                                          : colors.textDanger,
-                                                border: `1px solid ${data.status === 'success' ? colors.borderSuccessDim : data.status === 'pending' ? colors.borderWarningDim : colors.borderDangerDim}`,
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: '8px',
                                             }}
                                         >
-                                            {data.status.toUpperCase()}
-                                        </span>
-                                        {data.status.toLowerCase() === 'deferred' && (
-                                            <Button
-                                                onClick={() => onExecutePlugin(name)}
-                                                loading={executingPlugins.has(name)}
-                                                variant="secondary"
-                                                size="sm"
+                                            {canRerunPlugin(data) && (
+                                                <Button
+                                                    onClick={() => onExecutePlugin(name)}
+                                                    loading={executingPlugins.has(name)}
+                                                    variant="secondary"
+                                                    size="sm"
+                                                    title={`Re-run ${name}`}
+                                                >
+                                                    Re-run
+                                                </Button>
+                                            )}
+                                            <span
+                                                style={{
+                                                    fontSize: '11px',
+                                                    padding: '2px 10px',
+                                                    borderRadius: '12px',
+                                                    fontWeight: 600,
+                                                    background:
+                                                        data.status === 'success'
+                                                            ? colors.bgSuccessDim
+                                                            : data.status === 'pending'
+                                                              ? colors.bgWarningDim
+                                                              : colors.bgDangerDim,
+                                                    color:
+                                                        data.status === 'success'
+                                                            ? colors.textSuccess
+                                                            : data.status === 'pending'
+                                                              ? colors.textWarning
+                                                              : colors.textDanger,
+                                                    border: `1px solid ${data.status === 'success' ? colors.borderSuccessDim : data.status === 'pending' ? colors.borderWarningDim : colors.borderDangerDim}`,
+                                                }}
                                             >
-                                                Execute
-                                            </Button>
-                                        )}
+                                                {data.status.toUpperCase()}
+                                            </span>
+                                            {data.status.toLowerCase() === 'deferred' && (
+                                                <Button
+                                                    onClick={() => onExecutePlugin(name)}
+                                                    loading={executingPlugins.has(name)}
+                                                    variant="secondary"
+                                                    size="sm"
+                                                >
+                                                    Execute
+                                                </Button>
+                                            )}
+                                        </div>
                                     </div>
                                     <div
                                         className="plugin-output markdown-content"

--- a/bun_client/frontend/src/plugin_utils.test.ts
+++ b/bun_client/frontend/src/plugin_utils.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from 'bun:test';
 import {
     annotationSeverityVariant,
+    canRerunPlugin,
     resolvePluginBody,
     sortedAnnotations,
     totalAnnotationCount,
@@ -126,6 +127,26 @@ describe('annotationSeverityVariant', () => {
     test('falls back to neutral for free-form severities', () => {
         expect(annotationSeverityVariant('nitpick')).toBe('neutral');
         expect(annotationSeverityVariant('')).toBe('neutral');
+    });
+});
+
+describe('canRerunPlugin', () => {
+    test('offers a re-run for plugins that finished executing', () => {
+        expect(canRerunPlugin({ result: 'summary', status: 'success' })).toBe(true);
+        expect(canRerunPlugin({ result: 'Error: boom', status: 'error' })).toBe(true);
+    });
+
+    test('does not offer a re-run for a deferred plugin that never ran', () => {
+        expect(canRerunPlugin({ result: '', status: 'deferred' })).toBe(false);
+        expect(canRerunPlugin({ result: '', status: 'DEFERRED' })).toBe(false);
+    });
+
+    test('does not offer a re-run while a plugin is still in flight', () => {
+        expect(canRerunPlugin({ result: '', status: 'pending' })).toBe(false);
+    });
+
+    test('treats a missing status as not re-runnable', () => {
+        expect(canRerunPlugin({ result: '', status: '' })).toBe(false);
     });
 });
 

--- a/bun_client/frontend/src/plugin_utils.ts
+++ b/bun_client/frontend/src/plugin_utils.ts
@@ -90,6 +90,19 @@ export function annotationSeverityVariant(severity: string): StatusVariant {
     }
 }
 
+/**
+ * Whether a plugin can be re-run from the UI.
+ *
+ * Only plugins that have finished executing offer a re-run: a `deferred`
+ * plugin has never run (it gets an Execute button instead) and a `pending`
+ * one is still in flight. Everything else — success, error, or a status a
+ * newer server invents — has a result on screen worth refreshing.
+ */
+export function canRerunPlugin(plugin: PluginResult): boolean {
+    const status = (plugin.status || '').toLowerCase();
+    return status !== '' && status !== 'deferred' && status !== 'pending';
+}
+
 /** Total number of annotations across every plugin, for summary counts. */
 export function totalAnnotationCount(plugins: Record<string, PluginResult>): number {
     return Object.values(plugins).reduce((sum, p) => sum + (p.annotations?.length ?? 0), 0);


### PR DESCRIPTION
## Summary

Adds a "Re-run" button to the UI for plugins that have finished executing (success or error status), allowing users to refresh plugin results without reloading the page. Deferred plugins that have never run continue to show an "Execute" button, and pending plugins show no action button.

### Changes

- Added `canRerunPlugin()` utility function to determine which plugins can be re-run (those with a finished status: success, error, or any unknown status — but not deferred or pending)
- Updated `PluginsPanel.tsx` to display a "Re-run" button alongside the status badge for re-runnable plugins
- Updated `PluginOutput.tsx` to display a "Re-run" button in the plugin header for re-runnable plugins
- Refactored status badge layout in `PluginsPanel.tsx` from a single span to a flex container to accommodate the new button
- Added comprehensive unit tests for `canRerunPlugin()` covering success, error, deferred, pending, and missing status cases

## Test Plan

- [x] `bun run test` passes (new unit tests for `canRerunPlugin()` added)
- [x] `bun run type-check` passes
- [x] `bun run lint` passes

https://claude.ai/code/session_01AVBMnBAUNMCYhR1pWNsxEb