### PR TITLE
style_guidelines: emit the plugin response contract

### DIFF
--- a/cmd/internal/pluginkit/contract.go
+++ b/cmd/internal/pluginkit/contract.go
@@ -1,0 +1,124 @@
+// Package pluginkit holds the pieces a plugin binary in this repo needs to
+// speak the plugin response contract described in docs/plugins.md: a body the
+// client renders, plus line-level annotations anchored to the head side of the
+// PR's diff.
+package pluginkit
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+const (
+	BodyTypeMarkdown = "markdown"
+
+	SeverityInfo    = "info"
+	SeverityWarning = "warning"
+	SeverityError   = "error"
+)
+
+// Body is the renderable portion of a plugin response.
+type Body struct {
+	BodyType    string `json:"body_type"`
+	BodyContent string `json:"body_content"`
+}
+
+// Annotation anchors a remark to a line of a file in the PR.
+type Annotation struct {
+	Filename string `json:"filename"`
+	Line     int    `json:"line"`
+	Severity string `json:"severity"`
+	Content  string `json:"content"`
+}
+
+// Response is the document a plugin writes to stdout.
+type Response struct {
+	Body        Body         `json:"body"`
+	Annotations []Annotation `json:"annotations"`
+}
+
+// MarkdownResponse builds a response whose body is rendered as markdown,
+// dropping annotations the server would drop anyway.
+func MarkdownResponse(body string, annotations []Annotation) Response {
+	return Response{
+		Body:        Body{BodyType: BodyTypeMarkdown, BodyContent: body},
+		Annotations: SanitizeAnnotations(annotations),
+	}
+}
+
+// SanitizeAnnotations drops annotations that can't be anchored (no filename,
+// no positive line) or that carry no text, and normalizes the rest.
+func SanitizeAnnotations(annotations []Annotation) []Annotation {
+	cleaned := []Annotation{}
+	for _, a := range annotations {
+		a.Filename = strings.TrimPrefix(strings.TrimSpace(a.Filename), "./")
+		a.Content = strings.TrimSpace(a.Content)
+		a.Severity = strings.ToLower(strings.TrimSpace(a.Severity))
+		if a.Filename == "" || a.Line < 1 || a.Content == "" {
+			continue
+		}
+		if a.Severity == "" {
+			a.Severity = SeverityInfo
+		}
+		cleaned = append(cleaned, a)
+	}
+	return cleaned
+}
+
+// TrimCodeFence unwraps a ```json fence, which models add when they answer in
+// prose formatting despite the requested response MIME type.
+func TrimCodeFence(reply string) string {
+	trimmed := strings.TrimSpace(reply)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+	_, after, found := strings.Cut(trimmed, "\n")
+	if !found {
+		return trimmed
+	}
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(after), "```"))
+}
+
+// EncodeResponse writes the response contract document a client will parse.
+// HTML escaping is off so the stored raw output stays readable, and the
+// indentation is there for the same reason.
+func EncodeResponse(w io.Writer, response Response) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(response)
+}
+
+// PRMetadata is the PR shape passed to a plugin via the --headers flag.
+type PRMetadata struct {
+	Number       int      `json:"number"`
+	Title        string   `json:"title"`
+	Author       string   `json:"author"`
+	BaseRef      string   `json:"base_ref"`
+	HeadRef      string   `json:"head_ref"`
+	State        string   `json:"state"`
+	Milestone    string   `json:"milestone"`
+	Labels       []string `json:"labels"`
+	Assignees    []string `json:"assignees"`
+	Reviewers    []string `json:"reviewers"`
+	Draft        bool     `json:"draft"`
+	CIStatus     string   `json:"ci_status"`
+	CIFailures   []string `json:"ci_failures"`
+	Body         string   `json:"body"`
+	URL          string   `json:"url"`
+	WorktreePath string   `json:"worktree_path"`
+}
+
+// Context renders the PR title and description a prompt wants alongside the
+// diff, as lines ending in a newline (empty when the PR has neither).
+func (m PRMetadata) Context() string {
+	var context string
+	if m.Title != "" {
+		context += "PR Title: " + m.Title + "\n"
+	}
+	if m.Body != "" {
+		context += "PR Description: " + m.Body + "\n"
+	}
+	return context
+}

