### PR TITLE
Speed up crs-get-reviews by ~35x

### DIFF
--- a/client.el/crs-list-mode.el
+++ b/client.el/crs-list-mode.el
@@ -249,7 +249,13 @@ If the buffer already exists, switch to it instead of making a new RPC call."
 
       (crs--send-request
        "RPCHandler.GetAllReviews"
-       (vector)
+       ;; Ask the server to leave out the per-PR subtrees this buffer never
+       ;; reads.  Diffs alone were ~98% of the reply, and the list only ever
+       ;; parses a PR URL off the current line — `crs-get-review' re-fetches
+       ;; the diff through GetPR when a review is actually opened.
+       (vector (list (cons 'IncludeDiff :json-false)
+                     (cons 'IncludeComments
+                           (if crs-include-comments-tree t :json-false))))
        (lambda (result)
          (let* ((content (cdr (assq 'content result)))
                 (rendered (if crs-include-comments-tree

--- a/client.el/crs-review.el
+++ b/client.el/crs-review.el
@@ -57,7 +57,10 @@
                  (cons 'Repo repo)
                  (cons 'Number number)))
    (lambda (result)
-     (message "DEBUG GetPR result: %S" result)
+     (when crs-debug
+       (message "DEBUG GetPR result: %s"
+                (truncate-string-to-width (format "%S" result)
+                                          crs-debug-max-length nil nil t)))
      (let* ((buffer (get-buffer-create (crs--review-buffer-name owner repo number)))
             (project-path (expand-file-name (concat "~/" repo)))
             (error-info (cdr (assq 'error result))))

--- a/client.el/crs-rpc.el
+++ b/client.el/crs-rpc.el
@@ -67,25 +67,55 @@ Useful after recompiling the Go server binary."
   (sleep-for 0.2)  ; Give the process a moment to fully shut down
   (crs-start-server))
 
-(defun crs--process-filter (process output)
-  "Filter function for processing JSON-RPC responses from the server."
-  (setq crs--response-buffer
-        (concat crs--response-buffer output))
-
-  ;; Process complete lines (JSON-RPC uses newline-delimited JSON)
-  (while (string-match "\n" crs--response-buffer)
-    (let ((line (substring crs--response-buffer 0 (match-beginning 0))))
-      (setq crs--response-buffer
-            (substring crs--response-buffer (match-end 0)))
-
-      (when (> (length line) 0)
+(defun crs--process-filter (_process output)
+  "Filter function for processing JSON-RPC responses from the server.
+OUTPUT arrives in chunks of `read-process-output-max' bytes, so a reply is
+spread over many calls.  Chunks are pushed onto `crs--response-pending'
+untouched and joined only once a newline actually arrives; scanning is
+confined to the joined string.  Concatenating and rescanning the whole
+accumulator on every chunk instead makes this quadratic in the reply size."
+  (if (not (string-search "\n" output))
+      (push output crs--response-pending)
+    (let ((joined (apply #'concat (nreverse (cons output crs--response-pending))))
+          (start 0)
+          (lines nil)
+          pos)
+      (setq crs--response-pending nil)
+      ;; JSON-RPC is newline-delimited: split out every complete line and
+      ;; carry any trailing partial line over to the next chunk.
+      (while (setq pos (string-search "\n" joined start))
+        (let ((line (substring joined start pos)))
+          (when (> (length line) 0)
+            (push line lines)))
+        (setq start (1+ pos)))
+      (when (< start (length joined))
+        (push (substring joined start) crs--response-pending))
+      ;; Dispatch only after the pending state is settled, so a callback that
+      ;; re-enters the filter cannot lose a buffered chunk.
+      (dolist (line (nreverse lines))
         (crs--handle-response line)))))
+
+(defun crs--parse-json (string)
+  "Parse STRING as JSON, preferring the native parser.
+The keyword arguments reproduce `json-read-from-string' semantics exactly
+\(alists with symbol keys, arrays as vectors, null as nil, false as
+`:json-false') so callers see no behavior change, but parsing is roughly
+7x faster on the large replies this client receives."
+  (if (fboundp 'json-parse-string)
+      (json-parse-string string
+                         :object-type 'alist
+                         :array-type 'array
+                         :null-object nil
+                         :false-object :json-false)
+    (json-read-from-string string)))
 
 (defun crs--handle-response (response-line)
   "Handle a single JSON-RPC response line."
-  (message "DEBUG crs response: %s" response-line)
+  (when crs-debug
+    (message "DEBUG crs response: %s"
+             (truncate-string-to-width response-line crs-debug-max-length nil nil t)))
   (condition-case err
-      (let ((response (json-read-from-string response-line)))
+      (let ((response (crs--parse-json response-line)))
         (let ((id (cdr (assq 'id response)))
               (result (cdr (assq 'result response)))
               (error (cdr (assq 'error response))))

--- a/client.el/crs-tests.el
+++ b/client.el/crs-tests.el
@@ -13,6 +13,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-lib)
 (require 'crs-client)
 
 ;;; --- Wiring: the loader pulls in every module ---
@@ -252,6 +253,80 @@ line the diff does not show, and one for a file outside the diff.")
     (crs--insert-plugin-output-entry
      "Legacy" '((result . "plain text output") (status . "success")))
     (should (string-match-p "plain text output" (buffer-string)))))
+
+;;; --- JSON-RPC transport ---
+
+(defun crs-tests--filter-lines (chunks)
+  "Feed CHUNKS through `crs--process-filter', returning the lines dispatched."
+  (let ((got nil))
+    (setq crs--response-pending nil)
+    (cl-letf (((symbol-function 'crs--handle-response)
+               (lambda (line) (push line got))))
+      (dolist (chunk chunks)
+        (crs--process-filter nil chunk)))
+    (nreverse got)))
+
+(ert-deftest crs-test-process-filter-reassembles-chunks ()
+  "Complete lines are dispatched however the output is chunked."
+  ;; One chunk, one line.
+  (should (equal (crs-tests--filter-lines '("{\"id\":1}\n")) '("{\"id\":1}")))
+  ;; A line split across several chunks is dispatched once, intact.
+  (should (equal (crs-tests--filter-lines '("{\"id" "\":1}" "\n"))
+                 '("{\"id\":1}")))
+  ;; Several lines arriving in a single chunk are dispatched in order.
+  (should (equal (crs-tests--filter-lines '("a\nb\nc\n")) '("a" "b" "c")))
+  ;; A newline landing mid-chunk splits correctly.
+  (should (equal (crs-tests--filter-lines '("a\nb" "c\n")) '("a" "bc")))
+  ;; Empty lines are skipped, matching the previous behavior.
+  (should (equal (crs-tests--filter-lines '("a\n\n\nb\n")) '("a" "b"))))
+
+(ert-deftest crs-test-process-filter-holds-partial-line ()
+  "A trailing partial line is buffered until its newline arrives."
+  ;; Nothing dispatched while the line is incomplete.
+  (should (equal (crs-tests--filter-lines '("{\"id\":1}")) nil))
+  (should crs--response-pending)
+  ;; The buffered remainder is prepended to the next chunk.
+  (setq crs--response-pending nil)
+  (let ((got nil))
+    (cl-letf (((symbol-function 'crs--handle-response)
+               (lambda (line) (push line got))))
+      (crs--process-filter nil "{\"id\"")
+      (should (null got))
+      (crs--process-filter nil ":1}\nnext")
+      (should (equal got '("{\"id\":1}")))
+      ;; "next" is still pending, not dispatched.
+      (crs--process-filter nil "-line\n")
+      (should (equal (nreverse got) '("{\"id\":1}" "next-line")))))
+  (should-not crs--response-pending))
+
+(ert-deftest crs-test-process-filter-large-payload-roundtrip ()
+  "A large single-line reply survives chunking byte-for-byte.
+This is the shape that made the old filter quadratic: many chunks with no
+newline until the very end."
+  (let* ((payload (json-encode `((jsonrpc . "2.0") (id . 1)
+                                 (result . ((content . ,(make-string 200000 ?x)))))))
+         (chunks nil)
+         (i 0))
+    (while (< i (length payload))
+      (push (substring payload i (min (length payload) (+ i 4096))) chunks)
+      (setq i (+ i 4096)))
+    (setq chunks (nreverse (cons "\n" chunks)))
+    (should (equal (crs-tests--filter-lines chunks) (list payload)))))
+
+(ert-deftest crs-test-parse-json-matches-json-read ()
+  "`crs--parse-json' reproduces `json-read-from-string' semantics."
+  (dolist (doc '("{\"a\":1,\"b\":[1,2,3]}"
+                 "{\"t\":true,\"f\":false,\"n\":null}"
+                 "{\"nested\":{\"deep\":[{\"k\":\"v\"}]}}"
+                 "{\"unicode\":\"caf\\u00e9 \\u2014 ok\"}"
+                 "{\"empty_arr\":[],\"empty_obj\":{}}"
+                 "[1,\"two\",false]"))
+    (should (equal (crs--parse-json doc) (json-read-from-string doc))))
+  ;; Arrays stay vectors and false stays :json-false, which callers rely on.
+  (let ((parsed (crs--parse-json "{\"items\":[1,2],\"ok\":false}")))
+    (should (vectorp (cdr (assq 'items parsed))))
+    (should (eq (cdr (assq 'ok parsed)) :json-false))
+    (should (eq (cdr (assq 'missing parsed)) nil))))
 
 (provide 'crs-tests)
 ;;; crs-tests.el ends here

--- a/client.el/crs-vars.el
+++ b/client.el/crs-vars.el
@@ -23,8 +23,24 @@
 (defvar crs--pending-requests (make-hash-table :test 'equal)
   "Hash table mapping request IDs to callback functions.")
 
-(defvar crs--response-buffer ""
-  "Buffer for accumulating partial JSON-RPC responses.")
+(defvar crs--response-pending nil
+  "Reversed list of output chunks not yet terminated by a newline.
+Chunks are kept unjoined so that accumulating a large single-line reply
+costs one concatenation when it completes rather than one per chunk.")
+
+(defcustom crs-debug nil
+  "When non-nil, log JSON-RPC responses to the *Messages* buffer.
+Off by default: a reply can run to megabytes (a GetPR reply carries the
+whole diff), and logging one costs both the echo-area redisplay and a
+permanent copy in *Messages*.  Logged responses are truncated to
+`crs-debug-max-length' characters."
+  :type 'boolean
+  :group 'crs)
+
+(defcustom crs-debug-max-length 2000
+  "Maximum number of characters of a response logged when `crs-debug' is non-nil."
+  :type 'integer
+  :group 'crs)
 
 (defvar crs-reviews-buffer-name "* Reviews *"
   "Name of the buffer used to display the reviews list.")
@@ -37,8 +53,9 @@
 
 (defcustom crs-include-comments-tree nil
   "When non-nil, include a comments sub-tree for each PR in the GetAllReviews org output.
-This causes the server to embed cached PR comments inline under each PR heading.
-Disabled by default because fetching and rendering comments slows down the reviews buffer."
+This is passed to the server as IncludeComments, so the comments are left
+out of the reply entirely rather than stripped after transfer.  Disabled by
+default because fetching and rendering comments slows down the reviews buffer."
   :type 'boolean
   :group 'crs)
 

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -122,8 +122,25 @@ func sortEntries(entries []sectionEntry, sortMethod string, configured bool) {
 	}
 }
 
+// RenderOptions controls which of an item's heavy detail subtrees are
+// serialized into the org text. The zero value renders the compact dashboard
+// form — headline, metadata and CI status — which is all a list view needs;
+// clients that display a full PR fetch it with GetPR instead. Diffs and
+// comment threads dominate the payload (they were ~98% of it), so they are
+// opt-in rather than opt-out.
+type RenderOptions struct {
+	IncludeDiff     bool
+	IncludeComments bool
+}
+
+// FullRenderOptions renders every detail subtree, for callers that want the
+// complete org export rather than the dashboard list.
+func FullRenderOptions() RenderOptions {
+	return RenderOptions{IncludeDiff: true, IncludeComments: true}
+}
+
 // renderSectionViews serializes the pipeline output to the org-mode text form.
-func (r *OrgRenderer) renderSectionViews(views []sectionView) string {
+func (r *OrgRenderer) renderSectionViews(views []sectionView, opts RenderOptions) string {
 	var content strings.Builder
 	for _, view := range views {
 		items := make([]*database.Item, len(view.entries))
@@ -135,7 +152,7 @@ func (r *OrgRenderer) renderSectionViews(views []sectionView) string {
 		content.WriteString("\n")
 
 		for _, item := range items {
-			for _, line := range r.buildItemLines(item, 2) {
+			for _, line := range r.buildItemLines(item, 2, opts) {
 				content.WriteString(line)
 				if !strings.HasSuffix(line, "\n") {
 					content.WriteString("\n")
@@ -159,20 +176,22 @@ func reviewItemsFromViews(views []sectionView) []ReviewItem {
 	return reviewItems
 }
 
+// RenderAllSectionsToString renders the complete org export, including diffs
+// and comment threads.
 func (r *OrgRenderer) RenderAllSectionsToString() (string, error) {
 	views, err := r.collectSections()
 	if err != nil {
 		return "", err
 	}
-	return r.renderSectionViews(views), nil
+	return r.renderSectionViews(views, FullRenderOptions()), nil
 }
 
-func (r *OrgRenderer) RenderAndGetItems() (string, []ReviewItem, error) {
+func (r *OrgRenderer) RenderAndGetItems(opts RenderOptions) (string, []ReviewItem, error) {
 	views, err := r.collectSections()
 	if err != nil {
 		return "", nil, err
 	}
-	return r.renderSectionViews(views), reviewItemsFromViews(views), nil
+	return r.renderSectionViews(views, opts), reviewItemsFromViews(views), nil
 }
 
 // ReviewItem represents a single PR review item with structured metadata
@@ -314,7 +333,24 @@ func (r *OrgRenderer) buildSectionHeader(section *database.Section, items []*dat
 	return fmt.Sprintf("%s %s %s %s", indentStars, status, section.SectionName, ratio)
 }
 
-func (r *OrgRenderer) buildItemLines(item *database.Item, indentLevel int) []string {
+// detailSubtree returns the heading text of the subtree a detail element
+// opens (e.g. "Diff", "Comments [4]"), or "" when the element is ordinary
+// content and therefore inherits the enclosing subtree's keep/skip decision.
+// Detail elements are stored one-per-subtree-chunk, so a diff's body is a
+// single element and never mistaken for a heading.
+func detailSubtree(detail string) string {
+	if !strings.HasPrefix(detail, "*") {
+		return ""
+	}
+	rest := strings.TrimLeft(detail, "*")
+	if !strings.HasPrefix(rest, " ") {
+		return ""
+	}
+	heading, _, _ := strings.Cut(rest, "\n")
+	return strings.TrimSpace(heading)
+}
+
+func (r *OrgRenderer) buildItemLines(item *database.Item, indentLevel int, opts RenderOptions) []string {
 	details, err := item.GetDetails()
 	if err != nil {
 		slog.Error("Error getting item details", "error", err, "item_id", item.ID)
@@ -348,9 +384,25 @@ func (r *OrgRenderer) buildItemLines(item *database.Item, indentLevel int) []str
 		titleLine += "\t\t" + tagStr
 	}
 
+	// Walk the detail elements, dropping whole subtrees the caller did not
+	// ask for. keep carries across non-heading elements so a subtree's body
+	// follows its heading in or out.
 	lines := []string{titleLine + "\n"}
+	keep := true
 	for _, d := range details {
-		if !strings.HasPrefix(d, "*** BODY") {
+		if heading := detailSubtree(d); heading != "" {
+			switch {
+			case strings.HasPrefix(heading, "BODY"):
+				keep = false
+			case strings.HasPrefix(heading, "Diff"):
+				keep = opts.IncludeDiff
+			case strings.HasPrefix(heading, "Comments"):
+				keep = opts.IncludeComments
+			default:
+				keep = true
+			}
+		}
+		if keep {
 			lines = append(lines, d)
 		}
 	}

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -1030,6 +1030,107 @@ func TestGetLatestReviewEaseSkipsUnratedRows(t *testing.T) {
 	}
 }
 
+// detailsWithSubtrees mirrors the element layout PRToFileChangesDetails
+// produces: flat metadata, then one element per subtree heading followed by
+// that subtree's body.
+func detailsWithSubtrees() []string {
+	return []string{
+		"42",
+		"Repo: C-Hipple/code-review-server",
+		"*** SUCCESS CI Status\n",
+		" build: success\n",
+		"*** Diff\n",
+		"diff --git a/x.go b/x.go\n+added line\n-removed line\n",
+		"*** BODY\n the pr body\n",
+		"*** Comments [1]\n",
+		" alice: nice change\n",
+	}
+}
+
+func TestBuildItemLinesRenderOptions(t *testing.T) {
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	section, err := db.GetOrCreateSection("Test Section", 0)
+	if err != nil {
+		t.Fatalf("failed to create section: %v", err)
+	}
+	item, err := db.UpsertItem(section.ID, "42", "TODO", "Some PR",
+		detailsWithSubtrees(), []string{"code-review-server"}, 0)
+	if err != nil {
+		t.Fatalf("failed to create item: %v", err)
+	}
+	r := NewOrgRenderer(db)
+
+	for _, tc := range []struct {
+		name    string
+		opts    RenderOptions
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "compact zero value drops diff and comments",
+			opts:    RenderOptions{},
+			want:    []string{"CI Status", "build: success", "Repo:"},
+			notWant: []string{"*** Diff", "added line", "*** Comments", "alice", "the pr body"},
+		},
+		{
+			name:    "diff opted in",
+			opts:    RenderOptions{IncludeDiff: true},
+			want:    []string{"*** Diff", "added line", "CI Status"},
+			notWant: []string{"*** Comments", "alice", "the pr body"},
+		},
+		{
+			name:    "comments opted in",
+			opts:    RenderOptions{IncludeComments: true},
+			want:    []string{"*** Comments", "alice", "CI Status"},
+			notWant: []string{"*** Diff", "added line", "the pr body"},
+		},
+		{
+			name:    "full render keeps both but never the body",
+			opts:    FullRenderOptions(),
+			want:    []string{"*** Diff", "added line", "*** Comments", "alice"},
+			notWant: []string{"the pr body"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Join(r.buildItemLines(item, 2, tc.opts), "")
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("rendered output missing %q:\n%s", want, got)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(got, notWant) {
+					t.Errorf("rendered output should not contain %q:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}
+
+func TestDetailSubtree(t *testing.T) {
+	for _, tc := range []struct {
+		detail string
+		want   string
+	}{
+		{"*** Diff\n", "Diff"},
+		{"*** Comments [4]\n", "Comments [4]"},
+		{"** TODO Some PR\n", "TODO Some PR"},
+		{"Repo: C-Hipple/code-review-server", ""},
+		{" build: success\n", ""},
+		// A diff body is a single element and must not read as a heading,
+		// even when a diff line happens to begin with stars.
+		{"diff --git a/x.go b/x.go\n+*** not a heading\n", ""},
+		{"***nospace", ""},
+	} {
+		if got := detailSubtree(tc.detail); got != tc.want {
+			t.Errorf("detailSubtree(%q) = %q, want %q", tc.detail, got, tc.want)
+		}
+	}
+}
+
 func TestBuildItemLinesIncludesReviewEaseTag(t *testing.T) {
 	db := setupTestDB(t)
 	config.SetC(config.Config{DB: db, ExperimentalLLMReviewEase: true})
@@ -1053,7 +1154,7 @@ func TestBuildItemLinesIncludesReviewEaseTag(t *testing.T) {
 	}
 
 	r := NewOrgRenderer(db)
-	lines := r.buildItemLines(item, 2)
+	lines := r.buildItemLines(item, 2, FullRenderOptions())
 	if len(lines) == 0 {
 		t.Fatal("no lines rendered")
 	}
@@ -1063,7 +1164,7 @@ func TestBuildItemLinesIncludesReviewEaseTag(t *testing.T) {
 
 	// With the flag off, the headline keeps only the stored tags.
 	config.SetC(config.Config{DB: db})
-	lines = r.buildItemLines(item, 2)
+	lines = r.buildItemLines(item, 2, FullRenderOptions())
 	if !strings.Contains(lines[0], ":code-review-server:") || strings.Contains(lines[0], "medium") {
 		t.Errorf("title line %q should not include review-ease tag when disabled", lines[0])
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -74,7 +74,14 @@ func (h *RPCHandler) Hello(args *HelloArgs, reply *HelloReply) error {
 	return nil
 }
 
-type GetReviewsArgs struct{}
+// GetReviewsArgs lets a client opt in to the heavy per-PR detail subtrees in
+// the rendered org content. Both default to false: the dashboard only needs
+// headlines and metadata, and a client showing a full PR fetches it with
+// GetPR, which returns the diff and comments as structured fields.
+type GetReviewsArgs struct {
+	IncludeDiff     bool `json:"IncludeDiff"`
+	IncludeComments bool `json:"IncludeComments"`
+}
 
 type GetReviewsReply struct {
 	Content string       `json:"content"` // Kept for simplicity on org-mode clients
@@ -122,7 +129,10 @@ func (h *RPCHandler) GetAllReviews(args *GetReviewsArgs, reply *GetReviewsReply)
 	}
 
 	renderer := NewOrgRenderer(config.C().DB)
-	content, items, err := renderer.RenderAndGetItems()
+	content, items, err := renderer.RenderAndGetItems(RenderOptions{
+		IncludeDiff:     args.IncludeDiff,
+		IncludeComments: args.IncludeComments,
+	})
 	if err != nil {
 		slog.Error("Error rendering org files", "error", err)
 		return err
@@ -306,7 +316,8 @@ type GetAdjacentPRReply struct {
 
 func (h *RPCHandler) GetAdjacentPR(args *GetAdjacentPRArgs, reply *GetAdjacentPRReply) error {
 	renderer := NewOrgRenderer(config.C().DB)
-	_, items, err := renderer.RenderAndGetItems()
+	// Adjacency only needs the ordered items; skip rendering the org text.
+	items, err := renderer.GetAllReviewItems()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Loading the reviews list took ~870ms of Emacs time for 30 PRs, almost all
of it spent moving and re-scanning data the list buffer never displays.

Server: GetAllReviews rendered every PR's full diff and comment threads
into the org content. Diffs alone were ~98% of the reply. The Emacs list
buffer only parses a PR URL off the current line, and the web frontend
reads `items` and discards `content` entirely, so none of it was used.
GetReviewsArgs gains IncludeDiff/IncludeComments, both defaulting to
false, and buildItemLines drops whole subtrees the caller did not request.
RenderAllSectionsToString keeps rendering everything. GetAdjacentPR now
calls GetAllReviewItems instead of rendering org text it discarded.

Measured against the real server with a 30-PR database, the reply drops
from 1,084,448 to 19,598 bytes.

Client: crs--process-filter concatenated the whole accumulator and
rescanned it from position 0 on every 4KB chunk. Since a reply is a single
line, that scan found nothing until the last chunk, making the filter
quadratic in reply size — 670ms and 13 GCs on a 1MB reply, and 5.6s on a
4MB one. Chunks are now buffered unjoined and joined once a newline
arrives, and scanning is confined to the joined string.

Also parse responses with the native json-parse-string, using keyword
arguments that reproduce json-read-from-string semantics exactly (alists,
arrays as vectors, false as :json-false), and put the unconditional
DEBUG response logging in crs-rpc.el and crs-review.el behind a new
crs-debug option — it copied every megabyte reply into *Messages*.

End to end on real server replies: 871ms -> 25ms, 14 GCs -> 0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HVQCgbjU7VB59y4Nihq9LQ