### PR TITLE
Pass a --call-type argument to plugins

### DIFF
--- a/cmd/claude_review/README.md
+++ b/cmd/claude_review/README.md
@@ -33,6 +33,7 @@ IncludeComments = true
 
 ```
 claude_review --owner <owner> --repo <repo> --number <number>
+              [--call-type automatic|explicit|rerun]
               [--diff <unified-diff>]
               [--headers <pr-metadata-json>]
               [--comments <comments-json>]
@@ -42,6 +43,8 @@ claude_review --owner <owner> --repo <repo> --number <number>
 - `--diff`, `--headers`, `--comments` — when the server is configured with
   the corresponding `Include*` options, the values are injected into the
   prompt so the agent doesn't have to re-fetch them.
+- `--call-type` — why the server triggered this run. Accepted and ignored;
+  the review is the same either way. See [Call Types](../../docs/plugins.md#call-types).
 - `--post-review` — after producing the review, post it to GitHub as a
   comment-style PR review via `gh pr review`. Requires `gh` on `$PATH`
   with `repo` scope.

--- a/cmd/claude_review/main.go
+++ b/cmd/claude_review/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crs/cmd/internal/pluginkit"
 	"flag"
 	"fmt"
 	"io"
@@ -242,6 +243,9 @@ func main() {
 	headers := flag.String("headers", "", "PR metadata JSON")
 	comments := flag.String("comments", "", "Review comments JSON")
 	postReviewFlag := flag.Bool("post-review", false, "Post review via gh pr review")
+	// The review doesn't vary by call type, but the flag still has to be
+	// accepted since the server always passes it.
+	pluginkit.RegisterCallTypeFlag()
 	flag.Parse()
 
 	stderr := os.Stderr

--- a/cmd/example_plugin/main.go
+++ b/cmd/example_plugin/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crs/cmd/internal/pluginkit"
 	"flag"
 	"fmt"
 )
@@ -13,6 +14,7 @@ func main() {
 	comments := flag.String("comments", "", "PR comments JSON")
 	headers := flag.String("headers", "", "PR metadata JSON")
 	branch := flag.String("branch", "", "PR head branch name")
+	callType := pluginkit.RegisterCallTypeFlag()
 
 	flag.Parse()
 
@@ -25,6 +27,9 @@ func main() {
 	if *number != 0 {
 		fmt.Printf("Number: %d\n", *number)
 	}
+	// The server always passes --call-type, so a plugin can tell an automatic
+	// run apart from one a reviewer asked for.
+	fmt.Printf("Call Type: %s\n", callType())
 	if *branch != "" {
 		fmt.Printf("Branch: %s\n", *branch)
 	}

--- a/cmd/internal/pluginkit/calltype.go
+++ b/cmd/internal/pluginkit/calltype.go
@@ -1,0 +1,49 @@
+package pluginkit
+
+import "flag"
+
+// CallType is the value the server passes to a plugin via --call-type,
+// describing why the plugin is being run.
+type CallType string
+
+const (
+	// CallTypeAutomatic is a run the server triggered on its own, when a PR was
+	// fetched or its head SHA changed.
+	CallTypeAutomatic CallType = "automatic"
+	// CallTypeExplicit is a run of a deferred (OnlyOnDemand) plugin, which only
+	// ever executes because someone asked for it by name.
+	CallTypeExplicit CallType = "explicit"
+	// CallTypeRerun is a requested rerun of a plugin that would otherwise have
+	// run automatically.
+	CallTypeRerun CallType = "rerun"
+)
+
+// ParseCallType turns the raw --call-type value into a CallType, falling back
+// to CallTypeAutomatic for an empty or unrecognised value so a plugin built
+// against an older or newer server still behaves sensibly.
+func ParseCallType(s string) CallType {
+	switch CallType(s) {
+	case CallTypeExplicit:
+		return CallTypeExplicit
+	case CallTypeRerun:
+		return CallTypeRerun
+	default:
+		return CallTypeAutomatic
+	}
+}
+
+// Requested reports whether the run was asked for by a person, rather than
+// triggered by the server. Plugins that cache or throttle expensive work
+// should treat a requested run as a reason to redo it.
+func (c CallType) Requested() bool {
+	return c == CallTypeExplicit || c == CallTypeRerun
+}
+
+// RegisterCallTypeFlag declares --call-type on the default flag set and returns
+// a resolver to call after flag.Parse. Every plugin has to accept the flag,
+// since the server always passes it, so plugins that don't act on the value can
+// call this and discard the resolver.
+func RegisterCallTypeFlag() func() CallType {
+	raw := flag.String("call-type", string(CallTypeAutomatic), "why this run was triggered: automatic, explicit or rerun")
+	return func() CallType { return ParseCallType(*raw) }
+}

--- a/cmd/internal/pluginkit/calltype_test.go
+++ b/cmd/internal/pluginkit/calltype_test.go
@@ -1,0 +1,33 @@
+package pluginkit
+
+import "testing"
+
+func TestParseCallType(t *testing.T) {
+	tests := []struct {
+		in   string
+		want CallType
+	}{
+		{"automatic", CallTypeAutomatic},
+		{"explicit", CallTypeExplicit},
+		{"rerun", CallTypeRerun},
+		{"", CallTypeAutomatic},
+		{"something-new", CallTypeAutomatic},
+	}
+	for _, tt := range tests {
+		if got := ParseCallType(tt.in); got != tt.want {
+			t.Errorf("ParseCallType(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCallTypeRequested(t *testing.T) {
+	if CallTypeAutomatic.Requested() {
+		t.Error("automatic runs should not report as requested")
+	}
+	if !CallTypeExplicit.Requested() {
+		t.Error("explicit runs should report as requested")
+	}
+	if !CallTypeRerun.Requested() {
+		t.Error("reruns should report as requested")
+	}
+}

--- a/cmd/security_check/main.go
+++ b/cmd/security_check/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crs/cmd/internal/pluginkit"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -131,6 +132,9 @@ func main() {
 	number := flag.Int("number", 0, "PR number")
 	commentsJSON := flag.String("comments", "", "PR comments JSON")
 	headersJSON := flag.String("headers", "", "PR metadata JSON")
+	// The analysis doesn't vary by call type, but the flag still has to be
+	// accepted since the server always passes it.
+	pluginkit.RegisterCallTypeFlag()
 
 	flag.Parse()
 

--- a/cmd/style_guidelines/main.go
+++ b/cmd/style_guidelines/main.go
@@ -122,6 +122,9 @@ func main() {
 	number := flag.Int("number", 0, "PR number")
 	commentsJSON := flag.String("comments", "", "PR comments JSON")
 	headersJSON := flag.String("headers", "", "PR metadata JSON")
+	// The report doesn't vary by call type, but the flag still has to be
+	// accepted since the server always passes it.
+	pluginkit.RegisterCallTypeFlag()
 
 	flag.Parse()
 

--- a/cmd/summarize_diff/main.go
+++ b/cmd/summarize_diff/main.go
@@ -88,6 +88,9 @@ func main() {
 	number := flag.Int("number", 0, "PR number")
 	commentsJSON := flag.String("comments", "", "PR comments JSON")
 	headersJSON := flag.String("headers", "", "PR metadata JSON")
+	// The summary doesn't vary by call type, but the flag still has to be
+	// accepted since the server always passes it.
+	pluginkit.RegisterCallTypeFlag()
 
 	flag.Parse()
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,7 +60,34 @@ OnlyOnDemand = true    # This plugin only runs when explicitly requested
 - **Style Guidelines**: Uses Gemini 2.5 Flash to evaluate a PR's diff against your personal style guide. Reads rules from `~/.config/style_guidelines.md` and reports violations, compliance highlights, and an overall assessment. Emits the [response contract](#plugin-response-contract): a markdown body holding the report, plus an annotation on each line that breaks a guideline. Requires `GEMINI_API_KEY`. See [Style Guidelines Plugin](#style-guidelines-plugin) below.
 - **Claude Review**: Runs `claude -p "review PR #<number> on repo <owner>/<repo>" --model sonnet` via the Claude CLI. Written in Zig. Build with `zig build` inside `cmd/claude_review/` and place the resulting binary on your `$PATH`.
 
-Plugins are expected to accept flags like `--owner`, `--repo`, `--number`, and any of the optional content flags enabled above (`--diff`, `--headers`, `--comments`, `--branch`).
+Plugins are expected to accept flags like `--owner`, `--repo`, `--number`, `--call-type`, and any of the optional content flags enabled above (`--diff`, `--headers`, `--comments`, `--branch`).
+
+## Call Types
+
+Every invocation carries a `--call-type` flag naming why the plugin is being run, so a plugin can behave differently on a rerun than it does on the server's own scheduled runs.
+
+| Value       | When it's passed                                                                       |
+|-------------|----------------------------------------------------------------------------------------|
+| `automatic` | The server triggered the run itself, because a PR was fetched or its head SHA changed. |
+| `explicit`  | A deferred (`OnlyOnDemand = true`) plugin was requested by name via `RerunPlugins`. These plugins never run automatically, so any run of one is an explicit request. |
+| `rerun`     | A plugin that would otherwise run automatically was rerun via `RerunPlugins`. |
+
+`--call-type` is passed on **every** invocation, alongside `--owner`, `--repo` and `--number`, with no configuration option to turn it off. A plugin that rejects unknown flags — anything using Go's `flag` package, Python's `argparse`, or similar — must therefore declare it, even if it ignores the value. Plugins that parse flags loosely need no change.
+
+Both `explicit` and `rerun` mean a person asked for this run, which is the signal worth acting on: skip a cached result, spend a larger model budget, or re-fetch external state that an `automatic` run would have reused. The distinction between the two says whether the plugin is expensive-by-configuration (`explicit`) or was rerun on top of work it does routinely (`rerun`).
+
+Go plugins in this repository can use `cmd/internal/pluginkit` rather than parsing the value by hand:
+
+```go
+callType := pluginkit.RegisterCallTypeFlag() // declares --call-type
+flag.Parse()
+
+if callType().Requested() {
+    // A person asked for this run — redo the expensive work.
+}
+```
+
+`ParseCallType` maps an unrecognised or empty value to `automatic`, so a plugin built against a different server version keeps working. Plugins that don't act on the value can still call `pluginkit.RegisterCallTypeFlag()` and discard the result, purely so `flag.Parse` accepts the flag — that's what the bundled `summarize_diff`, `security_check`, `style_guidelines` and `claude_review` plugins do.
 
 ## Writing a Plugin
 
@@ -148,6 +175,7 @@ To avoid unnecessary costs, you can mark a plugin as `OnlyOnDemand = true` in th
 - **Not run automatically** when a PR is fetched or updated
 - Receive a `"deferred"` status in the database
 - **Only execute when explicitly requested** via the RerunPlugins RPC method with their name in the plugin list
+- Always be invoked with `--call-type explicit`, since a deferred plugin has no automatic runs to distinguish a rerun from (see [Call Types](#call-types))
 
 This allows cost control while keeping expensive plugins available for on-demand use.
 
@@ -192,6 +220,8 @@ By default, plugins only run once per PR commit (SHA). To force plugins to rerun
 ```
 
 The rerun bypasses the SHA cache check, allowing you to reprocess the same PR commit with potentially updated plugin logic or external dependencies.