--- a/cmd/internal/pluginkit/contract_test.go
+++ b/cmd/internal/pluginkit/contract_test.go
@@ -1,0 +1,89 @@
+package pluginkit
+
+import (
+	"bytes"
+	"crs/server"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeAnnotations(t *testing.T) {
+	got := SanitizeAnnotations([]Annotation{
+		{Filename: "./main.go", Line: 3, Severity: "WARNING", Content: " spaced "},
+		{Filename: "main.go", Line: 4, Severity: "", Content: "no severity"},
+		{Filename: "", Line: 5, Severity: SeverityInfo, Content: "no file"},
+		{Filename: "main.go", Line: 0, Severity: SeverityInfo, Content: "no line"},
+		{Filename: "main.go", Line: 6, Severity: SeverityInfo, Content: "  "},
+	})
+
+	want := []Annotation{
+		{Filename: "main.go", Line: 3, Severity: SeverityWarning, Content: "spaced"},
+		{Filename: "main.go", Line: 4, Severity: SeverityInfo, Content: "no severity"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("annotations = %+v, want %+v", got, want)
+	}
+}
+
+func TestSanitizeAnnotationsIsNeverNil(t *testing.T) {
+	// The contract's annotations key should encode as [], not null.
+	if got := SanitizeAnnotations(nil); got == nil || len(got) != 0 {
+		t.Errorf("SanitizeAnnotations(nil) = %#v, want an empty slice", got)
+	}
+}
+
+func TestTrimCodeFence(t *testing.T) {
+	tests := map[string]string{
+		"```json\n{\"a\":1}\n```": `{"a":1}`,
+		"```\n{\"a\":1}\n```":     `{"a":1}`,
+		` {"a":1} `:               `{"a":1}`,
+		"```no newline":           "```no newline",
+	}
+	for reply, want := range tests {
+		if got := TrimCodeFence(reply); got != want {
+			t.Errorf("TrimCodeFence(%q) = %q, want %q", reply, got, want)
+		}
+	}
+}
+
+func TestPRMetadataContext(t *testing.T) {
+	if got := (PRMetadata{}).Context(); got != "" {
+		t.Errorf("empty metadata context = %q, want empty", got)
+	}
+	got := PRMetadata{Title: "Add a thing", Body: "Because."}.Context()
+	if got != "PR Title: Add a thing\nPR Description: Because.\n" {
+		t.Errorf("context = %q", got)
+	}
+}
+
+// TestEncodedResponseMatchesContract runs what a plugin writes to stdout
+// through the server's parser, which is what decides whether a plugin speaks
+// the contract or gets treated as legacy output.
+func TestEncodedResponseMatchesContract(t *testing.T) {
+	response := MarkdownResponse("- <b>bold</b> & terse", []Annotation{
+		{Filename: "server/plugins.go", Line: 11, Severity: SeverityWarning, Content: "looks wrong"},
+	})
+
+	var out bytes.Buffer
+	if err := EncodeResponse(&out, response); err != nil {
+		t.Fatalf("EncodeResponse: %v", err)
+	}
+	if strings.Contains(out.String(), "\\u003c") {
+		t.Error("stdout escaped HTML, which makes the stored raw result unreadable")
+	}
+
+	parsed := server.ParsePluginOutput(out.String())
+	if parsed.Body.BodyType != server.BodyTypeMarkdown {
+		t.Errorf("parsed body type = %q, want %q", parsed.Body.BodyType, server.BodyTypeMarkdown)
+	}
+	if parsed.Body.BodyContent != "- <b>bold</b> & terse" {
+		t.Errorf("parsed body = %q", parsed.Body.BodyContent)
+	}
+	want := []server.PluginAnnotation{
+		{Filename: "server/plugins.go", Line: 11, Severity: SeverityWarning, Content: "looks wrong"},
+	}
+	if !reflect.DeepEqual(parsed.Annotations, want) {
+		t.Errorf("parsed annotations = %+v, want %+v", parsed.Annotations, want)
+	}
+}

--- a/cmd/internal/pluginkit/diff.go
+++ b/cmd/internal/pluginkit/diff.go
@@ -1,0 +1,109 @@
+package pluginkit
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// trimDiffPath cleans a path out of a diff file header, dropping git's a/ or
+// b/ prefix and reporting /dev/null as no path at all.
+func trimDiffPath(raw, prefix string) string {
+	path := strings.TrimSpace(raw)
+	if path == "/dev/null" {
+		return ""
+	}
+	return strings.TrimPrefix(path, prefix)
+}
+
+// hunkNewStart pulls the head-side starting line out of a hunk header such as
+// "@@ -12,7 +14,9 @@ func main() {".
+func hunkNewStart(header string) (int, bool) {
+	_, after, found := strings.Cut(header, "+")
+	if !found {
+		return 0, false
+	}
+	field, _, _ := strings.Cut(after, " ")
+	field, _, _ = strings.Cut(field, ",")
+	start, err := strconv.Atoi(field)
+	if err != nil || start < 0 {
+		return 0, false
+	}
+	return start, true
+}
+
+// NumberedDiff rewrites a unified diff with each line's head-side line number
+// — the number an annotation anchors to — and returns the files it found.
+// Lines are rendered as "<mark> <line> | <content>"; removed lines exist only
+// on the base side and so carry no number.
+func NumberedDiff(diff string) (string, []string) {
+	var (
+		out      strings.Builder
+		files    []string
+		baseName string
+		newLine  int
+		inHunk   bool
+	)
+
+	for _, line := range strings.Split(strings.TrimSuffix(diff, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			inHunk, baseName = false, ""
+		case strings.HasPrefix(line, "--- "):
+			baseName = trimDiffPath(strings.TrimPrefix(line, "--- "), "a/")
+			inHunk = false
+		case strings.HasPrefix(line, "+++ "):
+			inHunk = false
+			name := trimDiffPath(strings.TrimPrefix(line, "+++ "), "b/")
+			if name == "" {
+				// Deleted file: the base-side path is the only one it has.
+				name = baseName
+			}
+			if name == "" {
+				continue
+			}
+			files = append(files, name)
+			fmt.Fprintf(&out, "\n=== FILE: %s ===\n", name)
+		case strings.HasPrefix(line, "@@"):
+			start, ok := hunkNewStart(line)
+			if !ok {
+				continue
+			}
+			newLine, inHunk = start, true
+			fmt.Fprintf(&out, "%s\n", line)
+		case !inHunk:
+			// index/mode/rename lines between files: nothing to number.
+		case line == `\ No newline at end of file`:
+		case strings.HasPrefix(line, "-"):
+			fmt.Fprintf(&out, "- %5s | %s\n", "", line[1:])
+		case strings.HasPrefix(line, "+"):
+			fmt.Fprintf(&out, "+ %5d | %s\n", newLine, line[1:])
+			newLine++
+		default:
+			fmt.Fprintf(&out, "  %5d | %s\n", newLine, strings.TrimPrefix(line, " "))
+			newLine++
+		}
+	}
+
+	return strings.TrimSpace(out.String()), files
+}
+
+// DiffLegend explains the rendering of NumberedDiff to a model being asked for
+// annotations.
+const DiffLegend = `The diff is rendered as "<mark> <line number> | <content>", where mark is "+"
+for an added line, "-" for a removed one and blank for an unchanged one. The
+line number is the line's position in the file after this PR is merged.`
+
+// PromptDiff renders a diff for a prompt along with the list of files that can
+// be annotated. A diff the renderer can't make sense of is passed through
+// verbatim with an empty file list, so the model still sees the changes.
+func PromptDiff(diff string) (rendered, fileList string) {
+	rendered, files := NumberedDiff(diff)
+	if rendered == "" {
+		rendered = diff
+	}
+	if len(files) == 0 {
+		return rendered, "(none parsed - return an empty annotations list)"
+	}
+	return rendered, strings.Join(files, "\n")
+}

--- a/cmd/internal/pluginkit/diff_test.go
+++ b/cmd/internal/pluginkit/diff_test.go
@@ -1,0 +1,154 @@
+package pluginkit
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const sampleDiff = `diff --git a/server/plugins.go b/server/plugins.go
+index 1111111..2222222 100644
+--- a/server/plugins.go
++++ b/server/plugins.go
+@@ -10,4 +10,5 @@ func executePlugin() {
+ 	ctx := context.Background()
+-	old := run(ctx)
++	fresh := run(ctx)
++	log(fresh)
+ 	return
+@@ -30,2 +31,3 @@
+ 	tail()
++	extra()
+diff --git a/README.md b/README.md
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/README.md
+@@ -0,0 +1,2 @@
++# Title
++body
+diff --git a/old.txt b/old.txt
+deleted file mode 100644
+index 4444444..0000000
+--- a/old.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-gone
+-also gone
+`
+
+// canonical rewrites numbered diff lines as "<mark><line>:<content>" so the
+// expectations below stay readable without hard-coding column widths. Headers
+// pass through untouched.
+func canonical(rendered string) []string {
+	lines := []string{}
+	for _, line := range strings.Split(rendered, "\n") {
+		head, content, ok := strings.Cut(line, " | ")
+		if !ok {
+			lines = append(lines, line)
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%c%s:%s", head[0], strings.TrimSpace(head[1:]), content))
+	}
+	return lines
+}
+
+func TestNumberedDiff(t *testing.T) {
+	rendered, files := NumberedDiff(sampleDiff)
+
+	wantFiles := []string{"server/plugins.go", "README.md", "old.txt"}
+	if !reflect.DeepEqual(files, wantFiles) {
+		t.Errorf("files = %v, want %v", files, wantFiles)
+	}
+
+	// Numbers count the head side: unchanged and added lines carry the line
+	// they will occupy once the PR merges, removed lines carry none.
+	want := []string{
+		"=== FILE: server/plugins.go ===",
+		"@@ -10,4 +10,5 @@ func executePlugin() {",
+		" 10:\tctx := context.Background()",
+		"-:\told := run(ctx)",
+		"+11:\tfresh := run(ctx)",
+		"+12:\tlog(fresh)",
+		" 13:\treturn",
+		"@@ -30,2 +31,3 @@",
+		" 31:\ttail()",
+		"+32:\textra()",
+		"",
+		"=== FILE: README.md ===",
+		"@@ -0,0 +1,2 @@",
+		"+1:# Title",
+		"+2:body",
+		"",
+		"=== FILE: old.txt ===",
+		"@@ -1,2 +0,0 @@",
+		"-:gone",
+		"-:also gone",
+	}
+	if got := canonical(rendered); !reflect.DeepEqual(got, want) {
+		t.Errorf("numbered diff mismatch\ngot:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestNumberedDiffSkipsUnannotatableLines(t *testing.T) {
+	// A binary file has no lines to anchor to, and the no-newline marker isn't
+	// a line of either side. An empty context line is a line, though: diffs
+	// that strip its leading space still have to keep the count in step.
+	diff := "diff --git a/img.png b/img.png\n" +
+		"index 0000000..abc1234\n" +
+		"Binary files /dev/null and b/img.png differ\n" +
+		"diff --git a/a.txt b/a.txt\n" +
+		"--- a/a.txt\n" +
+		"+++ b/a.txt\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		" first\n" +
+		"\n" +
+		"+added\n" +
+		"\\ No newline at end of file\n"
+
+	rendered, files := NumberedDiff(diff)
+	if !reflect.DeepEqual(files, []string{"a.txt"}) {
+		t.Errorf("files = %v, want [a.txt]", files)
+	}
+	want := []string{
+		"=== FILE: a.txt ===",
+		"@@ -1,3 +1,3 @@",
+		" 1:first",
+		" 2:",
+		"+3:added",
+	}
+	if got := canonical(rendered); !reflect.DeepEqual(got, want) {
+		t.Errorf("numbered diff mismatch\ngot:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestPromptDiffWithoutHunks(t *testing.T) {
+	// A diff the renderer can't make sense of yields nothing to annotate, so
+	// the raw text is what a prompt has to fall back to.
+	rendered, files := NumberedDiff("not a diff at all")
+	if rendered != "" || len(files) != 0 {
+		t.Fatalf("NumberedDiff(garbage) = %q, %v; want empty", rendered, files)
+	}
+
+	rendered, fileList := PromptDiff("not a diff at all")
+	if rendered != "not a diff at all" {
+		t.Errorf("rendered = %q, want the diff verbatim", rendered)
+	}
+	if !strings.Contains(fileList, "(none parsed") {
+		t.Errorf("file list = %q, want a note that there are no annotatable files", fileList)
+	}
+}
+
+func TestPromptDiffListsFiles(t *testing.T) {
+	rendered, fileList := PromptDiff(sampleDiff)
+
+	if fileList != "server/plugins.go\nREADME.md\nold.txt" {
+		t.Errorf("file list = %q", fileList)
+	}
+	if !strings.Contains(rendered, "+    11 | \tfresh := run(ctx)") {
+		t.Errorf("rendered diff missing a numbered line:\n%s", rendered)
+	}
+}

--- a/cmd/internal/pluginkit/gemini.go
+++ b/cmd/internal/pluginkit/gemini.go
@@ -1,0 +1,127 @@
+package pluginkit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+const geminiEndpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key="
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+// Schema is the subset of the OpenAPI schema dialect Gemini accepts as a
+// response schema.
+type Schema struct {
+	Type             string             `json:"type"`
+	Description      string             `json:"description,omitempty"`
+	Enum             []string           `json:"enum,omitempty"`
+	Items            *Schema            `json:"items,omitempty"`
+	Properties       map[string]*Schema `json:"properties,omitempty"`
+	PropertyOrdering []string           `json:"propertyOrdering,omitempty"`
+	Required         []string           `json:"required,omitempty"`
+}
+
+type geminiGenerationConfig struct {
+	ResponseMimeType string  `json:"responseMimeType,omitempty"`
+	ResponseSchema   *Schema `json:"responseSchema,omitempty"`
+}
+
+type geminiRequest struct {
+	Contents         []geminiContent         `json:"contents"`
+	GenerationConfig *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"content"`
+	} `json:"candidates"`
+}
+
+// AnnotationsSchema describes an annotations array constrained to the fields
+// of Annotation, for a plugin asking Gemini for structured output.
+func AnnotationsSchema(max int) *Schema {
+	return &Schema{
+		Type:        "ARRAY",
+		Description: "Line-level remarks, at most " + strconv.Itoa(max) + ".",
+		Items: &Schema{
+			Type: "OBJECT",
+			Properties: map[string]*Schema{
+				"filename": {
+					Type:        "STRING",
+					Description: "Path of the annotated file, copied exactly from the diff.",
+				},
+				"line": {
+					Type:        "INTEGER",
+					Description: "Head-side line number shown beside the annotated line.",
+				},
+				"severity": {
+					Type: "STRING",
+					Enum: []string{SeverityInfo, SeverityWarning, SeverityError},
+				},
+				"content": {
+					Type:        "STRING",
+					Description: "One or two sentences about that line.",
+				},
+			},
+			PropertyOrdering: []string{"filename", "line", "severity", "content"},
+			Required:         []string{"filename", "line", "severity", "content"},
+		},
+	}
+}
+
+// Generate sends a prompt to Gemini 2.5 Flash and returns the text of the
+// first candidate. A non-nil schema asks for a JSON reply matching it.
+func Generate(prompt string, schema *Schema, apiKey string) (string, error) {
+	reqBody := geminiRequest{
+		Contents: []geminiContent{
+			{Parts: []geminiPart{{Text: prompt}}},
+		},
+	}
+	if schema != nil {
+		reqBody.GenerationConfig = &geminiGenerationConfig{
+			ResponseMimeType: "application/json",
+			ResponseSchema:   schema,
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.Post(geminiEndpoint+apiKey, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var geminiResp geminiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
+		return "", err
+	}
+
+	if len(geminiResp.Candidates) > 0 && len(geminiResp.Candidates[0].Content.Parts) > 0 {
+		return geminiResp.Candidates[0].Content.Parts[0].Text, nil
+	}
+
+	return "", fmt.Errorf("no content in response")
+}

--- a/cmd/style_guidelines/main.go
+++ b/cmd/style_guidelines/main.go
@@ -1,55 +1,46 @@
 package main
 
 import (
-	"bytes"
+	"crs/cmd/internal/pluginkit"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-type GeminiPart struct {
-	Text string `json:"text"`
+// style_guidelines emits the plugin response contract described in
+// docs/plugins.md: a markdown body holding the compliance report, plus an
+// annotation on each line of the diff that breaks one of the user's rules.
+
+// maxAnnotations is what the model is asked for. A style guide can be broken
+// on a lot of lines at once, and a diff buried in flags is unreadable, so the
+// worst offenders are worth more than an exhaustive list.
+const maxAnnotations = 10
+
+// modelOutput is the shape Gemini is asked to return, mirroring
+// responseSchema below.
+type modelOutput struct {
+	Report      string                 `json:"report"`
+	Annotations []pluginkit.Annotation `json:"annotations"`
 }
 
-type GeminiContent struct {
-	Parts []GeminiPart `json:"parts"`
-}
-
-type GeminiRequest struct {
-	Contents []GeminiContent `json:"contents"`
-}
-
-type GeminiResponse struct {
-	Candidates []struct {
-		Content struct {
-			Parts []struct {
-				Text string `json:"text"`
-			} `json:"parts"`
-		} `json:"content"`
-	} `json:"candidates"`
-}
-
-type PRMetadata struct {
-	Number      int      `json:"number"`
-	Title       string   `json:"title"`
-	Author      string   `json:"author"`
-	BaseRef     string   `json:"base_ref"`
-	HeadRef     string   `json:"head_ref"`
-	State       string   `json:"state"`
-	Milestone   string   `json:"milestone"`
-	Labels      []string `json:"labels"`
-	Assignees   []string `json:"assignees"`
-	Reviewers   []string `json:"reviewers"`
-	Draft       bool     `json:"draft"`
-	CIStatus    string   `json:"ci_status"`
-	CIFailures  []string `json:"ci_failures"`
-	Body        string   `json:"body"`
-	URL         string   `json:"url"`
-	WorktreePath string  `json:"worktree_path"`
+// responseSchema constrains Gemini's reply to the report and annotations we
+// know how to turn into a plugin response.
+func responseSchema() *pluginkit.Schema {
+	return &pluginkit.Schema{
+		Type: "OBJECT",
+		Properties: map[string]*pluginkit.Schema{
+			"report": {
+				Type:        "STRING",
+				Description: "Markdown report on the diff's compliance with the style guidelines.",
+			},
+			"annotations": pluginkit.AnnotationsSchema(maxAnnotations),
+		},
+		PropertyOrdering: []string{"report", "annotations"},
+		Required:         []string{"report", "annotations"},
+	}
 }
 
 func loadStyleGuidelines() (string, error) {
@@ -65,18 +56,10 @@ func loadStyleGuidelines() (string, error) {
 	return string(data), nil
 }
 
-func callGemini(diff string, metadata PRMetadata, styleGuidelines string, geminiToken string) (string, error) {
-	url := "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=" + geminiToken
+func buildPrompt(diff string, metadata pluginkit.PRMetadata, styleGuidelines string) string {
+	rendered, fileList := pluginkit.PromptDiff(diff)
 
-	var contextInfo string
-	if metadata.Title != "" {
-		contextInfo += fmt.Sprintf("PR Title: %s\n", metadata.Title)
-	}
-	if metadata.Body != "" {
-		contextInfo += fmt.Sprintf("PR Description: %s\n", metadata.Body)
-	}
-
-	prompt := fmt.Sprintf(`You are a code reviewer evaluating a pull request against style guidelines.
+	return fmt.Sprintf(`You are a code reviewer evaluating a pull request against style guidelines.
 
 ## Style Guidelines
 
@@ -85,56 +68,51 @@ func callGemini(diff string, metadata PRMetadata, styleGuidelines string, gemini
 ## PR Context
 
 %s
+## Files
+
+%s
+
 ## Diff
+
+%s
 
 %s
 
 ## Instructions
 
-Evaluate the PR diff against the style guidelines above. Be concise:
-- Note any violations with file and line references where possible
-- Note areas that follow the guidelines well (briefly)
-- Provide a short overall assessment
+Evaluate the diff against the style guidelines above, and return both a report
+and the violating lines. Focus only on style guideline compliance. Be direct
+and specific.
 
-Focus only on style guideline compliance. Be direct and specific.
-`, styleGuidelines, contextInfo, diff)
+report: a concise markdown report with
+- any violations, with file and line references
+- areas that follow the guidelines well (briefly)
+- a short overall assessment
 
-	reqBody := GeminiRequest{
-		Contents: []GeminiContent{
-			{
-				Parts: []GeminiPart{
-					{Text: prompt},
-				},
-			},
-		},
+annotations: at most %d remarks, each anchored to one line of the diff that
+breaks a guideline. Only annotate a line the guidelines actually speak to; an
+empty list is fine, and a clean diff should have one.
+- filename: one of the paths listed under Files, copied exactly.
+- line: the number shown beside that line in the diff. Lines marked "-" were
+  removed and have no number, so they cannot be annotated.
+- severity: %s for a nit, %s for a clear violation, %s for one that breaks a
+  guideline stated as a hard requirement.
+- content: the guideline broken and how to fix the line, in one or two
+  sentences.
+`, styleGuidelines, metadata.Context(), fileList, rendered, pluginkit.DiffLegend,
+		maxAnnotations, pluginkit.SeverityInfo, pluginkit.SeverityWarning, pluginkit.SeverityError)
+}
+
+// responseFor turns Gemini's reply into a plugin response. A reply that isn't
+// the JSON we asked for becomes the body verbatim, which is what this plugin
+// emitted before it spoke the contract.
+func responseFor(reply string) pluginkit.Response {
+	var parsed modelOutput
+	if err := json.Unmarshal([]byte(pluginkit.TrimCodeFence(reply)), &parsed); err != nil || strings.TrimSpace(parsed.Report) == "" {
+		return pluginkit.MarkdownResponse(reply, nil)
 	}
 
-	jsonData, err := json.Marshal(reqBody)
-	if err != nil {
-		return "", err
-	}
-
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var geminiResp GeminiResponse
-	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
-		return "", err
-	}
-
-	if len(geminiResp.Candidates) > 0 && len(geminiResp.Candidates[0].Content.Parts) > 0 {
-		return geminiResp.Candidates[0].Content.Parts[0].Text, nil
-	}
-
-	return "", fmt.Errorf("no content in response")
+	return pluginkit.MarkdownResponse(strings.TrimSpace(parsed.Report), parsed.Annotations)
 }
 
 func main() {
@@ -152,7 +130,7 @@ func main() {
 	_ = number
 	_ = commentsJSON
 
-	var metadata PRMetadata
+	var metadata pluginkit.PRMetadata
 	if *headersJSON != "" {
 		if err := json.Unmarshal([]byte(*headersJSON), &metadata); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to parse headers: %v\n", err)
@@ -176,11 +154,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	result, err := callGemini(*diff, metadata, styleGuidelines, geminiToken)
+	result, err := pluginkit.Generate(buildPrompt(*diff, metadata, styleGuidelines), responseSchema(), geminiToken)
 	if err != nil {
 		fmt.Printf("Error calling Gemini: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Println(result)
+	if err := pluginkit.EncodeResponse(os.Stdout, responseFor(result)); err != nil {
+		fmt.Printf("Error encoding plugin response: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/style_guidelines/main_test.go
+++ b/cmd/style_guidelines/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"crs/cmd/internal/pluginkit"
+	"crs/server"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const sampleDiff = `diff --git a/api/views.py b/api/views.py
+index 1111111..2222222 100644
+--- a/api/views.py
++++ b/api/views.py
+@@ -10,3 +10,5 @@ def index():
+ 	return render()
++def AdminPanel():
++	return secret(42)
+`
+
+const styleGuide = "# Style Guidelines\n\n- Use snake_case for all function names.\n"
+
+func TestBuildPromptCarriesGuidelinesFilesAndContext(t *testing.T) {
+	prompt := buildPrompt(sampleDiff, pluginkit.PRMetadata{Title: "Add a panel", Body: "Because."}, styleGuide)
+
+	for _, want := range []string{
+		"Use snake_case for all function names.",
+		"PR Title: Add a panel",
+		"PR Description: Because.",
+		"api/views.py",
+		// The head-side line number is what an annotation anchors to.
+		"+    11 | def AdminPanel():",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+func TestBuildPromptWithoutHunks(t *testing.T) {
+	prompt := buildPrompt("not a diff at all", pluginkit.PRMetadata{}, styleGuide)
+
+	if !strings.Contains(prompt, "not a diff at all") {
+		t.Error("prompt dropped the diff it could not number")
+	}
+	if !strings.Contains(prompt, "(none parsed") {
+		t.Error("prompt did not tell the model there are no annotatable files")
+	}
+}
+
+func TestResponseFor(t *testing.T) {
+	tests := []struct {
+		name            string
+		reply           string
+		wantBody        string
+		wantAnnotations []pluginkit.Annotation
+	}{
+		{
+			name:     "structured reply",
+			reply:    `{"report":"## Violations\n- api/views.py:11","annotations":[{"filename":"api/views.py","line":11,"severity":"warning","content":"Function names must be snake_case."}]}`,
+			wantBody: "## Violations\n- api/views.py:11",
+			wantAnnotations: []pluginkit.Annotation{
+				{Filename: "api/views.py", Line: 11, Severity: pluginkit.SeverityWarning, Content: "Function names must be snake_case."},
+			},
+		},
+		{
+			name:            "fenced reply",
+			reply:           "```json\n{\"report\":\"looks clean\",\"annotations\":[]}\n```",
+			wantBody:        "looks clean",
+			wantAnnotations: []pluginkit.Annotation{},
+		},
+		{
+			name: "annotations normalized and unanchorable ones dropped",
+			reply: `{"report":"r","annotations":[
+				{"filename":"./api/views.py","line":11,"severity":"ERROR","content":" snake_case "},
+				{"filename":"api/views.py","line":12,"severity":"","content":"no severity"},
+				{"filename":"","line":13,"severity":"info","content":"no file"},
+				{"filename":"api/views.py","line":0,"severity":"info","content":"no line"},
+				{"filename":"api/views.py","line":14,"severity":"info","content":"  "}
+			]}`,
+			wantBody: "r",
+			wantAnnotations: []pluginkit.Annotation{
+				{Filename: "api/views.py", Line: 11, Severity: pluginkit.SeverityError, Content: "snake_case"},
+				{Filename: "api/views.py", Line: 12, Severity: pluginkit.SeverityInfo, Content: "no severity"},
+			},
+		},
+		{
+			// Plain text is what this plugin used to emit, and what it still
+			// emits if the model ignores the schema.
+			name:            "legacy plain text",
+			reply:           "No violations found.\nOverall: fine.",
+			wantBody:        "No violations found.\nOverall: fine.",
+			wantAnnotations: []pluginkit.Annotation{},
+		},
+		{
+			name:            "json without a report",
+			reply:           `{"report":"","annotations":[{"filename":"api/views.py","line":11,"severity":"info","content":"x"}]}`,
+			wantBody:        `{"report":"","annotations":[{"filename":"api/views.py","line":11,"severity":"info","content":"x"}]}`,
+			wantAnnotations: []pluginkit.Annotation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := responseFor(tt.reply)
+			if got.Body.BodyType != pluginkit.BodyTypeMarkdown {
+				t.Errorf("body type = %q, want %q", got.Body.BodyType, pluginkit.BodyTypeMarkdown)
+			}
+			if got.Body.BodyContent != tt.wantBody {
+				t.Errorf("body = %q, want %q", got.Body.BodyContent, tt.wantBody)
+			}
+			if !reflect.DeepEqual(got.Annotations, tt.wantAnnotations) {
+				t.Errorf("annotations = %+v, want %+v", got.Annotations, tt.wantAnnotations)
+			}
+		})
+	}
+}
+
+// TestEncodedOutputMatchesContract runs what the plugin writes to stdout
+// through the server's parser, which is what decides whether a plugin speaks
+// the contract or gets treated as legacy output.
+func TestEncodedOutputMatchesContract(t *testing.T) {
+	response := responseFor(`{"report":"## Violations\n- api/views.py:11","annotations":[{"filename":"api/views.py","line":11,"severity":"warning","content":"Function names must be snake_case."}]}`)
+
+	var out bytes.Buffer
+	if err := pluginkit.EncodeResponse(&out, response); err != nil {
+		t.Fatalf("EncodeResponse: %v", err)
+	}
+
+	parsed := server.ParsePluginOutput(out.String())
+	if parsed.Body.BodyType != server.BodyTypeMarkdown || parsed.Body.BodyContent != "## Violations\n- api/views.py:11" {
+		t.Errorf("parsed body = %+v", parsed.Body)
+	}
+	want := []server.PluginAnnotation{
+		{Filename: "api/views.py", Line: 11, Severity: "warning", Content: "Function names must be snake_case."},
+	}
+	if !reflect.DeepEqual(parsed.Annotations, want) {
+		t.Errorf("parsed annotations = %+v, want %+v", parsed.Annotations, want)
+	}
+}

--- a/cmd/summarize_diff/main.go
+++ b/cmd/summarize_diff/main.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"bytes"
+	"crs/cmd/internal/pluginkit"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -16,243 +13,36 @@ import (
 // docs/plugins.md: a markdown body holding the summary, plus line-level
 // annotations anchored to the head side of the PR's diff.
 
-const (
-	bodyTypeMarkdown = "markdown"
-	severityInfo     = "info"
-
-	// maxAnnotations is what the model is asked for. A summary plugin that
-	// flags every other line is noise once the annotations render inline.
-	maxAnnotations = 6
-)
-
-// PluginBody is the renderable portion of a plugin response.
-type PluginBody struct {
-	BodyType    string `json:"body_type"`
-	BodyContent string `json:"body_content"`
-}
-
-// PluginAnnotation anchors a remark to a line of a file in the PR.
-type PluginAnnotation struct {
-	Filename string `json:"filename"`
-	Line     int    `json:"line"`
-	Severity string `json:"severity"`
-	Content  string `json:"content"`
-}
-
-// PluginResponse is the document written to stdout.
-type PluginResponse struct {
-	Body        PluginBody         `json:"body"`
-	Annotations []PluginAnnotation `json:"annotations"`
-}
+// maxAnnotations is what the model is asked for. A summary plugin that flags
+// every other line is noise once the annotations render inline.
+const maxAnnotations = 6
 
 // modelOutput is the shape Gemini is asked to return, mirroring
 // responseSchema below.
 type modelOutput struct {
-	Summary     string             `json:"summary"`
-	Annotations []PluginAnnotation `json:"annotations"`
-}
-
-type GeminiPart struct {
-	Text string `json:"text"`
-}
-
-type GeminiContent struct {
-	Parts []GeminiPart `json:"parts"`
-}
-
-// GeminiSchema is the subset of the OpenAPI schema dialect Gemini accepts as
-// a response schema.
-type GeminiSchema struct {
-	Type             string                   `json:"type"`
-	Description      string                   `json:"description,omitempty"`
-	Enum             []string                 `json:"enum,omitempty"`
-	Items            *GeminiSchema            `json:"items,omitempty"`
-	Properties       map[string]*GeminiSchema `json:"properties,omitempty"`
-	PropertyOrdering []string                 `json:"propertyOrdering,omitempty"`
-	Required         []string                 `json:"required,omitempty"`
-}
-
-type GeminiGenerationConfig struct {
-	ResponseMimeType string        `json:"responseMimeType,omitempty"`
-	ResponseSchema   *GeminiSchema `json:"responseSchema,omitempty"`
-}
-
-type GeminiRequest struct {
-	Contents         []GeminiContent         `json:"contents"`
-	GenerationConfig *GeminiGenerationConfig `json:"generationConfig,omitempty"`
-}
-
-type GeminiResponse struct {
-	Candidates []struct {
-		Content struct {
-			Parts []struct {
-				Text string `json:"text"`
-			} `json:"parts"`
-		} `json:"content"`
-	} `json:"candidates"`
-}
-
-type PRMetadata struct {
-	Number       int      `json:"number"`
-	Title        string   `json:"title"`
-	Author       string   `json:"author"`
-	BaseRef      string   `json:"base_ref"`
-	HeadRef      string   `json:"head_ref"`
-	State        string   `json:"state"`
-	Milestone    string   `json:"milestone"`
-	Labels       []string `json:"labels"`
-	Assignees    []string `json:"assignees"`
-	Reviewers    []string `json:"reviewers"`
-	Draft        bool     `json:"draft"`
-	CIStatus     string   `json:"ci_status"`
-	CIFailures   []string `json:"ci_failures"`
-	Body         string   `json:"body"`
-	URL          string   `json:"url"`
-	WorktreePath string   `json:"worktree_path"`
+	Summary     string                 `json:"summary"`
+	Annotations []pluginkit.Annotation `json:"annotations"`
 }
 
 // responseSchema constrains Gemini's reply to the summary and annotations we
 // know how to turn into a plugin response.
-func responseSchema() *GeminiSchema {
-	return &GeminiSchema{
+func responseSchema() *pluginkit.Schema {
+	return &pluginkit.Schema{
 		Type: "OBJECT",
-		Properties: map[string]*GeminiSchema{
+		Properties: map[string]*pluginkit.Schema{
 			"summary": {
 				Type:        "STRING",
 				Description: "Terse markdown summary of the PR.",
 			},
-			"annotations": {
-				Type:        "ARRAY",
-				Description: "Line-level remarks, at most " + strconv.Itoa(maxAnnotations) + ".",
-				Items: &GeminiSchema{
-					Type: "OBJECT",
-					Properties: map[string]*GeminiSchema{
-						"filename": {
-							Type:        "STRING",
-							Description: "Path of the annotated file, copied exactly from the diff.",
-						},
-						"line": {
-							Type:        "INTEGER",
-							Description: "Head-side line number shown beside the annotated line.",
-						},
-						"severity": {
-							Type: "STRING",
-							Enum: []string{severityInfo, "warning", "error"},
-						},
-						"content": {
-							Type:        "STRING",
-							Description: "One or two sentences about that line.",
-						},
-					},
-					PropertyOrdering: []string{"filename", "line", "severity", "content"},
-					Required:         []string{"filename", "line", "severity", "content"},
-				},
-			},
+			"annotations": pluginkit.AnnotationsSchema(maxAnnotations),
 		},
 		PropertyOrdering: []string{"summary", "annotations"},
 		Required:         []string{"summary", "annotations"},
 	}
 }
 
-// trimDiffPath cleans a path out of a diff file header, dropping git's a/ or
-// b/ prefix and reporting /dev/null as no path at all.
-func trimDiffPath(raw, prefix string) string {
-	path := strings.TrimSpace(raw)
-	if path == "/dev/null" {
-		return ""
-	}
-	return strings.TrimPrefix(path, prefix)
-}
-
-// hunkNewStart pulls the head-side starting line out of a hunk header such as
-// "@@ -12,7 +14,9 @@ func main() {".
-func hunkNewStart(header string) (int, bool) {
-	_, after, found := strings.Cut(header, "+")
-	if !found {
-		return 0, false
-	}
-	field, _, _ := strings.Cut(after, " ")
-	field, _, _ = strings.Cut(field, ",")
-	start, err := strconv.Atoi(field)
-	if err != nil || start < 0 {
-		return 0, false
-	}
-	return start, true
-}
-
-// numberedDiff rewrites a unified diff with each line's head-side line number
-// — the number an annotation anchors to — and returns the files it found.
-// Lines are rendered as "<mark> <line> | <content>"; removed lines exist only
-// on the base side and so carry no number.
-func numberedDiff(diff string) (string, []string) {
-	var (
-		out      strings.Builder
-		files    []string
-		baseName string
-		newLine  int
-		inHunk   bool
-	)
-
-	for _, line := range strings.Split(strings.TrimSuffix(diff, "\n"), "\n") {
-		switch {
-		case strings.HasPrefix(line, "diff --git "):
-			inHunk, baseName = false, ""
-		case strings.HasPrefix(line, "--- "):
-			baseName = trimDiffPath(strings.TrimPrefix(line, "--- "), "a/")
-			inHunk = false
-		case strings.HasPrefix(line, "+++ "):
-			inHunk = false
-			name := trimDiffPath(strings.TrimPrefix(line, "+++ "), "b/")
-			if name == "" {
-				// Deleted file: the base-side path is the only one it has.
-				name = baseName
-			}
-			if name == "" {
-				continue
-			}
-			files = append(files, name)
-			fmt.Fprintf(&out, "\n=== FILE: %s ===\n", name)
-		case strings.HasPrefix(line, "@@"):
-			start, ok := hunkNewStart(line)
-			if !ok {
-				continue
-			}
-			newLine, inHunk = start, true
-			fmt.Fprintf(&out, "%s\n", line)
-		case !inHunk:
-			// index/mode/rename lines between files: nothing to number.
-		case line == `\ No newline at end of file`:
-		case strings.HasPrefix(line, "-"):
-			fmt.Fprintf(&out, "- %5s | %s\n", "", line[1:])
-		case strings.HasPrefix(line, "+"):
-			fmt.Fprintf(&out, "+ %5d | %s\n", newLine, line[1:])
-			newLine++
-		default:
-			fmt.Fprintf(&out, "  %5d | %s\n", newLine, strings.TrimPrefix(line, " "))
-			newLine++
-		}
-	}
-
-	return strings.TrimSpace(out.String()), files
-}
-
-func buildPrompt(diff string, metadata PRMetadata) string {
-	var contextInfo string
-	if metadata.Title != "" {
-		contextInfo += fmt.Sprintf("PR Title: %s\n", metadata.Title)
-	}
-	if metadata.Body != "" {
-		contextInfo += fmt.Sprintf("PR Description: %s\n", metadata.Body)
-	}
-
-	rendered, files := numberedDiff(diff)
-	fileList := "(none parsed - return an empty annotations list)"
-	if len(files) > 0 {
-		fileList = strings.Join(files, "\n")
-	}
-	if rendered == "" {
-		rendered = diff
-	}
+func buildPrompt(diff string, metadata pluginkit.PRMetadata) string {
+	rendered, fileList := pluginkit.PromptDiff(diff)
 
 	return fmt.Sprintf(`Summarize this PR, and flag the specific lines a reviewer should look at.
 
@@ -265,126 +55,30 @@ is fine.
 - filename: one of the paths listed under Files, copied exactly.
 - line: the number shown beside that line in the diff. Lines marked "-" were
   removed and have no number, so they cannot be annotated.
-- severity: %s, warning or error.
+- severity: %s, %s or %s.
 - content: one or two sentences.
 
 Files:
 %s
 
-The diff is rendered as "<mark> <line number> | <content>", where mark is "+"
-for an added line, "-" for a removed one and blank for an unchanged one. The
-line number is the line's position in the file after this PR is merged.
+%s
 
 %sDiff:
 %s
-`, maxAnnotations, severityInfo, fileList, contextInfo, rendered)
-}
-
-func callGemini(diff string, metadata PRMetadata, geminiToken string) (string, error) {
-	// Using gemini-2.5-flash
-	url := "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=" + geminiToken
-
-	reqBody := GeminiRequest{
-		Contents: []GeminiContent{
-			{
-				Parts: []GeminiPart{
-					{Text: buildPrompt(diff, metadata)},
-				},
-			},
-		},
-		GenerationConfig: &GeminiGenerationConfig{
-			ResponseMimeType: "application/json",
-			ResponseSchema:   responseSchema(),
-		},
-	}
-
-	jsonData, err := json.Marshal(reqBody)
-	if err != nil {
-		return "", err
-	}
-
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var geminiResp GeminiResponse
-	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
-		return "", err
-	}
-
-	if len(geminiResp.Candidates) > 0 && len(geminiResp.Candidates[0].Content.Parts) > 0 {
-		return geminiResp.Candidates[0].Content.Parts[0].Text, nil
-	}
-
-	return "", fmt.Errorf("no content in response")
-}
-
-// trimCodeFence unwraps a ```json fence, which models add when they answer in
-// prose formatting despite the requested response MIME type.
-func trimCodeFence(reply string) string {
-	trimmed := strings.TrimSpace(reply)
-	if !strings.HasPrefix(trimmed, "```") {
-		return trimmed
-	}
-	_, after, found := strings.Cut(trimmed, "\n")
-	if !found {
-		return trimmed
-	}
-	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(after), "```"))
-}
-
-// sanitizeAnnotations drops annotations the server would drop anyway (no
-// filename, no positive line) or that carry no text, and normalizes the rest.
-func sanitizeAnnotations(annotations []PluginAnnotation) []PluginAnnotation {
-	cleaned := []PluginAnnotation{}
-	for _, a := range annotations {
-		a.Filename = strings.TrimPrefix(strings.TrimSpace(a.Filename), "./")
-		a.Content = strings.TrimSpace(a.Content)
-		a.Severity = strings.ToLower(strings.TrimSpace(a.Severity))
-		if a.Filename == "" || a.Line < 1 || a.Content == "" {
-			continue
-		}
-		if a.Severity == "" {
-			a.Severity = severityInfo
-		}
-		cleaned = append(cleaned, a)
-	}
-	return cleaned
+`, maxAnnotations, pluginkit.SeverityInfo, pluginkit.SeverityWarning, pluginkit.SeverityError,
+		fileList, pluginkit.DiffLegend, metadata.Context(), rendered)
 }
 
 // responseFor turns Gemini's reply into a plugin response. A reply that isn't
 // the JSON we asked for becomes the body verbatim, which is what this plugin
 // emitted before it spoke the contract.
-func responseFor(reply string) PluginResponse {
+func responseFor(reply string) pluginkit.Response {
 	var parsed modelOutput
-	if err := json.Unmarshal([]byte(trimCodeFence(reply)), &parsed); err != nil || strings.TrimSpace(parsed.Summary) == "" {
-		return PluginResponse{
-			Body:        PluginBody{BodyType: bodyTypeMarkdown, BodyContent: reply},
-			Annotations: []PluginAnnotation{},
-		}
+	if err := json.Unmarshal([]byte(pluginkit.TrimCodeFence(reply)), &parsed); err != nil || strings.TrimSpace(parsed.Summary) == "" {
+		return pluginkit.MarkdownResponse(reply, nil)
 	}
 
-	return PluginResponse{
-		Body:        PluginBody{BodyType: bodyTypeMarkdown, BodyContent: strings.TrimSpace(parsed.Summary)},
-		Annotations: sanitizeAnnotations(parsed.Annotations),
-	}
-}
-
-// encodeResponse writes the response contract document a client will parse.
-// HTML escaping is off so the stored raw output stays readable, and the
-// indentation is there for the same reason.
-func encodeResponse(w io.Writer, response PluginResponse) error {
-	encoder := json.NewEncoder(w)
-	encoder.SetEscapeHTML(false)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(response)
+	return pluginkit.MarkdownResponse(strings.TrimSpace(parsed.Summary), parsed.Annotations)
 }
 
 func main() {
@@ -403,7 +97,7 @@ func main() {
 	_ = number
 	_ = commentsJSON
 
-	var metadata PRMetadata
+	var metadata pluginkit.PRMetadata
 	if *headersJSON != "" {
 		if err := json.Unmarshal([]byte(*headersJSON), &metadata); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to parse headers: %v\n", err)
@@ -421,13 +115,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	summary, err := callGemini(*diff, metadata, geminiToken)
+	summary, err := pluginkit.Generate(buildPrompt(*diff, metadata), responseSchema(), geminiToken)
 	if err != nil {
 		fmt.Printf("Error calling Gemini: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := encodeResponse(os.Stdout, responseFor(summary)); err != nil {
+	if err := pluginkit.EncodeResponse(os.Stdout, responseFor(summary)); err != nil {
 		fmt.Printf("Error encoding plugin response: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/summarize_diff/main_test.go
+++ b/cmd/summarize_diff/main_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crs/cmd/internal/pluginkit"
 	"crs/server"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -19,9 +19,6 @@ index 1111111..2222222 100644
 +	fresh := run(ctx)
 +	log(fresh)
  	return
-@@ -30,2 +31,3 @@
- 	tail()
-+	extra()
 diff --git a/README.md b/README.md
 new file mode 100644
 index 0000000..3333333
@@ -30,122 +27,10 @@ index 0000000..3333333
 @@ -0,0 +1,2 @@
 +# Title
 +body
-diff --git a/old.txt b/old.txt
-deleted file mode 100644
-index 4444444..0000000
---- a/old.txt
-+++ /dev/null
-@@ -1,2 +0,0 @@
--gone
--also gone
 `
 
-// canonical rewrites numbered diff lines as "<mark><line>:<content>" so the
-// expectations below stay readable without hard-coding column widths. Headers
-// pass through untouched.
-func canonical(rendered string) []string {
-	lines := []string{}
-	for _, line := range strings.Split(rendered, "\n") {
-		head, content, ok := strings.Cut(line, " | ")
-		if !ok {
-			lines = append(lines, line)
-			continue
-		}
-		lines = append(lines, fmt.Sprintf("%c%s:%s", head[0], strings.TrimSpace(head[1:]), content))
-	}
-	return lines
-}
-
-func TestNumberedDiff(t *testing.T) {
-	rendered, files := numberedDiff(sampleDiff)
-
-	wantFiles := []string{"server/plugins.go", "README.md", "old.txt"}
-	if !reflect.DeepEqual(files, wantFiles) {
-		t.Errorf("files = %v, want %v", files, wantFiles)
-	}
-
-	// Numbers count the head side: unchanged and added lines carry the line
-	// they will occupy once the PR merges, removed lines carry none.
-	want := []string{
-		"=== FILE: server/plugins.go ===",
-		"@@ -10,4 +10,5 @@ func executePlugin() {",
-		" 10:\tctx := context.Background()",
-		"-:\told := run(ctx)",
-		"+11:\tfresh := run(ctx)",
-		"+12:\tlog(fresh)",
-		" 13:\treturn",
-		"@@ -30,2 +31,3 @@",
-		" 31:\ttail()",
-		"+32:\textra()",
-		"",
-		"=== FILE: README.md ===",
-		"@@ -0,0 +1,2 @@",
-		"+1:# Title",
-		"+2:body",
-		"",
-		"=== FILE: old.txt ===",
-		"@@ -1,2 +0,0 @@",
-		"-:gone",
-		"-:also gone",
-	}
-	if got := canonical(rendered); !reflect.DeepEqual(got, want) {
-		t.Errorf("numbered diff mismatch\ngot:\n%s\nwant:\n%s",
-			strings.Join(got, "\n"), strings.Join(want, "\n"))
-	}
-}
-
-func TestNumberedDiffSkipsUnannotatableLines(t *testing.T) {
-	// A binary file has no lines to anchor to, and the no-newline marker isn't
-	// a line of either side. An empty context line is a line, though: diffs
-	// that strip its leading space still have to keep the count in step.
-	diff := "diff --git a/img.png b/img.png\n" +
-		"index 0000000..abc1234\n" +
-		"Binary files /dev/null and b/img.png differ\n" +
-		"diff --git a/a.txt b/a.txt\n" +
-		"--- a/a.txt\n" +
-		"+++ b/a.txt\n" +
-		"@@ -1,3 +1,3 @@\n" +
-		" first\n" +
-		"\n" +
-		"+added\n" +
-		"\\ No newline at end of file\n"
-
-	rendered, files := numberedDiff(diff)
-	if !reflect.DeepEqual(files, []string{"a.txt"}) {
-		t.Errorf("files = %v, want [a.txt]", files)
-	}
-	want := []string{
-		"=== FILE: a.txt ===",
-		"@@ -1,3 +1,3 @@",
-		" 1:first",
-		" 2:",
-		"+3:added",
-	}
-	if got := canonical(rendered); !reflect.DeepEqual(got, want) {
-		t.Errorf("numbered diff mismatch\ngot:\n%s\nwant:\n%s",
-			strings.Join(got, "\n"), strings.Join(want, "\n"))
-	}
-}
-
-func TestNumberedDiffWithoutHunks(t *testing.T) {
-	// A diff the renderer can't make sense of yields nothing to annotate, and
-	// buildPrompt falls back to the raw text.
-	rendered, files := numberedDiff("not a diff at all")
-	if rendered != "" || len(files) != 0 {
-		t.Fatalf("numberedDiff(garbage) = %q, %v; want empty", rendered, files)
-	}
-
-	prompt := buildPrompt("not a diff at all", PRMetadata{})
-	if !strings.Contains(prompt, "not a diff at all") {
-		t.Error("prompt dropped the diff it could not number")
-	}
-	if !strings.Contains(prompt, "(none parsed") {
-		t.Error("prompt did not tell the model there are no annotatable files")
-	}
-}
-
 func TestBuildPromptListsFilesAndContext(t *testing.T) {
-	prompt := buildPrompt(sampleDiff, PRMetadata{Title: "Add a thing", Body: "Because."})
+	prompt := buildPrompt(sampleDiff, pluginkit.PRMetadata{Title: "Add a thing", Body: "Because."})
 
 	for _, want := range []string{
 		"PR Title: Add a thing",
@@ -160,18 +45,29 @@ func TestBuildPromptListsFilesAndContext(t *testing.T) {
 	}
 }
 
+func TestBuildPromptWithoutHunks(t *testing.T) {
+	prompt := buildPrompt("not a diff at all", pluginkit.PRMetadata{})
+
+	if !strings.Contains(prompt, "not a diff at all") {
+		t.Error("prompt dropped the diff it could not number")
+	}
+	if !strings.Contains(prompt, "(none parsed") {
+		t.Error("prompt did not tell the model there are no annotatable files")
+	}
+}
+
 func TestResponseFor(t *testing.T) {
 	tests := []struct {
 		name            string
 		reply           string
 		wantBody        string
-		wantAnnotations []PluginAnnotation
+		wantAnnotations []pluginkit.Annotation
 	}{
 		{
 			name:     "structured reply",
 			reply:    `{"summary":"- did a thing","annotations":[{"filename":"server/plugins.go","line":11,"severity":"warning","content":"looks wrong"}]}`,
 			wantBody: "- did a thing",
-			wantAnnotations: []PluginAnnotation{
+			wantAnnotations: []pluginkit.Annotation{
 				{Filename: "server/plugins.go", Line: 11, Severity: "warning", Content: "looks wrong"},
 			},
 		},
@@ -179,21 +75,18 @@ func TestResponseFor(t *testing.T) {
 			name:            "fenced reply",
 			reply:           "```json\n{\"summary\":\"- did a thing\",\"annotations\":[]}\n```",
 			wantBody:        "- did a thing",
-			wantAnnotations: []PluginAnnotation{},
+			wantAnnotations: []pluginkit.Annotation{},
 		},
 		{
 			name: "annotations normalized and unanchorable ones dropped",
 			reply: `{"summary":"s","annotations":[
 				{"filename":"./main.go","line":3,"severity":"WARNING","content":" spaced "},
-				{"filename":"main.go","line":4,"severity":"","content":"no severity"},
 				{"filename":"","line":5,"severity":"info","content":"no file"},
-				{"filename":"main.go","line":0,"severity":"info","content":"no line"},
-				{"filename":"main.go","line":6,"severity":"info","content":"  "}
+				{"filename":"main.go","line":0,"severity":"info","content":"no line"}
 			]}`,
 			wantBody: "s",
-			wantAnnotations: []PluginAnnotation{
-				{Filename: "main.go", Line: 3, Severity: "warning", Content: "spaced"},
-				{Filename: "main.go", Line: 4, Severity: severityInfo, Content: "no severity"},
+			wantAnnotations: []pluginkit.Annotation{
+				{Filename: "main.go", Line: 3, Severity: pluginkit.SeverityWarning, Content: "spaced"},
 			},
 		},
 		{
@@ -202,21 +95,21 @@ func TestResponseFor(t *testing.T) {
 			name:            "legacy plain text",
 			reply:           "- just a summary\n- no JSON here",
 			wantBody:        "- just a summary\n- no JSON here",
-			wantAnnotations: []PluginAnnotation{},
+			wantAnnotations: []pluginkit.Annotation{},
 		},
 		{
 			name:            "json without a summary",
 			reply:           `{"summary":"","annotations":[{"filename":"main.go","line":2,"severity":"info","content":"x"}]}`,
 			wantBody:        `{"summary":"","annotations":[{"filename":"main.go","line":2,"severity":"info","content":"x"}]}`,
-			wantAnnotations: []PluginAnnotation{},
+			wantAnnotations: []pluginkit.Annotation{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := responseFor(tt.reply)
-			if got.Body.BodyType != bodyTypeMarkdown {
-				t.Errorf("body type = %q, want %q", got.Body.BodyType, bodyTypeMarkdown)
+			if got.Body.BodyType != pluginkit.BodyTypeMarkdown {
+				t.Errorf("body type = %q, want %q", got.Body.BodyType, pluginkit.BodyTypeMarkdown)
 			}
 			if got.Body.BodyContent != tt.wantBody {
 				t.Errorf("body = %q, want %q", got.Body.BodyContent, tt.wantBody)
@@ -232,22 +125,16 @@ func TestResponseFor(t *testing.T) {
 // through the server's parser, which is what decides whether a plugin speaks
 // the contract or gets treated as legacy output.
 func TestEncodedOutputMatchesContract(t *testing.T) {
-	response := responseFor(`{"summary":"- <b>bold</b> & terse","annotations":[{"filename":"server/plugins.go","line":11,"severity":"warning","content":"looks wrong"}]}`)
+	response := responseFor(`{"summary":"- terse","annotations":[{"filename":"server/plugins.go","line":11,"severity":"warning","content":"looks wrong"}]}`)
 
 	var out bytes.Buffer
-	if err := encodeResponse(&out, response); err != nil {
-		t.Fatalf("encodeResponse: %v", err)
-	}
-	if strings.Contains(out.String(), "\\u003c") {
-		t.Error("stdout escaped HTML, which makes the stored raw result unreadable")
+	if err := pluginkit.EncodeResponse(&out, response); err != nil {
+		t.Fatalf("EncodeResponse: %v", err)
 	}
 
 	parsed := server.ParsePluginOutput(out.String())
-	if parsed.Body.BodyType != server.BodyTypeMarkdown {
-		t.Errorf("parsed body type = %q, want %q", parsed.Body.BodyType, server.BodyTypeMarkdown)
-	}
-	if parsed.Body.BodyContent != "- <b>bold</b> & terse" {
-		t.Errorf("parsed body = %q", parsed.Body.BodyContent)
+	if parsed.Body.BodyType != server.BodyTypeMarkdown || parsed.Body.BodyContent != "- terse" {
+		t.Errorf("parsed body = %+v", parsed.Body)
 	}
 	want := []server.PluginAnnotation{
 		{Filename: "server/plugins.go", Line: 11, Severity: "warning", Content: "looks wrong"},

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -57,7 +57,7 @@ OnlyOnDemand = true    # This plugin only runs when explicitly requested
 
 - **Summarize Diff**: Uses Gemini 2.5 Flash to provide a terse bulleted summary of the changes in a PR. Emits the [response contract](#plugin-response-contract): a markdown body holding the summary, plus up to six annotations anchored to the lines worth a reviewer's attention.
 - **Security Check**: Uses Gemini 2.5 Flash to analyze the diff for potential security risks, specifically looking for unprotected sensitive endpoints, hardcoded secrets, or missing security decorators (like `@authenticated`).
-- **Style Guidelines**: Uses Gemini 2.5 Flash to evaluate a PR's diff against your personal style guide. Reads rules from `~/.config/style_guidelines.md` and reports violations, compliance highlights, and an overall assessment. Requires `GEMINI_API_KEY`. See [Style Guidelines Plugin](#style-guidelines-plugin) below.
+- **Style Guidelines**: Uses Gemini 2.5 Flash to evaluate a PR's diff against your personal style guide. Reads rules from `~/.config/style_guidelines.md` and reports violations, compliance highlights, and an overall assessment. Emits the [response contract](#plugin-response-contract): a markdown body holding the report, plus an annotation on each line that breaks a guideline. Requires `GEMINI_API_KEY`. See [Style Guidelines Plugin](#style-guidelines-plugin) below.
 - **Claude Review**: Runs `claude -p "review PR #<number> on repo <owner>/<repo>" --model sonnet` via the Claude CLI. Written in Zig. Build with `zig build` inside `cmd/claude_review/` and place the resulting binary on your `$PATH`.
 
 Plugins are expected to accept flags like `--owner`, `--repo`, `--number`, and any of the optional content flags enabled above (`--diff`, `--headers`, `--comments`, `--branch`).
@@ -67,6 +67,8 @@ Plugins are expected to accept flags like `--owner`, `--repo`, `--number`, and a
 You can write a plugin in any language you like. The only requirement is that the binary must be discoverable on your `$PATH`.
 
 The `example_plugin` included in this repository demonstrates the interface and potential options.
+
+Go plugins living in this repository share `cmd/internal/pluginkit`, which holds the response contract types, the diff line numbering that lets a model anchor annotations, and the Gemini call the bundled LLM plugins make.
 
 When your plugin runs, its standard output (stdout) is captured and stored in the database. Clients can then retrieve and display this output when you are reviewing a PR. For example, in the web client, plugin outputs appear in a dedicated "Plugins" section for each PR.
 
@@ -228,7 +230,11 @@ The `style_guidelines` plugin evaluates PR diffs against a Markdown file of your
 
 ### Output
 
-The plugin produces a brief report with:
+The plugin emits the [response contract](#plugin-response-contract).
+
+Its markdown body is a brief report with:
 - Specific violations (with file/line references where available)
 - Areas of the diff that comply well with the guidelines
 - An overall style compliance assessment
+
+Alongside the report it returns up to ten annotations, one per line of the diff that breaks a guideline, so violations render inline in the diff as well as in the report. Each annotation names the guideline broken and how to fix the line, with a severity of `info` for a nit, `warning` for a clear violation, or `error` for one that breaks a guideline stated as a hard requirement. A diff the model can't number — one with no parseable hunks — yields no annotations, and the report alone is returned.


### PR DESCRIPTION
The style plugin wrote its report as plain text, so violations only
existed as prose the reviewer had to map back onto the diff by hand. It
now emits the contract from docs/plugins.md: the report as a markdown
body, plus an annotation on each line that breaks a guideline, which the
web and Emacs clients render inline in the diff.

Gemini is asked for the report and the annotations under a response
schema, and the diff it sees is numbered with head-side line numbers so
it can anchor them. A reply that isn't the JSON we asked for still
becomes the body verbatim, so the plugin degrades to its old behaviour
rather than failing.

The pieces this needs — the contract types, the diff numbering, the
Gemini call — were all in summarize_diff's package main. They move to
cmd/internal/pluginkit, with their tests, and summarize_diff now uses
them instead of its own copies; its behaviour is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HKFWmaWo8tZzr8myNnQavh