### PR TITLE
Reprocess a PR through its repo's workflows after a review

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -393,6 +393,12 @@ Submits a review to GitHub. This will:
 2. Submit reply comments individually to maintain threading
 3. Submit top-level comments as part of a GitHub review
 4. Delete all local comments after successful submission
+5. Re-evaluate the PR against every workflow that targets its repo, updating the
+   PR's membership in those workflows' sections immediately rather than at the
+   next workflow cycle. A PR that no longer matches a section's filters (e.g. a
+   "needs review" section, now that the review request is gone) drops out of it;
+   one that now matches a section it wasn't in is added. Reprocessing failures
+   are logged, not returned — the review itself has already been submitted.
 
 **Arguments** (`SubmitReviewArgs`):
 | Field    | Type   | Required | Description                                              |

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -16,6 +16,13 @@ The review environment is fully functional. You can:
 - **Add Comments**: Start a review, add pending comments, and submit them all at once.
 - **Reply to Threads**: Engage in discussions directly from the interface.
 
+### Sections Update As Soon As You Submit
+Submitting a review re-runs that pull request through the filters of every
+workflow that targets its repository, so the dashboard reflects the review
+right away instead of at the next background cycle. A PR drops out of a
+"needs review" section the moment its filters stop matching, and appears in
+any section whose filters now match it.
+
 ![Bun Review Interface](img/bun-review-1.png)
 ![Bun Review File Tree](img/bun-review-filetree.png)
 

--- a/server/server.go
+++ b/server/server.go
@@ -566,12 +566,15 @@ func (h *RPCHandler) SubmitReview(args *SubmitReviewArgs, reply *SubmitReviewRep
 		slog.Error("Error deleting local comments after submission", "error", err)
 	}
 