+
+Reruns are also visible to the plugin itself: a plugin invoked through `RerunPlugins` receives `--call-type rerun`, or `--call-type explicit` if it is deferred, instead of the `automatic` it gets from the server's own runs. See [Call Types](#call-types).
 
 ## Style Guidelines Plugin
 

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -13,6 +13,37 @@ import (
 
 const pluginTimeout = 5 * time.Minute
 
+// PluginCallType describes why a plugin is being executed. It is handed to the
+// plugin binary via the --call-type flag so a plugin can adapt its behaviour to
+// the situation - for instance skipping cached work on an automatic run but
+// redoing it from scratch when a reviewer asked for a rerun.
+type PluginCallType string
+
+const (
+	// PluginCallAutomatic is a run the server triggered on its own, when a PR
+	// was fetched or its head SHA changed.
+	PluginCallAutomatic PluginCallType = "automatic"
+	// PluginCallExplicit is a run of a deferred (OnlyOnDemand) plugin, which
+	// only ever executes because someone asked for it by name.
+	PluginCallExplicit PluginCallType = "explicit"
+	// PluginCallRerun is a requested rerun of a plugin that would otherwise
+	// have run automatically.
+	PluginCallRerun PluginCallType = "rerun"
+)
+
+// callTypeFor maps a plugin and the way RunPluginsForce was invoked onto the
+// call type reported to the plugin. Automatic runs never reach deferred
+// plugins, so a forced run of one is always an explicit request for it.
+func callTypeFor(plugin config.Plugin, force bool) PluginCallType {
+	if !force {
+		return PluginCallAutomatic
+	}
+	if plugin.OnlyOnDemand {
+		return PluginCallExplicit
+	}
+	return PluginCallRerun
+}
+
 // RunPlugins executes all configured plugins for a given PR.
 // It is intended to run asynchronously.
 // Plugins are only executed if the current SHA differs from the SHA for which they were last run.
@@ -53,18 +84,19 @@ func RunPluginsForce(owner, repo string, number int, sha string, diff string, co
 					slog.Error("Plugin runner panicked", "plugin", p.Name, "panic", r)
 				}
 			}()
