### PR TITLE
Add line-level annotations to summarize_diff plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 
-crs
-example_plugin
-summarize_diff
+# Binaries built into the repo root. Anchored, so they don't also ignore the
+# cmd/ directories the plugins are built from.
+/crs
+/example_plugin
+/summarize_diff

--- a/cmd/summarize_diff/main.go
+++ b/cmd/summarize_diff/main.go
@@ -8,7 +8,49 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 )
+
+// summarize_diff emits the plugin response contract described in
+// docs/plugins.md: a markdown body holding the summary, plus line-level
+// annotations anchored to the head side of the PR's diff.
+
+const (
+	bodyTypeMarkdown = "markdown"
+	severityInfo     = "info"
+
+	// maxAnnotations is what the model is asked for. A summary plugin that
+	// flags every other line is noise once the annotations render inline.
+	maxAnnotations = 6
+)
+
+// PluginBody is the renderable portion of a plugin response.
+type PluginBody struct {
+	BodyType    string `json:"body_type"`
+	BodyContent string `json:"body_content"`
+}
+
+// PluginAnnotation anchors a remark to a line of a file in the PR.
+type PluginAnnotation struct {
+	Filename string `json:"filename"`
+	Line     int    `json:"line"`
+	Severity string `json:"severity"`
+	Content  string `json:"content"`
+}
+
+// PluginResponse is the document written to stdout.
+type PluginResponse struct {
+	Body        PluginBody         `json:"body"`
+	Annotations []PluginAnnotation `json:"annotations"`
+}
+
+// modelOutput is the shape Gemini is asked to return, mirroring
+// responseSchema below.
+type modelOutput struct {
+	Summary     string             `json:"summary"`
+	Annotations []PluginAnnotation `json:"annotations"`
+}
 
 type GeminiPart struct {
 	Text string `json:"text"`
@@ -18,8 +60,26 @@ type GeminiContent struct {
 	Parts []GeminiPart `json:"parts"`
 }
 
+// GeminiSchema is the subset of the OpenAPI schema dialect Gemini accepts as
+// a response schema.
+type GeminiSchema struct {
+	Type             string                   `json:"type"`
+	Description      string                   `json:"description,omitempty"`
+	Enum             []string                 `json:"enum,omitempty"`
+	Items            *GeminiSchema            `json:"items,omitempty"`
+	Properties       map[string]*GeminiSchema `json:"properties,omitempty"`
+	PropertyOrdering []string                 `json:"propertyOrdering,omitempty"`
+	Required         []string                 `json:"required,omitempty"`
+}
+
+type GeminiGenerationConfig struct {
+	ResponseMimeType string        `json:"responseMimeType,omitempty"`
+	ResponseSchema   *GeminiSchema `json:"responseSchema,omitempty"`
+}
+
 type GeminiRequest struct {
-	Contents []GeminiContent `json:"contents"`
+	Contents         []GeminiContent         `json:"contents"`
+	GenerationConfig *GeminiGenerationConfig `json:"generationConfig,omitempty"`
 }
 
 type GeminiResponse struct {
@@ -33,28 +93,150 @@ type GeminiResponse struct {
 }
 
 type PRMetadata struct {
-	Number      int      `json:"number"`
-	Title       string   `json:"title"`
-	Author      string   `json:"author"`
-	BaseRef     string   `json:"base_ref"`
-	HeadRef     string   `json:"head_ref"`
-	State       string   `json:"state"`
-	Milestone   string   `json:"milestone"`
-	Labels      []string `json:"labels"`
-	Assignees   []string `json:"assignees"`
-	Reviewers   []string `json:"reviewers"`
-	Draft       bool     `json:"draft"`
-	CIStatus    string   `json:"ci_status"`
-		CIFailures         []string `json:"ci_failures"`
-		Body               string   `json:"body"`
-		URL                string   `json:"url"`
-		WorktreePath       string   `json:"worktree_path"`
+	Number       int      `json:"number"`
+	Title        string   `json:"title"`
+	Author       string   `json:"author"`
+	BaseRef      string   `json:"base_ref"`
+	HeadRef      string   `json:"head_ref"`
+	State        string   `json:"state"`
+	Milestone    string   `json:"milestone"`
+	Labels       []string `json:"labels"`
+	Assignees    []string `json:"assignees"`
+	Reviewers    []string `json:"reviewers"`
+	Draft        bool     `json:"draft"`
+	CIStatus     string   `json:"ci_status"`
+	CIFailures   []string `json:"ci_failures"`
+	Body         string   `json:"body"`
+	URL          string   `json:"url"`
+	WorktreePath string   `json:"worktree_path"`
+}
+
+// responseSchema constrains Gemini's reply to the summary and annotations we
+// know how to turn into a plugin response.
+func responseSchema() *GeminiSchema {
+	return &GeminiSchema{
+		Type: "OBJECT",
+		Properties: map[string]*GeminiSchema{
+			"summary": {
+				Type:        "STRING",
+				Description: "Terse markdown summary of the PR.",
+			},
+			"annotations": {
+				Type:        "ARRAY",
+				Description: "Line-level remarks, at most " + strconv.Itoa(maxAnnotations) + ".",
+				Items: &GeminiSchema{
+					Type: "OBJECT",
+					Properties: map[string]*GeminiSchema{
+						"filename": {
+							Type:        "STRING",
+							Description: "Path of the annotated file, copied exactly from the diff.",
+						},
+						"line": {
+							Type:        "INTEGER",
+							Description: "Head-side line number shown beside the annotated line.",
+						},
+						"severity": {
+							Type: "STRING",
+							Enum: []string{severityInfo, "warning", "error"},
+						},
+						"content": {
+							Type:        "STRING",
+							Description: "One or two sentences about that line.",
+						},
+					},
+					PropertyOrdering: []string{"filename", "line", "severity", "content"},
+					Required:         []string{"filename", "line", "severity", "content"},
+				},
+			},
+		},
+		PropertyOrdering: []string{"summary", "annotations"},
+		Required:         []string{"summary", "annotations"},
+	}
+}
+
+// trimDiffPath cleans a path out of a diff file header, dropping git's a/ or
+// b/ prefix and reporting /dev/null as no path at all.
+func trimDiffPath(raw, prefix string) string {
+	path := strings.TrimSpace(raw)
+	if path == "/dev/null" {
+		return ""
+	}
+	return strings.TrimPrefix(path, prefix)
+}
+
+// hunkNewStart pulls the head-side starting line out of a hunk header such as
+// "@@ -12,7 +14,9 @@ func main() {".
+func hunkNewStart(header string) (int, bool) {
+	_, after, found := strings.Cut(header, "+")
+	if !found {
+		return 0, false
+	}
+	field, _, _ := strings.Cut(after, " ")
+	field, _, _ = strings.Cut(field, ",")
+	start, err := strconv.Atoi(field)
+	if err != nil || start < 0 {
+		return 0, false
+	}
+	return start, true
+}
+
+// numberedDiff rewrites a unified diff with each line's head-side line number
+// — the number an annotation anchors to — and returns the files it found.
+// Lines are rendered as "<mark> <line> | <content>"; removed lines exist only
+// on the base side and so carry no number.
+func numberedDiff(diff string) (string, []string) {
+	var (
+		out      strings.Builder
+		files    []string
+		baseName string
+		newLine  int
+		inHunk   bool
+	)
+
+	for _, line := range strings.Split(strings.TrimSuffix(diff, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			inHunk, baseName = false, ""
+		case strings.HasPrefix(line, "--- "):
+			baseName = trimDiffPath(strings.TrimPrefix(line, "--- "), "a/")
+			inHunk = false
+		case strings.HasPrefix(line, "+++ "):
+			inHunk = false
+			name := trimDiffPath(strings.TrimPrefix(line, "+++ "), "b/")
+			if name == "" {
+				// Deleted file: the base-side path is the only one it has.
+				name = baseName
+			}
+			if name == "" {
+				continue
+			}
+			files = append(files, name)
+			fmt.Fprintf(&out, "\n=== FILE: %s ===\n", name)
+		case strings.HasPrefix(line, "@@"):
+			start, ok := hunkNewStart(line)
+			if !ok {
+				continue
+			}
+			newLine, inHunk = start, true
+			fmt.Fprintf(&out, "%s\n", line)
+		case !inHunk:
+			// index/mode/rename lines between files: nothing to number.
+		case line == `\ No newline at end of file`:
+		case strings.HasPrefix(line, "-"):
+			fmt.Fprintf(&out, "- %5s | %s\n", "", line[1:])
+		case strings.HasPrefix(line, "+"):
+			fmt.Fprintf(&out, "+ %5d | %s\n", newLine, line[1:])
+			newLine++
+		default:
+			fmt.Fprintf(&out, "  %5d | %s\n", newLine, strings.TrimPrefix(line, " "))
+			newLine++
+		}
 	}
 
-func callGemini(diff string, metadata PRMetadata, geminiToken string) (string, error) {
-	// Using gemini-2.0-flash
-	url := "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=" + geminiToken
+	return strings.TrimSpace(out.String()), files
+}
 
+func buildPrompt(diff string, metadata PRMetadata) string {
 	var contextInfo string
 	if metadata.Title != "" {
 		contextInfo += fmt.Sprintf("PR Title: %s\n", metadata.Title)
@@ -63,23 +245,56 @@ func callGemini(diff string, metadata PRMetadata, geminiToken string) (string, e
 		contextInfo += fmt.Sprintf("PR Description: %s\n", metadata.Body)
 	}
 
-	prompt := fmt.Sprintf(`Summarize this PR as briefly as possible.
-- 2-4 bullet points on key changes (one line each)
-- 1-2 brief suggestions if any
+	rendered, files := numberedDiff(diff)
+	fileList := "(none parsed - return an empty annotations list)"
+	if len(files) > 0 {
+		fileList = strings.Join(files, "\n")
+	}
+	if rendered == "" {
+		rendered = diff
+	}
 
-Be terse. No fluff.
+	return fmt.Sprintf(`Summarize this PR, and flag the specific lines a reviewer should look at.
+
+summary: 2-4 bullet points on key changes (one line each), then 1-2 brief
+suggestions if any. Markdown. Be terse. No fluff.
+
+annotations: at most %d remarks, each anchored to one line of the diff. Only
+annotate a line that genuinely warrants a reviewer's attention; an empty list
+is fine.
+- filename: one of the paths listed under Files, copied exactly.
+- line: the number shown beside that line in the diff. Lines marked "-" were
+  removed and have no number, so they cannot be annotated.
+- severity: %s, warning or error.
+- content: one or two sentences.
+
+Files:
+%s
+
+The diff is rendered as "<mark> <line number> | <content>", where mark is "+"
+for an added line, "-" for a removed one and blank for an unchanged one. The
+line number is the line's position in the file after this PR is merged.
 
 %sDiff:
 %s
-`, contextInfo, diff)
+`, maxAnnotations, severityInfo, fileList, contextInfo, rendered)
+}
+
+func callGemini(diff string, metadata PRMetadata, geminiToken string) (string, error) {
+	// Using gemini-2.5-flash
+	url := "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=" + geminiToken
 
 	reqBody := GeminiRequest{
 		Contents: []GeminiContent{
 			{
 				Parts: []GeminiPart{
-					{Text: prompt},
+					{Text: buildPrompt(diff, metadata)},
 				},
 			},
+		},
+		GenerationConfig: &GeminiGenerationConfig{
+			ResponseMimeType: "application/json",
+			ResponseSchema:   responseSchema(),
 		},
 	}
 
@@ -109,6 +324,67 @@ Be terse. No fluff.
 	}
 
 	return "", fmt.Errorf("no content in response")
+}
+
+// trimCodeFence unwraps a ```json fence, which models add when they answer in
+// prose formatting despite the requested response MIME type.
+func trimCodeFence(reply string) string {
+	trimmed := strings.TrimSpace(reply)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+	_, after, found := strings.Cut(trimmed, "\n")
+	if !found {
+		return trimmed
+	}
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(after), "```"))
+}
+
+// sanitizeAnnotations drops annotations the server would drop anyway (no
+// filename, no positive line) or that carry no text, and normalizes the rest.
+func sanitizeAnnotations(annotations []PluginAnnotation) []PluginAnnotation {
+	cleaned := []PluginAnnotation{}
+	for _, a := range annotations {
+		a.Filename = strings.TrimPrefix(strings.TrimSpace(a.Filename), "./")
+		a.Content = strings.TrimSpace(a.Content)
+		a.Severity = strings.ToLower(strings.TrimSpace(a.Severity))
+		if a.Filename == "" || a.Line < 1 || a.Content == "" {
+			continue
+		}
+		if a.Severity == "" {
+			a.Severity = severityInfo
+		}
+		cleaned = append(cleaned, a)
+	}
+	return cleaned
+}
+
+// responseFor turns Gemini's reply into a plugin response. A reply that isn't
+// the JSON we asked for becomes the body verbatim, which is what this plugin
+// emitted before it spoke the contract.
+func responseFor(reply string) PluginResponse {
+	var parsed modelOutput
+	if err := json.Unmarshal([]byte(trimCodeFence(reply)), &parsed); err != nil || strings.TrimSpace(parsed.Summary) == "" {
+		return PluginResponse{
+			Body:        PluginBody{BodyType: bodyTypeMarkdown, BodyContent: reply},
+			Annotations: []PluginAnnotation{},
+		}
+	}
+
+	return PluginResponse{
+		Body:        PluginBody{BodyType: bodyTypeMarkdown, BodyContent: strings.TrimSpace(parsed.Summary)},
+		Annotations: sanitizeAnnotations(parsed.Annotations),
+	}
+}
+
+// encodeResponse writes the response contract document a client will parse.
+// HTML escaping is off so the stored raw output stays readable, and the
+// indentation is there for the same reason.
+func encodeResponse(w io.Writer, response PluginResponse) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(response)
 }
 
 func main() {
@@ -151,5 +427,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println(summary)
+	if err := encodeResponse(os.Stdout, responseFor(summary)); err != nil {
+		fmt.Printf("Error encoding plugin response: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/summarize_diff/main_test.go
+++ b/cmd/summarize_diff/main_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"bytes"
+	"crs/server"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const sampleDiff = `diff --git a/server/plugins.go b/server/plugins.go
+index 1111111..2222222 100644
+--- a/server/plugins.go
++++ b/server/plugins.go
+@@ -10,4 +10,5 @@ func executePlugin() {
+ 	ctx := context.Background()
+-	old := run(ctx)
++	fresh := run(ctx)
++	log(fresh)
+ 	return
+@@ -30,2 +31,3 @@
+ 	tail()
++	extra()
+diff --git a/README.md b/README.md
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/README.md
+@@ -0,0 +1,2 @@
++# Title
++body
+diff --git a/old.txt b/old.txt
+deleted file mode 100644
+index 4444444..0000000
+--- a/old.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-gone
+-also gone
+`
+
+// canonical rewrites numbered diff lines as "<mark><line>:<content>" so the
+// expectations below stay readable without hard-coding column widths. Headers
+// pass through untouched.
+func canonical(rendered string) []string {
+	lines := []string{}
+	for _, line := range strings.Split(rendered, "\n") {
+		head, content, ok := strings.Cut(line, " | ")
+		if !ok {
+			lines = append(lines, line)
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%c%s:%s", head[0], strings.TrimSpace(head[1:]), content))
+	}
+	return lines
+}
+
+func TestNumberedDiff(t *testing.T) {
+	rendered, files := numberedDiff(sampleDiff)
+
+	wantFiles := []string{"server/plugins.go", "README.md", "old.txt"}
+	if !reflect.DeepEqual(files, wantFiles) {
+		t.Errorf("files = %v, want %v", files, wantFiles)
+	}
+
+	// Numbers count the head side: unchanged and added lines carry the line
+	// they will occupy once the PR merges, removed lines carry none.
+	want := []string{
+		"=== FILE: server/plugins.go ===",
+		"@@ -10,4 +10,5 @@ func executePlugin() {",
+		" 10:\tctx := context.Background()",
+		"-:\told := run(ctx)",
+		"+11:\tfresh := run(ctx)",
+		"+12:\tlog(fresh)",
+		" 13:\treturn",
+		"@@ -30,2 +31,3 @@",
+		" 31:\ttail()",
+		"+32:\textra()",
+		"",
+		"=== FILE: README.md ===",
+		"@@ -0,0 +1,2 @@",
+		"+1:# Title",
+		"+2:body",
+		"",
+		"=== FILE: old.txt ===",
+		"@@ -1,2 +0,0 @@",
+		"-:gone",
+		"-:also gone",
+	}
+	if got := canonical(rendered); !reflect.DeepEqual(got, want) {
+		t.Errorf("numbered diff mismatch\ngot:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestNumberedDiffSkipsUnannotatableLines(t *testing.T) {
+	// A binary file has no lines to anchor to, and the no-newline marker isn't
+	// a line of either side. An empty context line is a line, though: diffs
+	// that strip its leading space still have to keep the count in step.
+	diff := "diff --git a/img.png b/img.png\n" +
+		"index 0000000..abc1234\n" +
+		"Binary files /dev/null and b/img.png differ\n" +
+		"diff --git a/a.txt b/a.txt\n" +
+		"--- a/a.txt\n" +
+		"+++ b/a.txt\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		" first\n" +
+		"\n" +
+		"+added\n" +
+		"\\ No newline at end of file\n"
+
+	rendered, files := numberedDiff(diff)
+	if !reflect.DeepEqual(files, []string{"a.txt"}) {
+		t.Errorf("files = %v, want [a.txt]", files)
+	}
+	want := []string{
+		"=== FILE: a.txt ===",
+		"@@ -1,3 +1,3 @@",
+		" 1:first",
+		" 2:",
+		"+3:added",
+	}
+	if got := canonical(rendered); !reflect.DeepEqual(got, want) {
+		t.Errorf("numbered diff mismatch\ngot:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestNumberedDiffWithoutHunks(t *testing.T) {
+	// A diff the renderer can't make sense of yields nothing to annotate, and
+	// buildPrompt falls back to the raw text.
+	rendered, files := numberedDiff("not a diff at all")
+	if rendered != "" || len(files) != 0 {
+		t.Fatalf("numberedDiff(garbage) = %q, %v; want empty", rendered, files)
+	}
+
+	prompt := buildPrompt("not a diff at all", PRMetadata{})
+	if !strings.Contains(prompt, "not a diff at all") {
+		t.Error("prompt dropped the diff it could not number")
+	}
+	if !strings.Contains(prompt, "(none parsed") {
+		t.Error("prompt did not tell the model there are no annotatable files")
+	}
+}
+
+func TestBuildPromptListsFilesAndContext(t *testing.T) {
+	prompt := buildPrompt(sampleDiff, PRMetadata{Title: "Add a thing", Body: "Because."})
+
+	for _, want := range []string{
+		"PR Title: Add a thing",
+		"PR Description: Because.",
+		"server/plugins.go",
+		"README.md",
+		"+    11 | \tfresh := run(ctx)",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+func TestResponseFor(t *testing.T) {
+	tests := []struct {
+		name            string
+		reply           string
+		wantBody        string
+		wantAnnotations []PluginAnnotation
+	}{
+		{
+			name:     "structured reply",
+			reply:    `{"summary":"- did a thing","annotations":[{"filename":"server/plugins.go","line":11,"severity":"warning","content":"looks wrong"}]}`,
+			wantBody: "- did a thing",
+			wantAnnotations: []PluginAnnotation{
+				{Filename: "server/plugins.go", Line: 11, Severity: "warning", Content: "looks wrong"},
+			},
+		},
+		{
+			name:            "fenced reply",
+			reply:           "```json\n{\"summary\":\"- did a thing\",\"annotations\":[]}\n```",
+			wantBody:        "- did a thing",
+			wantAnnotations: []PluginAnnotation{},
+		},
+		{
+			name: "annotations normalized and unanchorable ones dropped",
+			reply: `{"summary":"s","annotations":[
+				{"filename":"./main.go","line":3,"severity":"WARNING","content":" spaced "},
+				{"filename":"main.go","line":4,"severity":"","content":"no severity"},
+				{"filename":"","line":5,"severity":"info","content":"no file"},
+				{"filename":"main.go","line":0,"severity":"info","content":"no line"},
+				{"filename":"main.go","line":6,"severity":"info","content":"  "}
+			]}`,
+			wantBody: "s",
+			wantAnnotations: []PluginAnnotation{
+				{Filename: "main.go", Line: 3, Severity: "warning", Content: "spaced"},
+				{Filename: "main.go", Line: 4, Severity: severityInfo, Content: "no severity"},
+			},
+		},
+		{
+			// Plain text is what this plugin used to emit, and what it still
+			// emits if the model ignores the schema.
+			name:            "legacy plain text",
+			reply:           "- just a summary\n- no JSON here",
+			wantBody:        "- just a summary\n- no JSON here",
+			wantAnnotations: []PluginAnnotation{},
+		},
+		{
+			name:            "json without a summary",
+			reply:           `{"summary":"","annotations":[{"filename":"main.go","line":2,"severity":"info","content":"x"}]}`,
+			wantBody:        `{"summary":"","annotations":[{"filename":"main.go","line":2,"severity":"info","content":"x"}]}`,
+			wantAnnotations: []PluginAnnotation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := responseFor(tt.reply)
+			if got.Body.BodyType != bodyTypeMarkdown {
+				t.Errorf("body type = %q, want %q", got.Body.BodyType, bodyTypeMarkdown)
+			}
+			if got.Body.BodyContent != tt.wantBody {
+				t.Errorf("body = %q, want %q", got.Body.BodyContent, tt.wantBody)
+			}
+			if !reflect.DeepEqual(got.Annotations, tt.wantAnnotations) {
+				t.Errorf("annotations = %+v, want %+v", got.Annotations, tt.wantAnnotations)
+			}
+		})
+	}
+}
+
+// TestEncodedOutputMatchesContract runs what the plugin writes to stdout
+// through the server's parser, which is what decides whether a plugin speaks
+// the contract or gets treated as legacy output.
+func TestEncodedOutputMatchesContract(t *testing.T) {
+	response := responseFor(`{"summary":"- <b>bold</b> & terse","annotations":[{"filename":"server/plugins.go","line":11,"severity":"warning","content":"looks wrong"}]}`)
+
+	var out bytes.Buffer
+	if err := encodeResponse(&out, response); err != nil {
+		t.Fatalf("encodeResponse: %v", err)
+	}
+	if strings.Contains(out.String(), "\\u003c") {
+		t.Error("stdout escaped HTML, which makes the stored raw result unreadable")
+	}
+
+	parsed := server.ParsePluginOutput(out.String())
+	if parsed.Body.BodyType != server.BodyTypeMarkdown {
+		t.Errorf("parsed body type = %q, want %q", parsed.Body.BodyType, server.BodyTypeMarkdown)
+	}
+	if parsed.Body.BodyContent != "- <b>bold</b> & terse" {
+		t.Errorf("parsed body = %q", parsed.Body.BodyContent)
+	}
+	want := []server.PluginAnnotation{
+		{Filename: "server/plugins.go", Line: 11, Severity: "warning", Content: "looks wrong"},
+	}
+	if !reflect.DeepEqual(parsed.Annotations, want) {
+		t.Errorf("parsed annotations = %+v, want %+v", parsed.Annotations, want)
+	}
+}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -55,7 +55,7 @@ OnlyOnDemand = true    # This plugin only runs when explicitly requested
 
 ## Included Plugins
 
-- **Summarize Diff**: Uses Gemini 2.5 Flash to provide a terse bulleted summary of the changes in a PR.
+- **Summarize Diff**: Uses Gemini 2.5 Flash to provide a terse bulleted summary of the changes in a PR. Emits the [response contract](#plugin-response-contract): a markdown body holding the summary, plus up to six annotations anchored to the lines worth a reviewer's attention.
 - **Security Check**: Uses Gemini 2.5 Flash to analyze the diff for potential security risks, specifically looking for unprotected sensitive endpoints, hardcoded secrets, or missing security decorators (like `@authenticated`).
 - **Style Guidelines**: Uses Gemini 2.5 Flash to evaluate a PR's diff against your personal style guide. Reads rules from `~/.config/style_guidelines.md` and reports violations, compliance highlights, and an overall assessment. Requires `GEMINI_API_KEY`. See [Style Guidelines Plugin](#style-guidelines-plugin) below.
 - **Claude Review**: Runs `claude -p "review PR #<number> on repo <owner>/<repo>" --model sonnet` via the Claude CLI. Written in Zig. Build with `zig build` inside `cmd/claude_review/` and place the resulting binary on your `$PATH`.


### PR DESCRIPTION
## Summary

Enhance the `summarize_diff` plugin to emit structured JSON responses with line-level annotations, matching the plugin response contract defined in `docs/plugins.md`. The plugin now uses Gemini's response schema to request both a summary and specific line-level remarks anchored to the diff.

### Changes

- **Add plugin response contract types**: `PluginBody`, `PluginAnnotation`, and `PluginResponse` structs to match the documented contract
- **Implement diff numbering**: `numberedDiff()` parses unified diffs and annotates each line with its head-side line number, enabling reviewers to anchor comments to specific lines
- **Add response schema generation**: `responseSchema()` constrains Gemini's reply to summary + annotations via OpenAPI schema validation
- **Enhance prompt**: `buildPrompt()` now instructs the model to provide both a summary and up to 6 line-level annotations, with file paths and line numbers
- **Add response parsing**: `responseFor()` parses Gemini's JSON reply, handles legacy plain-text fallback, and `sanitizeAnnotations()` validates and normalizes annotations
- **Update Gemini request**: Include `GenerationConfig` with `responseMimeType: "application/json"` and the response schema
- **Output structured JSON**: `encodeResponse()` writes the plugin response contract to stdout with readable formatting
- **Add comprehensive tests**: `main_test.go` covers diff numbering, prompt building, response parsing, and contract compliance

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — new unit tests verify diff numbering, prompt generation, response parsing, and contract compliance

https://claude.ai/code/session_01YDJ423RNG6NkeTFPM7LU16