-	// 5. Remove the item from all sections in the database
-	// The identifier is constructed as RepoName + PRNumber (matching PRToOrgBridge.Identifier)
-	identifier := fmt.Sprintf("%s%d", args.Repo, args.Number)
-	err = config.C().DB.DeleteItemByIdentifier(identifier)
-	if err != nil {
-		slog.Error("Error removing item from sections after review", "identifier", identifier, "error", err)
+	// 5. Re-run the PR through the workflows that target its repo so the
+	// dashboard reflects the review immediately instead of at the next cycle.
+	// Every targeting workflow is consulted, not just the ones holding the PR:
+	// a review can move a PR into a section ("waiting on author") as easily as
+	// out of one ("needs review"). Failures are logged rather than returned —
+	// the review itself already succeeded, and the next cycle re-syncs anyway.
+	if err := workflows.ReprocessPR(args.Owner, args.Repo, args.Number); err != nil {
+		slog.Error("Error reprocessing PR through workflows after review",
+			"owner", args.Owner, "repo", args.Repo, "pr", args.Number, "error", err)
 	}
 
 	details, content, err := h.fetchPR(args.Owner, args.Repo, args.Number, true)

--- a/workflows/reprocess.go
+++ b/workflows/reprocess.go
@@ -1,0 +1,331 @@
+package workflows
+
+// Reprocessing one PR, outside the background cycle.
+//
+// Submitting a review changes the answers the section filters give for that PR
+// — the review request GitHub was tracking is gone, my latest review is no
+// longer DISMISSED, the ball is now in the author's court — but nothing in the
+// dashboard reflects that until the next workflow cycle, up to ten minutes
+// later. ReprocessPR closes that gap for a single PR by re-asking every
+// workflow that draws from the PR's repo whether the PR still belongs in its
+// section, and writing the answer through the same DB path a cycle uses.
+//
+// Every workflow targeting the repo is consulted, not just the ones that
+// currently hold the PR: a filter can just as easily start matching after a
+// review (a "waiting on author" section) as stop matching (a "needs review"
+// section), and a section the PR has never been in has no way to notice it
+// otherwise.
+//
+// What this deliberately does NOT do is re-run the workflows. A workflow's Run
+// treats its PR list as the complete contents of its section and emits a Delete
+// for every item not in that list, so handing it a one-PR slice would empty the
+// section. Membership for the single PR is decided by MatchesPR instead, and
+// only that PR's row is touched.
+
+import (
+	"crs/config"
+	"crs/database"
+	"crs/git_tools"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// reprocessItemTTL matches the TTL ProcessPRsDB stamps on items during a normal
+// cycle, so an item written by a reprocess expires on the same schedule as one
+// written by the background manager.
+const reprocessItemTTL = 2 * time.Hour
+
+// RepoTargeter is implemented by workflows that can say which repos they draw
+// PRs from. It answers "which sections could this PR possibly belong to" without
+// running the workflow.
+type RepoTargeter interface {
+	TargetsRepo(owner, repo string) bool
+}
+
+// SinglePRMatcher is implemented by workflows that can decide membership for one
+// PR without re-fetching their whole PR set.
+//
+// ownedByWorkflow reports whether the workflow already claims this PR in its
+// section. It matters for workflows whose PR set comes from somewhere other than
+// the PR's own attributes (ProjectListWorkflow gets its PR numbers from a Jira
+// epic): for those, the existing item is the only record of membership we have
+// here, so they can drop a PR that no longer passes their filters but must never
+// adopt one they were never given.
+type SinglePRMatcher interface {
+	MatchesPR(pr *github.PullRequest, ownedByWorkflow bool) bool
+}
+
+// ReprocessPR re-evaluates a single PR against every configured workflow that
+// targets its repo and syncs the PR's membership in each of those workflows'
+// sections. Call it after an action that changes how the filters see a PR —
+// submitting a review, most notably.
+//
+// It fetches the PR and its auxiliary data fresh: the whole point is to judge
+// the PR by its post-action state, and the caches still hold the pre-action one.
+func ReprocessPR(owner, repo string, number int) error {
+	cfg := config.C()
+	targets := WorkflowsTargetingRepo(MatchWorkflows(cfg.RawWorkflows, &cfg.Repos, cfg.JiraDomain), owner, repo)
+	if len(targets) == 0 {
+		slog.Debug("No workflows target this repo, nothing to reprocess",
+			"owner", owner, "repo", repo, "pr", number)
+		return nil
+	}
+
+	client := git_tools.GetGithubClient()
+	prs, err := git_tools.GetSpecificPRs(client, owner, repo, []int{number})
+	if err != nil {
+		return fmt.Errorf("fetching PR %s/%s#%d for reprocess: %w", owner, repo, number, err)
+	}
+	if len(prs) == 0 || prs[0] == nil {
+		return fmt.Errorf("PR %s/%s#%d not found", owner, repo, number)
+	}
+
+	names := make([]string, 0, len(targets))
+	for _, wf := range targets {
+		names = append(names, wf.GetName())
+	}
+	// Refreshes the DB caches as a side effect, so the PR the user is still
+	// looking at reads back its new review state rather than a cache miss.
+	prefetchAuxDataForPRs(client, strings.Join(names, ","), owner, repo, prs,
+		reprocessAuxRequirements(targets, owner, repo))
+
+	applyReprocessedPR(config.C().DB, targets, prs[0])
+	return nil
+}
+
+// WorkflowsTargetingRepo returns the workflows that draw PRs from owner/repo.
+// Workflows that can't report their repos are skipped: without that answer we
+// would have to run them to find out, which is exactly what reprocessing avoids.
+func WorkflowsTargetingRepo(wfs []Workflow, owner, repo string) []Workflow {
+	targets := []Workflow{}
+	for _, wf := range wfs {
+		targeter, ok := wf.(RepoTargeter)
+		if !ok {
+			slog.Warn("Workflow cannot report its repos; skipping it during reprocess",
+				"workflow", wf.GetName())
+			continue
+		}
+		if targeter.TargetsRepo(owner, repo) {
+			targets = append(targets, wf)
+		}
+	}
+	return targets
+}
+
+// applyReprocessedPR decides, for each workflow, whether pr belongs in that
+// workflow's section and writes the difference: an upsert when it belongs, a
+// release of this workflow's ownership when it does not. Items left with no
+// owners are pruned, which is what actually clears a PR out of a section.
+func applyReprocessedPR(db *database.DB, wfs []Workflow, pr *github.PullRequest) {
+	if db == nil || pr == nil {
+		return
+	}
+	identifier := PRToOrgBridge{PR: pr}.Identifier()
+	ttl := time.Now().Add(reprocessItemTTL).Unix()
+
+	changes := []FileChanges{}
+	for _, wf := range wfs {
+		matcher, ok := wf.(SinglePRMatcher)
+		if !ok {
+			slog.Warn("Workflow cannot evaluate a single PR; skipping it during reprocess",
+				"workflow", wf.GetName())
+			continue
+		}
+
+		sectionName := wf.GetOrgSectionName()
+		section, err := db.GetOrCreateSection(sectionName, config.C().SectionPriority[sectionName])
+		if err != nil {
+			slog.Error("Error getting section during reprocess",
+				"section", sectionName, "workflow", wf.GetName(), "error", err)
+			continue
+		}
+
+		item, err := db.GetItem(section.ID, identifier)
+		owned := err == nil && item != nil && slices.Contains(item.GetWorkflows(), wf.GetName())
+
+		if matcher.MatchesPR(pr, owned) {
+			change := SyncTODOToSectionDB(db, wf.GetName(), pr, section, workflowIncludesDiff(wf))
+			change.TTL = ttl
+			change.NotifyOnAdd = workflowShouldNotify(wf)
+			changes = append(changes, change)
+			continue
+		}
+
+		if !owned {
+			continue
+		}
+		// Mirrors the cycle's Delete: ownership is released here and the row is
+		// removed by the prune below only if no other workflow still claims it.
+		// Details and tags are omitted because nothing on the Delete path reads
+		// them.
+		changes = append(changes, FileChanges{
+			ChangeType:   "Delete",
+			Identifier:   identifier,
+			Status:       item.Status,
+			Title:        item.Title,
+			SectionID:    section.ID,
+			SectionName:  section.SectionName,
+			TTL:          0,
+			WorkflowName: wf.GetName(),
+		})
+	}
+
+	applyReprocessChanges(changes)
+	pruneOrphanedItems()
+}
+
+// applyReprocessChanges runs the changes through the same ApplyChanges consumer
+// the background cycle uses, so item writes, worktree handling, and the workflow
+// action log all behave identically to a cycle.
+func applyReprocessChanges(changes []FileChanges) {
+	pending := make([]FileChanges, 0, len(changes))
+	for _, change := range changes {
+		if change.ChangeType == "No Change" {
+			continue
+		}
+		change.Report()
+		pending = append(pending, change)
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	serialized := make(chan SerializedFileChange)
+	var wg sync.WaitGroup
+	go ApplyChanges(serialized, &wg)
+	for i := range pending {
+		var lines []string
+		if pending[i].ChangeType != "Delete" {
+			lines = pending[i].GetLines(2)
+		}
+		wg.Add(1)
+		serialized <- SerializedFileChange{FileChange: &pending[i], Lines: lines}
+	}
+	close(serialized)
+	wg.Wait()
+}
+
+// reprocessAuxRequirements is the union of what the targeted workflows' filters
+// need, plus comments and reviews unconditionally. Reviews are the data the
+// reprocess exists to act on — the identity filters read them out of the aux
+// store and the section display summarizes them — and comments come along
+// because Details() would otherwise fetch them one PR at a time anyway.
+func reprocessAuxRequirements(wfs []Workflow, owner, repo string) AuxDataRequirement {
+	req := AuxDataRequirement{Comments: true, Reviews: true}
+	for _, wf := range wfs {
+		for _, prReq := range wf.GetPRRequirements() {
+			if !strings.EqualFold(prReq.Owner, owner) || !strings.EqualFold(prReq.Repo, repo) {
+				continue
+			}
+			req = mergeAuxRequirements(req, prReq.AuxData)
+		}
+		if srw, ok := wf.(SyncReviewRequestsWorkflow); ok {
+			// Fetched for survivors only during a cycle; here there is exactly
+			// one candidate, so the distinction costs nothing.
+			req = mergeAuxRequirements(req, srw.PostFilterAux)
+		}
+		if workflowIncludesDiff(wf) {
+			req.Diff = true
+		}
+	}
+	return req
+}
+
+func mergeAuxRequirements(a, b AuxDataRequirement) AuxDataRequirement {
+	return AuxDataRequirement{
+		Comments: a.Comments || b.Comments,
+		CIStatus: a.CIStatus || b.CIStatus,
+		Diff:     a.Diff || b.Diff,
+		Reviews:  a.Reviews || b.Reviews,
+		Commits:  a.Commits || b.Commits,
+	}
+}
+
+func workflowIncludesDiff(wf Workflow) bool {
+	switch w := wf.(type) {
+	case SyncReviewRequestsWorkflow:
+		return w.IncludeDiff
+	case ProjectListWorkflow:
+		return w.IncludeDiff
+	}
+	return false
+}
+
+func workflowShouldNotify(wf Workflow) bool {
+	switch w := wf.(type) {
+	case SyncReviewRequestsWorkflow:
+		return w.ShouldNotify()
+	case ProjectListWorkflow:
+		return w.ShouldNotify()
+	}
+	return false
+}
+
+// repoEntriesInclude reports whether any configured repo entry names owner/repo.
+// defaultOwner covers the deprecated single-repo config shape, where the entry
+// is a bare repo name and the owner lives in a separate field.
+func repoEntriesInclude(entries []string, defaultOwner, owner, repo string) bool {
+	for _, entry := range entries {
+		entryOwner, entryRepo, err := git_tools.ParseRepoName(strings.TrimSpace(entry))
+		if err != nil {
+			entryOwner, entryRepo = defaultOwner, strings.TrimSpace(entry)
+		}
+		if entryOwner == "" || entryRepo == "" {
+			continue
+		}
+		if strings.EqualFold(entryOwner, owner) && strings.EqualFold(entryRepo, repo) {
+			return true
+		}
+	}
+	return false
+}
+
+// TargetsRepo reports whether this workflow fetches PRs from owner/repo.
+func (w SyncReviewRequestsWorkflow) TargetsRepo(owner, repo string) bool {
+	return repoEntriesInclude(w.Repos, w.Owner, owner, repo)
+}
+
+// MatchesPR reports whether pr belongs in this workflow's section right now.
+// The workflow's PR set is "every PR of my repos in my state", so membership is
+// exactly: right state, survives the filters. Whether the workflow already owns
+// the PR is irrelevant — that is the point of reprocessing every targeting
+// workflow rather than only the ones currently holding the PR.
+func (w SyncReviewRequestsWorkflow) MatchesPR(pr *github.PullRequest, _ bool) bool {
+	if pr == nil {
+		return false
+	}
+	state := w.PRState
+	if state == "" {
+		state = "open"
+	}
+	if state != "all" && !strings.EqualFold(pr.GetState(), state) {
+		return false
+	}
+	return len(git_tools.ApplyPRFilters([]*github.PullRequest{pr}, w.Filters)) > 0
+}
+
+// TargetsRepo reports whether this workflow can draw PRs from owner/repo.
+func (w ProjectListWorkflow) TargetsRepo(owner, repo string) bool {
+	return repoEntriesInclude(w.Repos, "", owner, repo)
+}
+
+// MatchesPR reports whether pr belongs in this workflow's section right now.
+//
+// Membership in a project list is decided by the Jira epic, not by anything on
+// the PR, and resolving the epic is the slow lookup this path exists to avoid.
+// So a reprocess can only ever narrow the section: a PR the workflow already
+// holds is kept while it still passes the filters and dropped when it stops,
+// and a PR the workflow does not hold is left alone for the next cycle's Jira
+// lookup to add.
+func (w ProjectListWorkflow) MatchesPR(pr *github.PullRequest, ownedByWorkflow bool) bool {
+	if pr == nil || !ownedByWorkflow {
+		return false
+	}
+	return len(git_tools.ApplyPRFilters([]*github.PullRequest{pr}, w.Filters)) > 0
+}

--- a/workflows/reprocess_test.go
+++ b/workflows/reprocess_test.go
@@ -1,0 +1,310 @@
+package workflows
+
+import (
+	"crs/config"
+	"crs/database"
+	"crs/git_tools"
+	"testing"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// reprocessTestPR builds an open, non-draft PR with every field Details()
+// dereferences, so section writes during a reprocess don't panic.
+func reprocessTestPR(owner, repo string, number int) *github.PullRequest {
+	return &github.PullRequest{
+		Number: github.Int(number),
+		State:  github.String("open"),
+		Draft:  github.Bool(false),
+		Title:  github.String("Add a thing"),
+		Body:   github.String("body"),
+		User:   &github.User{Login: github.String("author")},
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				FullName: github.String(owner + "/" + repo),
+				Name:     github.String(repo),
+				Owner:    &github.User{Login: github.String(owner)},
+			},
+			SHA: github.String("base-sha"),
+		},
+		Head: &github.PullRequestBranch{
+			Label: github.String("author:feature"),
+			SHA:   github.String("head-sha"),
+			Repo:  &github.Repository{Name: github.String(repo)},
+		},
+	}
+}
+
+// seedReprocessAuxData puts empty-but-present aux data in the global store so
+// Details() takes its cached branches instead of calling GitHub.
+func seedReprocessAuxData(t *testing.T, owner, repo string, number int) {
+	t.Helper()
+	store := NewAuxDataStore()
+	store.Set(PRKey{Owner: owner, Repo: repo, Number: number}, &PRAuxData{
+		Comments: []*github.PullRequestComment{},
+		CIStatus: &git_tools.CIStatusInfo{},
+		Reviews:  []*github.PullRequestReview{},
+		HeadSHA:  "head-sha",
+	})
+	SetCurrentAuxDataStore(store)
+	t.Cleanup(func() { SetCurrentAuxDataStore(nil) })
+}
+
+func matchAllFilter(prs []*github.PullRequest) []*github.PullRequest {
+	return prs
+}
+
+func matchNoneFilter([]*github.PullRequest) []*github.PullRequest {
+	return []*github.PullRequest{}
+}
+
+func seedItem(t *testing.T, db *database.DB, sectionName, identifier, workflowName string) *database.Section {
+	t.Helper()
+	section, err := db.GetOrCreateSection(sectionName, 0)
+	if err != nil {
+		t.Fatalf("GetOrCreateSection(%q): %v", sectionName, err)
+	}
+	if _, err := db.UpsertItemWithWorkflow(section.ID, identifier, "TODO", "Add a thing",
+		[]string{"detail"}, []string{"tag"}, 0, workflowName); err != nil {
+		t.Fatalf("UpsertItemWithWorkflow: %v", err)
+	}
+	return section
+}
+
+func itemInSection(t *testing.T, db *database.DB, sectionName, identifier string) *database.Item {
+	t.Helper()
+	section, err := db.GetSection(sectionName)
+	if err != nil {
+		return nil
+	}
+	item, err := db.GetItem(section.ID, identifier)
+	if err != nil {
+		return nil
+	}
+	return item
+}
+
+// A review makes the "needs review" filters stop matching and can make another
+// section's filters start matching. Both have to land in the same pass: the PR
+// leaves the section it no longer belongs to, and joins the one it now does —
+// even though no workflow held it there before.
+func TestApplyReprocessedPRMovesPRBetweenSections(t *testing.T) {
+	const (
+		owner      = "C-hipple"
+		repo       = "code-review-server"
+		number     = 211
+		identifier = owner + "/" + repo + "-211"
+	)
+	db := warmTestDB(t)
+	config.SetC(config.Config{DB: db})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+	seedReprocessAuxData(t, owner, repo, number)
+
+	needsReview := SyncReviewRequestsWorkflow{
+		Name:         "needs_review",
+		Repos:        []string{owner + "/" + repo},
+		Filters:      []git_tools.PRFilter{matchNoneFilter},
+		SectionTitle: "Needs Review",
+	}
+	waitingOnAuthor := SyncReviewRequestsWorkflow{
+		Name:         "waiting_on_author",
+		Repos:        []string{owner + "/" + repo},
+		Filters:      []git_tools.PRFilter{matchAllFilter},
+		SectionTitle: "Waiting on Author",
+	}
+
+	// Before the review: the PR sits in Needs Review only.
+	seedItem(t, db, needsReview.SectionTitle, identifier, needsReview.Name)
+
+	applyReprocessedPR(db, []Workflow{needsReview, waitingOnAuthor}, reprocessTestPR(owner, repo, number))
+
+	if item := itemInSection(t, db, needsReview.SectionTitle, identifier); item != nil {
+		t.Errorf("PR still in %q after its filters stopped matching (workflows: %v)",
+			needsReview.SectionTitle, item.GetWorkflows())
+	}
+	item := itemInSection(t, db, waitingOnAuthor.SectionTitle, identifier)
+	if item == nil {
+		t.Fatalf("PR was not added to %q by the workflow whose filters now match", waitingOnAuthor.SectionTitle)
+	}
+	if got := item.GetWorkflows(); len(got) != 1 || got[0] != waitingOnAuthor.Name {
+		t.Errorf("item workflows = %v, want [%s]", got, waitingOnAuthor.Name)
+	}
+}
+
+// Dropping out of one workflow must not evict the row while another workflow
+// still claims it — ownership is per workflow, and the prune only removes rows
+// with no owners left.
+func TestApplyReprocessedPRKeepsItemClaimedByAnotherWorkflow(t *testing.T) {
+	const (
+		owner      = "C-hipple"
+		repo       = "code-review-server"
+		number     = 211
+		identifier = owner + "/" + repo + "-211"
+		section    = "Shared Section"
+	)
+	db := warmTestDB(t)
+	config.SetC(config.Config{DB: db})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+	seedReprocessAuxData(t, owner, repo, number)
+
+	dropping := SyncReviewRequestsWorkflow{
+		Name:         "dropping",
+		Repos:        []string{owner + "/" + repo},
+		Filters:      []git_tools.PRFilter{matchNoneFilter},
+		SectionTitle: section,
+	}
+	seedItem(t, db, section, identifier, dropping.Name)
+	seedItem(t, db, section, identifier, "other_workflow")
+
+	applyReprocessedPR(db, []Workflow{dropping}, reprocessTestPR(owner, repo, number))
+
+	item := itemInSection(t, db, section, identifier)
+	if item == nil {
+		t.Fatal("item was pruned even though another workflow still claims it")
+	}
+	if got := item.GetWorkflows(); len(got) != 1 || got[0] != "other_workflow" {
+		t.Errorf("item workflows = %v, want [other_workflow]", got)
+	}
+}
+
+// A workflow whose PRs come from Jira can narrow its section on a reprocess but
+// must not adopt a PR the epic never listed.
+func TestApplyReprocessedPRLeavesProjectListAdditionsToTheCycle(t *testing.T) {
+	const (
+		owner      = "C-hipple"
+		repo       = "code-review-server"
+		number     = 211
+		identifier = owner + "/" + repo + "-211"
+	)
+	db := warmTestDB(t)
+	config.SetC(config.Config{DB: db})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+	seedReprocessAuxData(t, owner, repo, number)
+
+	project := ProjectListWorkflow{
+		Name:         "project",
+		Repos:        []string{owner + "/" + repo},
+		Filters:      []git_tools.PRFilter{matchAllFilter},
+		SectionTitle: "Project",
+		JiraEpic:     "ABC-1",
+	}
+
+	applyReprocessedPR(db, []Workflow{project}, reprocessTestPR(owner, repo, number))
+
+	if item := itemInSection(t, db, project.SectionTitle, identifier); item != nil {
+		t.Fatal("project list section adopted a PR that the Jira epic never listed")
+	}
+
+	// Once the epic has put it there, a reprocess keeps it while the filters
+	// still match and drops it when they stop.
+	seedItem(t, db, project.SectionTitle, identifier, project.Name)
+	applyReprocessedPR(db, []Workflow{project}, reprocessTestPR(owner, repo, number))
+	if itemInSection(t, db, project.SectionTitle, identifier) == nil {
+		t.Fatal("project list dropped a PR that still passes its filters")
+	}
+
+	project.Filters = []git_tools.PRFilter{matchNoneFilter}
+	applyReprocessedPR(db, []Workflow{project}, reprocessTestPR(owner, repo, number))
+	if itemInSection(t, db, project.SectionTitle, identifier) != nil {
+		t.Fatal("project list kept a PR that no longer passes its filters")
+	}
+}
+
+func TestWorkflowsTargetingRepo(t *testing.T) {
+	sync := SyncReviewRequestsWorkflow{
+		Name:  "sync",
+		Repos: []string{"C-hipple/code-review-server", "multimediallc/chaturbate"},
+	}
+	// The deprecated single-repo shape stores a bare repo name plus a separate
+	// owner; it targets the same repo as the "owner/repo" form.
+	legacy := SyncReviewRequestsWorkflow{
+		Name:  "legacy",
+		Owner: "C-hipple",
+		Repos: []string{"code-review-server"},
+	}
+	project := ProjectListWorkflow{
+		Name:  "project",
+		Repos: []string{"multimediallc/chaturbate"},
+	}
+	all := []Workflow{sync, legacy, project}
+
+	cases := []struct {
+		owner, repo string
+		want        []string
+	}{
+		// Repo names are compared case-insensitively: the owner casing a user
+		// types into the client rarely matches the config exactly.
+		{"C-hipple", "code-review-server", []string{"sync", "legacy"}},
+		{"c-hipple", "Code-Review-Server", []string{"sync", "legacy"}},
+		{"multimediallc", "chaturbate", []string{"sync", "project"}},
+		{"C-hipple", "gtdbot", nil},
+	}
+
+	for _, c := range cases {
+		got := []string{}
+		for _, wf := range WorkflowsTargetingRepo(all, c.owner, c.repo) {
+			got = append(got, wf.GetName())
+		}
+		if len(got) != len(c.want) {
+			t.Errorf("WorkflowsTargetingRepo(%s/%s) = %v, want %v", c.owner, c.repo, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("WorkflowsTargetingRepo(%s/%s) = %v, want %v", c.owner, c.repo, got, c.want)
+				break
+			}
+		}
+	}
+}
+
+func TestSyncWorkflowMatchesPRState(t *testing.T) {
+	pr := reprocessTestPR("C-hipple", "code-review-server", 211)
+	closed := reprocessTestPR("C-hipple", "code-review-server", 212)
+	closed.State = github.String("closed")
+
+	open := SyncReviewRequestsWorkflow{Filters: []git_tools.PRFilter{matchAllFilter}}
+	if !open.MatchesPR(pr, false) {
+		t.Error("open workflow should match an open PR that passes its filters")
+	}
+	if open.MatchesPR(closed, true) {
+		t.Error("open workflow should not match a closed PR, even one it already owns")
+	}
+
+	all := SyncReviewRequestsWorkflow{PRState: "all", Filters: []git_tools.PRFilter{matchAllFilter}}
+	if !all.MatchesPR(closed, false) {
+		t.Error(`PRState "all" should match a closed PR`)
+	}
+
+	filtered := SyncReviewRequestsWorkflow{Filters: []git_tools.PRFilter{matchNoneFilter}}
+	if filtered.MatchesPR(pr, true) {
+		t.Error("a PR its filters reject should not match, even one the workflow already owns")
+	}
+}
+
+func TestReprocessAuxRequirementsUnionsWorkflowNeeds(t *testing.T) {
+	const owner, repo = "C-hipple", "code-review-server"
+	ci := SyncReviewRequestsWorkflow{
+		Name:       "ci",
+		Repos:      []string{owner + "/" + repo},
+		AuxDataReq: AuxDataRequirement{CIStatus: true},
+	}
+	interaction := SyncReviewRequestsWorkflow{
+		Name:          "interaction",
+		Repos:         []string{owner + "/" + repo},
+		PostFilterAux: AuxDataRequirement{Commits: true},
+		IncludeDiff:   true,
+	}
+	// A workflow on some other repo contributes nothing.
+	elsewhere := SyncReviewRequestsWorkflow{
+		Name:       "elsewhere",
+		Repos:      []string{"multimediallc/chaturbate"},
+		AuxDataReq: AuxDataRequirement{Comments: true},
+	}
+
+	got := reprocessAuxRequirements([]Workflow{ci, interaction, elsewhere}, owner, repo)
+	want := AuxDataRequirement{Comments: true, Reviews: true, CIStatus: true, Diff: true, Commits: true}
+	if got != want {
+		t.Errorf("reprocessAuxRequirements = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
Submitting a review changes what the section filters say about a PR — the
review request is gone, my latest review is no longer DISMISSED — but the
dashboard didn't reflect that until the next workflow cycle, up to ten
minutes later. SubmitReview tried to paper over this by deleting the item
outright, using an identifier ("repo211") that no item has ever had, so it
deleted nothing.

Replace it with workflows.ReprocessPR: fetch the PR and its aux data fresh,
then ask every workflow that targets the PR's repo whether the PR belongs in
its section now. Every targeting workflow is consulted, not only the ones
currently holding the PR, so a filter that starts matching after a review
(a "waiting on author" section) adds the PR just as a filter that stops
matching drops it.

Membership for a single PR is decided by a new MatchesPR rather than by
re-running the workflow: Run treats its PR list as the whole section and
would emit a Delete for every other item, emptying it. Writes go through the
cycle's own ApplyChanges path, so ownership release, pruning, worktrees, and
the workflow action log all behave identically. ProjectListWorkflow can only
narrow its section on a reprocess — its membership comes from a Jira epic,
not from the PR — leaving additions to the next cycle's lookup.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WT69q1w4tWF8rfFkkQkB5a