-			executePluginForce(p, owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch, force)
+			executePlugin(p, owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch, callTypeFor(p, force))
 		}(plugin)
 	}
 
 	wg.Wait()
 }
 
-func executePlugin(plugin config.Plugin, owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string) {
-	executePluginForce(plugin, owner, repo, number, sha, diff, commentsJSON, metadataJSON, branch, false)
-}
+// executePlugin runs a single plugin binary and stores its result. callType
+// says why the run was triggered; anything other than PluginCallAutomatic
+// bypasses the per-SHA skip so a requested run always executes.
+func executePlugin(plugin config.Plugin, owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string, callType PluginCallType) {
+	force := callType != PluginCallAutomatic
 
-func executePluginForce(plugin config.Plugin, owner, repo string, number int, sha string, diff string, commentsJSON string, metadataJSON string, branch string, force bool) {
 	// Check if we need to rerun this plugin
 	storedSHA, err := config.C().DB.GetPluginResultSHA(owner, repo, number, plugin.Name)
 	if err != nil {
@@ -79,7 +111,7 @@ func executePluginForce(plugin config.Plugin, owner, repo string, number int, sh
 	}
 
 	if force {
-		slog.Info("Forcing plugin execution", "plugin", plugin.Name)
+		slog.Info("Forcing plugin execution", "plugin", plugin.Name, "call_type", callType)
 	}
 
 	// Set status to pending
@@ -93,6 +125,7 @@ func executePluginForce(plugin config.Plugin, owner, repo string, number int, sh
 		"--owner", owner,
 		"--repo", repo,
 		"--number", fmt.Sprintf("%d", number),
+		"--call-type", string(callType),
 	}
 
 	if plugin.IncludeDiff {
@@ -121,14 +154,14 @@ func executePluginForce(plugin config.Plugin, owner, repo string, number int, sh
 		slog.Warn("Plugin stderr", "plugin", plugin.Name, "stderr", stderrBuf.String())
 	}
 	if err != nil {
-		slog.Error("Plugin execution failed", "plugin", plugin.Name, "error", err, "stderr", stderrBuf.String())
+		slog.Error("Plugin execution failed", "plugin", plugin.Name, "error", err, "call_type", callType, "stderr", stderrBuf.String())
 		if upsertErr := config.C().DB.UpsertPluginResult(owner, repo, number, plugin.Name, fmt.Sprintf("Error: %v\nStderr: %s\nStdout: %s", err, stderrBuf.String(), resultStr), "error", sha); upsertErr != nil {
 			slog.Error("Failed to store plugin error result", "plugin", plugin.Name, "error", upsertErr)
 		}
 		return
 	}
 
-	slog.Info("Plugin executed", "plugin", plugin.Name, "result_len", len(resultStr), "sha", sha)
+	slog.Info("Plugin executed", "plugin", plugin.Name, "result_len", len(resultStr), "sha", sha, "call_type", callType)
 
 	// Store result
 	err = config.C().DB.UpsertPluginResult(owner, repo, number, plugin.Name, resultStr, "success", sha)

--- a/server/plugins_test.go
+++ b/server/plugins_test.go
@@ -5,6 +5,7 @@ import (
 	"crs/database"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -111,6 +112,100 @@ func TestRunPluginsForce_EmptyListSkipsOnDemandPlugins(t *testing.T) {
 	}
 	if _, err := os.Stat(onDemandMarker); err == nil {
 		t.Error("expected on-demand plugin to be skipped on empty rerun, but it ran")
+	}
+}
+
+func TestCallTypeFor(t *testing.T) {
+	tests := []struct {
+		name   string
+		plugin config.Plugin
+		force  bool
+		want   PluginCallType
+	}{
+		{"normal plugin, unforced", config.Plugin{Name: "p"}, false, PluginCallAutomatic},
+		{"normal plugin, forced", config.Plugin{Name: "p"}, true, PluginCallRerun},
+		{"deferred plugin, forced", config.Plugin{Name: "p", OnlyOnDemand: true}, true, PluginCallExplicit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := callTypeFor(tt.plugin, tt.force); got != tt.want {
+				t.Errorf("callTypeFor() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// argRecorderScript writes a plugin invocation's arguments to argsPath so a
+// test can assert on the flags the server passed.
+func argRecorderScript(t *testing.T, dir, name, argsPath string) string {
+	t.Helper()
+	script := filepath.Join(dir, name)
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$@\" > "+argsPath+"\n"), 0755); err != nil {
+		t.Fatalf("failed to write plugin script: %v", err)
+	}
+	return script
+}
+
+func recordedArgs(t *testing.T, argsPath string) string {
+	t.Helper()
+	got, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("plugin did not record its arguments: %v", err)
+	}
+	return string(got)
+}
+
+func TestRunPlugins_PassesAutomaticCallType(t *testing.T) {
+	db := setupTestDB(t)
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := argRecorderScript(t, dir, "normal.sh", argsPath)
+
+	config.SetC(config.Config{
+		DB:      db,
+		Plugins: []config.Plugin{{Name: "normal-plugin", Command: script}},
+	})
+
+	RunPlugins("owner", "repo", 1, "sha123", "", "", "", "main")
+
+	if args := recordedArgs(t, argsPath); !strings.Contains(args, "--call-type automatic") {
+		t.Errorf("expected --call-type automatic in plugin args, got %q", args)
+	}
+}
+
+func TestRunPluginsForce_PassesRerunCallType(t *testing.T) {
+	db := setupTestDB(t)
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := argRecorderScript(t, dir, "normal.sh", argsPath)
+
+	config.SetC(config.Config{
+		DB:      db,
+		Plugins: []config.Plugin{{Name: "normal-plugin", Command: script}},
+	})
+
+	RunPluginsForce("owner", "repo", 1, "sha123", "", "", "", "main", true, []string{"normal-plugin"})
+
+	if args := recordedArgs(t, argsPath); !strings.Contains(args, "--call-type rerun") {
+		t.Errorf("expected --call-type rerun in plugin args, got %q", args)
+	}
+}
+
+func TestRunPluginsForce_PassesExplicitCallTypeForDeferredPlugin(t *testing.T) {
+	db := setupTestDB(t)
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := argRecorderScript(t, dir, "ondemand.sh", argsPath)
+
+	config.SetC(config.Config{
+		DB:      db,
+		Plugins: []config.Plugin{{Name: "expensive-plugin", Command: script, OnlyOnDemand: true}},
+	})
+
+	RunPluginsForce("owner", "repo", 1, "sha123", "", "", "", "feature-branch", true, []string{"expensive-plugin"})
+
+	if args := recordedArgs(t, argsPath); !strings.Contains(args, "--call-type explicit") {
+		t.Errorf("expected --call-type explicit in plugin args, got %q", args)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -247,7 +247,7 @@ func (h *RPCHandler) fetchPR(owner, repo string, number int, skipCache bool) (*P
 // hookDispatchTTL is how long a (PR, head SHA) pair is considered recently
 // dispatched. Within this window repeated reads of the same PR revision skip
 // re-dispatching the post-update hooks entirely; the per-plugin SHA check in
-// executePluginForce remains the durable guard against duplicate work.
+// executePlugin remains the durable guard against duplicate work.
 const hookDispatchTTL = time.Minute
 
 var recentHookDispatches sync.Map // "owner/repo#number@sha" -> time.Time


### PR DESCRIPTION
Plugins had no way to tell why they were running. A run triggered by the
server when a PR's head SHA changed looked identical to one a reviewer
asked for through RerunPlugins, so a plugin couldn't spend more effort on
a requested run or drop cached state that an automatic run would reuse.

Every plugin invocation now carries --call-type alongside --owner,
--repo and --number:

  automatic  the server triggered the run itself
  explicit   a deferred (OnlyOnDemand) plugin was requested by name
  rerun      a normally-automatic plugin was rerun via RerunPlugins

executePluginForce takes the call type in place of its force bool, since
force is just "not automatic", and the dead unforced executePlugin
wrapper collapses into it.

pluginkit gains CallType, ParseCallType and RegisterCallTypeFlag so Go
plugins can declare the flag and read the value in two lines.
ParseCallType maps unknown values to automatic so a plugin built against
a different server version keeps working.

The flag is unconditional, so plugins that reject unknown flags must
declare it. The bundled summarize_diff, security_check, style_guidelines
and claude_review plugins accept and ignore it; example_plugin prints it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DaJq59zajzkpKcPz9YBxzo