### PR TITLE
Rename PORT env var to CRS_PORT for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,8 @@ VOLUME ["/home/crs/data"]
 ENV XDG_CONFIG_HOME=/home/crs/.config
 ENV CRS_HOME=/home/crs/data
 
-# Web UI port (override with -e PORT=...)
-ENV PORT=5172
+# Web UI port (override with -e CRS_PORT=...)
+ENV CRS_PORT=5172
 EXPOSE 5172
 
 ENTRYPOINT ["/usr/local/bin/crs-gui"]

--- a/bun_client/server.ts
+++ b/bun_client/server.ts
@@ -138,13 +138,15 @@ const CORS_HEADERS = {
     'Access-Control-Allow-Headers': 'Content-Type',
 };
 
+const SERVER_PORT = parseInt(process.env.CRS_PORT || '5172', 10);
+
 Bun.serve<{
     cmd: string | null;
     args?: string[];
     envs: Record<string, string>;
     proc?: Subprocess;
 }>({
-    port: parseInt(process.env.PORT || '5172', 10),
+    port: SERVER_PORT,
     async fetch(req, server) {
         const url = new URL(req.url);
 
@@ -595,4 +597,4 @@ Type: ${type}
     },
 });
 
-console.log(`Bun server running on http://localhost:${parseInt(process.env.PORT || '5172', 10)}`);
+console.log(`Bun server running on http://localhost:${SERVER_PORT}`);


### PR DESCRIPTION
## Summary

Renames the `PORT` environment variable to `CRS_PORT` throughout the Bun web client and Dockerfile to align with the project's naming convention (all CRS-specific env vars use the `CRS_` prefix, as documented in CLAUDE.md).

### Changes

- Extract server port configuration to a `SERVER_PORT` constant in `bun_client/server.ts` to avoid repeated parsing
- Update `Bun.serve()` port configuration to use `CRS_PORT` instead of `PORT`
- Update startup log message to reference the new constant
- Update Dockerfile to use `CRS_PORT=5172` instead of `PORT=5172`
- Update Dockerfile comment to reflect the new env var name

## Test Plan

- [ ] `bun run type-check` passes (TypeScript validation)
- [ ] `bun run lint` passes (ESLint)
- [ ] Verify server starts with default port: `bun run build && bun_client/server.ts`
- [ ] Verify server respects custom port: `CRS_PORT=3000 bun_client/server.ts`

https://claude.ai/code/session_01ACVAvayY5uvtC2o6pG1DDL