### PR TITLE
Don't block opening a review on background analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,11 @@ RPC handlers serve data to clients (web UI, Emacs).
 
 1. **Workflow fetch**: GitHub API → filter PRs → `ProcessPRsDB` upserts into `sections`/`items` tables
 2. **Aux data fetch**: `fetchAuxDataForPR` (manager.go) fetches reviews/commits/CI and persists to DB caches, recording each write in `WorkflowActionLog` (workflow name, head SHA, fields written)
-3. **Client request**: RPC `GetPR` → `GetPRDetails` (renderer.go) → checks DB caches → falls back to GitHub API
-4. **Rendering**: `OrgRenderer` reads sections/items from DB, sorts by priority, returns org-mode or JSON
+3. **Post-update hooks**: for each PR the cycle added or re-fetched after a push, `notifyPRsUpdated` (manager.go) calls the hook registered via `workflows.SetPRUpdatedHook` — `server.WarmPRAnalysis` in server mode — which runs the plugins and the LLM diff analysis in the background so they're cached before anyone opens the review
+4. **Client request**: RPC `GetPR` → `GetPRDetails` (renderer.go) → checks DB caches → falls back to GitHub API
+5. **Rendering**: `OrgRenderer` reads sections/items from DB, sorts by priority, returns org-mode or JSON
+
+Nothing on the read path waits for a plugin or an LLM call: `ensurePostUpdateHooks` dispatches them in goroutines, and `orderDiffFiles` uses the cached LLM ordering or falls back to `sortFilesTestsLast`. The workflow layer cannot import `server` (`server` imports `workflows`), which is why step 3 goes through a registered callback wired up in `main.go`.
 
 ## Cache Key Convention
 

--- a/llm/call_log_test.go
+++ b/llm/call_log_test.go
@@ -62,7 +62,7 @@ func TestCallLogMissingAPIKey(t *testing.T) {
 	t.Cleanup(func() { config.SetC(config.Config{}) })
 
 	files := []*utils.DiffFile{{NewName: "main.go"}, {NewName: "helper.go"}}
-	EnsureDiffAnalysis(files, "code-review-server", 42, "sha-42")
+	EnsureDiffAnalysis(files, "code-review-server", 42, "sha-42", TriggerPostUpdateHook)
 
 	log := readCallLog(t, crsHome)
 	for _, want := range []string{
@@ -96,7 +96,7 @@ func TestCallLogPartialParseKeepsOrderingAndLogsProblem(t *testing.T) {
 	useFakeClient(t, &fakeClient{text: "helper.go\nmain.go\n"}, nil)
 
 	files := []*utils.DiffFile{{NewName: "main.go"}, {NewName: "helper.go"}}
-	EnsureDiffAnalysis(files, "code-review-server", 7, "sha-7")
+	EnsureDiffAnalysis(files, "code-review-server", 7, "sha-7", TriggerPostUpdateHook)
 
 	// The ordering must still have been cached; the rating must not have been.
 	if ordering, err := db.GetDiffFileOrdering(7, "code-review-server", "sha-7"); err != nil || ordering == "" {
@@ -132,7 +132,7 @@ func TestCallLogSuccess(t *testing.T) {
 	useFakeClient(t, &fakeClient{text: "REVIEW_EASE: hard\n"}, nil)
 
 	files := []*utils.DiffFile{{NewName: "main.go"}}
-	EnsureDiffAnalysis(files, "code-review-server", 9, "sha-9")
+	EnsureDiffAnalysis(files, "code-review-server", 9, "sha-9", TriggerPostUpdateHook)
 
 	if ease, _ := db.GetReviewEase(9, "code-review-server", "sha-9"); ease != "hard" {
 		t.Errorf("expected cached review ease %q, got %q", "hard", ease)

--- a/llm/ratings.go
+++ b/llm/ratings.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 )
@@ -85,10 +86,28 @@ type DiffAnalysis struct {
 	ReviewEase string
 }
 
+// Triggers recorded in the call log, naming what caused an analysis call.
+const (
+	// TriggerPostUpdateHook is the analysis the post-update hook runs after a
+	// PR is fetched or its head SHA changes.
+	TriggerPostUpdateHook = "post-update hook"
+	// TriggerRender is the analysis a render kicks off in the background when
+	// it finds no cached ordering. The render itself does not wait for it.
+	TriggerRender = "render (background)"
+)
+
+// inflightAnalysis tracks the (repo, PR, SHA) triples an analysis is currently
+// running for, so the render-triggered dispatch and the post-update hook
+// firing for the same revision collapse into a single LLM call instead of two.
+var inflightAnalysis sync.Map // "repo#pr@sha" -> struct{}
+
 // EnsureDiffAnalysis makes sure the LLM-derived values enabled in config
 // (the diff file ordering and the review-ease rating) are cached for the PR
-// SHA, calling the LLM at most once if anything is missing.
-func EnsureDiffAnalysis(files []*utils.DiffFile, repo string, prNumber int, sha string) {
+// SHA, calling the LLM at most once if anything is missing. It blocks for the
+// duration of the LLM call, so callers on a request path must run it in a
+// goroutine. Concurrent calls for the same PR SHA collapse into one: the
+// first runs the analysis and the rest return immediately.
+func EnsureDiffAnalysis(files []*utils.DiffFile, repo string, prNumber int, sha, trigger string) {
 	cfg := config.C()
 	needOrdering := cfg.ExperimentalLLMFileOrdering && len(files) >= 2 &&
 		cachedFileOrdering(repo, prNumber, sha) == nil
@@ -97,7 +116,14 @@ func EnsureDiffAnalysis(files []*utils.DiffFile, repo string, prNumber int, sha 
 		return
 	}
 
-	ctx := callContext{repo: repo, prNumber: prNumber, sha: sha, trigger: "post-update hook"}
+	key := fmt.Sprintf("%s#%d@%s", repo, prNumber, sha)
+	if _, running := inflightAnalysis.LoadOrStore(key, struct{}{}); running {
+		slog.Debug("LLM diff analysis already running for revision, skipping", "repo", repo, "pr", prNumber, "sha", sha)
+		return
+	}
+	defer inflightAnalysis.Delete(key)
+
+	ctx := callContext{repo: repo, prNumber: prNumber, sha: sha, trigger: trigger}
 	analysis, err := analyzeDiff(files, needOrdering, needEase, ctx)
 	if err != nil {
 		slog.Warn("LLM diff analysis failed", "repo", repo, "pr", prNumber, "error", err)
@@ -106,24 +132,20 @@ func EnsureDiffAnalysis(files []*utils.DiffFile, repo string, prNumber int, sha 
 	storeDiffAnalysis(repo, prNumber, sha, analysis)
 }
 
-// OrderedDiffFiles returns files in the LLM-derived display order for the PR
-// SHA, from cache when available and by calling the LLM otherwise. The
-// second return is false when no ordering could be produced and the caller
-// should fall back to its default sort.
-func OrderedDiffFiles(files []*utils.DiffFile, repo string, prNumber int, sha string) ([]*utils.DiffFile, bool) {
-	if names := cachedFileOrdering(repo, prNumber, sha); names != nil {
-		return reorderFilesByNames(files, names), true
-	}
-
-	ctx := callContext{repo: repo, prNumber: prNumber, sha: sha, trigger: "render"}
-	analysis, err := analyzeDiff(files, true, config.C().ExperimentalLLMReviewEase, ctx)
-	if err != nil {
-		slog.Warn("LLM diff analysis failed, falling back to default sort", "error", err)
+// CachedOrderedDiffFiles returns files in the LLM-derived display order for
+// the PR SHA when that ordering is already cached. It never calls the LLM:
+// rendering a PR is on the critical path of opening a review, and an LLM
+// round trip there is a delay the reviewer waits on. Producing the ordering
+// is EnsureDiffAnalysis's job, which callers run in the background.
+//
+// The second return is false when nothing is cached and the caller should
+// fall back to its default sort.
+func CachedOrderedDiffFiles(files []*utils.DiffFile, repo string, prNumber int, sha string) ([]*utils.DiffFile, bool) {
+	names := cachedFileOrdering(repo, prNumber, sha)
+	if names == nil {
 		return nil, false
 	}
-
-	storeDiffAnalysis(repo, prNumber, sha, analysis)
-	return reorderFilesByNames(files, analysis.Ordering), true
+	return reorderFilesByNames(files, names), true
 }
 
 // analyzeDiff asks the LLM for the requested analysis values: the file

--- a/llm/ratings_test.go
+++ b/llm/ratings_test.go
@@ -1,10 +1,111 @@
 package llm
 
 import (
+	"crs/config"
 	"crs/utils"
 	"strings"
 	"testing"
 )
+
+// blockingClient holds each Generate call until release is closed, so a test
+// can observe a call while it is still in flight, and counts every call it
+// received.
+type blockingClient struct {
+	started chan struct{}
+	release chan struct{}
+	calls   chan struct{}
+}
+
+func newBlockingClient(maxCalls int) *blockingClient {
+	return &blockingClient{
+		started: make(chan struct{}, maxCalls),
+		release: make(chan struct{}),
+		calls:   make(chan struct{}, maxCalls),
+	}
+}
+
+func (c *blockingClient) Provider() string { return "fake" }
+func (c *blockingClient) Model() string    { return "fake-model" }
+func (c *blockingClient) Generate(string) (string, error) {
+	c.calls <- struct{}{}
+	c.started <- struct{}{}
+	<-c.release
+	return "helper.go\nmain.go\n", nil
+}
+
+// failingClient fails the test if the LLM is contacted at all.
+type failingClient struct{ t *testing.T }
+
+func (c *failingClient) Provider() string { return "fake" }
+func (c *failingClient) Model() string    { return "fake-model" }
+func (c *failingClient) Generate(string) (string, error) {
+	c.t.Error("LLM was called on a path that must not contact it")
+	return "", nil
+}
+
+func TestCachedOrderedDiffFilesNeverCallsLLM(t *testing.T) {
+	// A render asking for the ordering must be answered from cache or not at
+	// all: it is on the critical path of opening a review.
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db, ExperimentalLLMFileOrdering: true})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+	useFakeClient(t, &failingClient{t: t}, nil)
+
+	files := []*utils.DiffFile{{NewName: "main.go"}, {NewName: "helper.go"}}
+
+	if _, ok := CachedOrderedDiffFiles(files, "code-review-server", 3, "sha-3"); ok {
+		t.Fatal("expected a cache miss to report ok=false")
+	}
+
+	if err := db.UpsertDiffFileOrdering(3, "code-review-server", "sha-3", `["helper.go","main.go"]`); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	ordered, ok := CachedOrderedDiffFiles(files, "code-review-server", 3, "sha-3")
+	if !ok {
+		t.Fatal("expected a cache hit to report ok=true")
+	}
+	if ordered[0].NewName != "helper.go" || ordered[1].NewName != "main.go" {
+		t.Errorf("cached ordering not applied: got %q, %q", ordered[0].NewName, ordered[1].NewName)
+	}
+}
+
+func TestEnsureDiffAnalysisCollapsesConcurrentCallsForSameRevision(t *testing.T) {
+	// The render dispatch and the post-update hook both fire for a freshly
+	// opened PR; only one of them should reach the LLM.
+	t.Setenv("CRS_HOME", t.TempDir())
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db, ExperimentalLLMFileOrdering: true})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	client := newBlockingClient(4)
+	useFakeClient(t, client, nil)
+
+	files := []*utils.DiffFile{{NewName: "main.go"}, {NewName: "helper.go"}}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		EnsureDiffAnalysis(files, "code-review-server", 11, "sha-11", TriggerRender)
+	}()
+
+	// Wait until the first analysis is inside the LLM call, then fire the
+	// second one for the same revision: it must return without calling out.
+	<-client.started
+	EnsureDiffAnalysis(files, "code-review-server", 11, "sha-11", TriggerPostUpdateHook)
+
+	close(client.release)
+	<-done
+
+	if got := len(client.calls); got != 1 {
+		t.Errorf("expected exactly 1 LLM call for the revision, got %d", got)
+	}
+
+	// The completed analysis is cached, so nothing after it needs the LLM.
+	if ordering, err := db.GetDiffFileOrdering(11, "code-review-server", "sha-11"); err != nil || ordering == "" {
+		t.Errorf("expected the completed analysis to be cached, got %q (err %v)", ordering, err)
+	}
+}
 
 func TestCleanFileName(t *testing.T) {
 	tests := []struct {

--- a/main.go
+++ b/main.go
@@ -86,6 +86,13 @@ func main() {
 	ms.Initialize()
 
 	if *serverFlag {
+		// Compute plugin results and the LLM diff analysis off the back of the
+		// workflow cycle that added or refreshed a PR, so opening a review
+		// finds them already cached. Only registered in server mode: a
+		// workflow-only process exits when its cycle ends and would kill the
+		// hooks mid-run.
+		workflows.SetPRUpdatedHook(server.WarmPRAnalysis)
+
 		go func() {
 			slog.Info("Starting pprof server", "addr", "localhost:6061")
 			if err := http.ListenAndServe("localhost:6061", nil); err != nil {

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -38,5 +38,5 @@ func ensureDiffAnalysis(repo string, prNumber int, sha, diff string) {
 		slog.Warn("Failed to parse diff for LLM diff analysis hook", "repo", repo, "pr", prNumber, "error", err)
 		return
 	}
-	llm.EnsureDiffAnalysis(parsed.Files, repo, prNumber, sha)
+	llm.EnsureDiffAnalysis(parsed.Files, repo, prNumber, sha, llm.TriggerPostUpdateHook)
 }

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -21,6 +21,24 @@ func RunPostUpdatePRHooks(owner, repo string, number int, sha string, diff strin
 	go ensureDiffAnalysis(repo, number, sha, diff)
 }
 
+// WarmPRAnalysis runs the post-update hooks for a PR whose caches a workflow
+// has just filled, so the plugin results and the LLM diff analysis are already
+// computed by the time anyone opens the review. It is the entry point the
+// workflow layer is wired to (see workflows.SetPRUpdatedHook): workflows
+// cannot call into this package directly, because server imports workflows.
+//
+// Everything the hooks need was written to the DB by the workflow that
+// triggered this, so the GetPRDetails call below is expected to be all cache
+// hits. It blocks for that read, so callers run it in a goroutine.
+func WarmPRAnalysis(owner, repo string, number int) {
+	details, err := GetPRDetails(owner, repo, number, false)
+	if err != nil {
+		slog.Warn("Error loading PR details to warm post-update hooks", "repo", repo, "pr", number, "error", err)
+		return
+	}
+	ensurePostUpdateHooks(owner, repo, number, details)
+}
+
 // ensureDiffAnalysis pre-computes and caches the LLM diff analysis (file
 // ordering and review-ease rating, per the enabled config flags) for a PR SHA
 // so subsequent renders hit the cache. The underlying analysis is cache-first

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -13,6 +13,17 @@ import (
 
 const pluginTimeout = 5 * time.Minute
 
+// maxAutomaticPluginProcs caps how many automatic plugin runs execute at once.
+// Automatic runs are fan-out work: opening the dashboard warms every visible
+// PR, so without a cap one page load can launch dozens of plugin processes,
+// each competing for CPU and for the server's single SQLite connection with
+// the request the reviewer is actually waiting on. Explicit runs (a rerun, or
+// an on-demand plugin someone asked for by name) are never queued behind this
+// - someone is watching those.
+const maxAutomaticPluginProcs = 4
+
+var automaticPluginSlots = make(chan struct{}, maxAutomaticPluginProcs)
+
 // PluginCallType describes why a plugin is being executed. It is handed to the
 // plugin binary via the --call-type flag so a plugin can adapt its behaviour to
 // the situation - for instance skipping cached work on an automatic run but
@@ -112,6 +123,11 @@ func executePlugin(plugin config.Plugin, owner, repo string, number int, sha str
 
 	if force {
 		slog.Info("Forcing plugin execution", "plugin", plugin.Name, "call_type", callType)
+	} else {
+		// Automatic runs wait their turn so a burst of them can't starve the
+		// foreground. The slot is held only for the subprocess itself.
+		automaticPluginSlots <- struct{}{}
+		defer func() { <-automaticPluginSlots }()
 	}
 
 	// Set status to pending

--- a/server/plugins_test.go
+++ b/server/plugins_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func setupTestDB(t *testing.T) *database.DB {
@@ -206,6 +207,55 @@ func TestRunPluginsForce_PassesExplicitCallTypeForDeferredPlugin(t *testing.T) {
 
 	if args := recordedArgs(t, argsPath); !strings.Contains(args, "--call-type explicit") {
 		t.Errorf("expected --call-type explicit in plugin args, got %q", args)
+	}
+}
+
+// fillAutomaticPluginSlots takes every automatic-run slot for the duration of
+// the test, simulating a background fan-out already saturating the cap.
+func fillAutomaticPluginSlots(t *testing.T) {
+	t.Helper()
+	for i := 0; i < maxAutomaticPluginProcs; i++ {
+		automaticPluginSlots <- struct{}{}
+	}
+	t.Cleanup(func() {
+		for i := 0; i < maxAutomaticPluginProcs; i++ {
+			<-automaticPluginSlots
+		}
+	})
+}
+
+func TestRunPluginsForce_ExplicitRunIsNotQueuedBehindAutomaticRuns(t *testing.T) {
+	// A rerun someone asked for has a person waiting on it, so it must not
+	// wait for the automatic background runs to drain.
+	db := setupTestDB(t)
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ran")
+	script := filepath.Join(dir, "plugin.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ntouch "+marker), 0755); err != nil {
+		t.Fatalf("failed to write plugin script: %v", err)
+	}
+
+	config.SetC(config.Config{
+		DB:      db,
+		Plugins: []config.Plugin{{Name: "normal-plugin", Command: script}},
+	})
+
+	fillAutomaticPluginSlots(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		RunPluginsForce("owner", "repo", 1, "sha123", "", "", "", "main", true, []string{"normal-plugin"})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("explicit plugin rerun blocked behind the automatic-run cap")
+	}
+
+	if _, err := os.Stat(marker); os.IsNotExist(err) {
+		t.Error("expected the explicitly requested plugin to run")
 	}
 }
 

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -961,6 +961,35 @@ func TestOrderDiffFilesUsesCachedOrdering(t *testing.T) {
 	}
 }
 
+func TestOrderDiffFilesFallsBackWithoutWaitingOnLLM(t *testing.T) {
+	// With the flag on and nothing cached for the SHA, the render must not
+	// block on the analysis: it falls back to the tests-last sort and leaves
+	// the LLM call to the background dispatch.
+	t.Setenv("CRS_HOME", t.TempDir())
+	t.Setenv("GEMINI_API_KEY", "")
+
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db, ExperimentalLLMFileOrdering: true})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	files := []*utils.DiffFile{
+		{NewName: "a_test.go"},
+		{NewName: "main.go"},
+	}
+
+	done := make(chan []*utils.DiffFile, 1)
+	go func() { done <- orderDiffFiles(files, "code-review-server", 12, "sha-uncached") }()
+
+	select {
+	case got := <-done:
+		if got[0].NewName != "main.go" || got[1].NewName != "a_test.go" {
+			t.Errorf("expected tests-last fallback, got %q, %q", got[0].NewName, got[1].NewName)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("orderDiffFiles blocked on a cache miss instead of falling back")
+	}
+}
+
 func TestReviewEaseCacheRoundtrip(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/server/server.go
+++ b/server/server.go
@@ -218,7 +218,7 @@ func (h *RPCHandler) GetPR(args *GetPRstructArgs, reply *GetPRReply) error {
 	if err != nil {
 		return err
 	}
-	h.ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
+	ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
 	reply.populate(details, content, args.Owner, args.Repo, args.Number)
 	return nil
 }
@@ -270,15 +270,25 @@ func shouldDispatchHooks(owner, repo string, number int, sha string) bool {
 			return false
 		}
 	}
+	// Keys are per revision and every workflow cycle mints new ones, so drop
+	// the expired entries rather than letting the map grow for the life of the
+	// process. Anything past the TTL can no longer debounce anything.
+	recentHookDispatches.Range(func(k, v any) bool {
+		if last, ok := v.(time.Time); ok && now.Sub(last) >= hookDispatchTTL {
+			recentHookDispatches.Delete(k)
+		}
+		return true
+	})
 	recentHookDispatches.Store(key, now)
 	return true
 }
 
 // ensurePostUpdateHooks dispatches the async post-update hooks (plugins and
-// the experimental LLM diff analysis) for a PR. Only methods that represent
-// "the client is looking at fresh PR content" call this; local-comment
-// mutations do not, since they never change the PR's head SHA.
-func (h *RPCHandler) ensurePostUpdateHooks(owner, repo string, number int, details *PRDetails) {
+// the experimental LLM diff analysis) for a PR, reading the hooks' inputs from
+// the DB caches. RPC methods that represent "the client is looking at fresh PR
+// content" call this; local-comment mutations do not, since they never change
+// the PR's head SHA. The workflow layer reaches it through WarmPRAnalysis.
+func ensurePostUpdateHooks(owner, repo string, number int, details *PRDetails) {
 	_, sha, err := config.C().DB.GetPullRequest(number, repo)
 	if err != nil {
 		slog.Warn("Error reading cached PR SHA for hook dispatch", "repo", repo, "pr", number, "error", err)
@@ -365,7 +375,7 @@ func (h *RPCHandler) GetAdjacentPR(args *GetAdjacentPRArgs, reply *GetAdjacentPR
 	if err != nil {
 		return err
 	}
-	h.ensurePostUpdateHooks(adjacent.Owner, adjacent.Repo, adjacent.Number, details)
+	ensurePostUpdateHooks(adjacent.Owner, adjacent.Repo, adjacent.Number, details)
 
 	reply.AdjacentOwner = adjacent.Owner
 	reply.AdjacentRepo = adjacent.Repo
@@ -654,7 +664,7 @@ func (h *RPCHandler) SyncPR(args *SyncPRArgs, reply *SyncPRReply) error {
 	if err != nil {
 		return err
 	}
-	h.ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
+	ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
 
 	_, newSHA, _ := config.C().DB.GetPullRequest(args.Number, args.Repo)
 	newCommentsJSON, _ := config.C().DB.GetPRComments(args.Number, args.Repo)
@@ -1190,7 +1200,7 @@ func (h *RPCHandler) GetPluginOutput(args *GetPluginOutputArgs, reply *GetPlugin
 				slog.Error("Error fetching PR details for plugin trigger", "repo", args.Repo, "pr", args.Number, "error", err)
 				return
 			}
-			h.ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
+			ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
 		}()
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -228,18 +228,27 @@ func (h *RPCHandler) GetPR(args *GetPRstructArgs, reply *GetPRReply) error {
 // plugins or LLM analysis — callers that want those side effects invoke
 // ensurePostUpdateHooks explicitly.
 func (h *RPCHandler) fetchPR(owner, repo string, number int, skipCache bool) (*PRDetails, string, error) {
+	fetchStart := time.Now()
 	details, err := GetPRDetails(owner, repo, number, skipCache)
 	if err != nil {
 		slog.Error("Error fetching PR details", "error", err)
 		return nil, "", err
 	}
+	fetchMS := time.Since(fetchStart).Milliseconds()
 
 	// Get the full formatted response for the UI.
 	// We pass the already fetched details to avoid redundant API calls.
+	renderStart := time.Now()
 	content, err := GetFullPRResponse(owner, repo, number, false, details)
 	if err != nil {
 		slog.Error("Error building formatted PR response", "repo", repo, "pr", number, "error", err)
 	}
+
+	// Timed because this is what a reviewer waits on when opening a PR: a slow
+	// open shows up here as either fetch time (a cache miss going to GitHub) or
+	// render time, rather than having to be guessed at from surrounding logs.
+	slog.Info("Served PR", "repo", repo, "pr", number, "skip_cache", skipCache,
+		"fetch_ms", fetchMS, "render_ms", time.Since(renderStart).Milliseconds())
 
 	return details, content, nil
 }
@@ -1226,25 +1235,27 @@ func (h *RPCHandler) RerunPlugins(args *RerunPluginsArgs, reply *RerunPluginsRep
 		slog.Info("Cleared specific plugin results for PR, triggering rerun", "repo", args.Repo, "pr", args.Number, "plugins", args.Plugins)
 	}
 
-	// Fetch PR details and trigger plugins
-	details, err := GetPRDetails(args.Owner, args.Repo, args.Number, false)
-	if err != nil {
-		slog.Error("Error fetching PR details for plugin rerun", "error", err)
-		return err
-	}
+	// Gather the plugin inputs and run them, all in the background: fetching
+	// the details can reach GitHub on a cache miss, and the caller only needs
+	// to know the rerun was accepted. Results arrive through GetPluginOutput.
+	go func() {
+		details, err := GetPRDetails(args.Owner, args.Repo, args.Number, false)
+		if err != nil {
+			slog.Error("Error fetching PR details for plugin rerun", "repo", args.Repo, "pr", args.Number, "error", err)
+			return
+		}
 
-	// Get PR metadata and diff
-	commentsJSON := "[]"
-	rawComments, _ := config.C().DB.GetPRComments(args.Number, args.Repo)
-	if rawComments != "" {
-		commentsJSON = rawComments
-	}
+		commentsJSON := "[]"
+		rawComments, _ := config.C().DB.GetPRComments(args.Number, args.Repo)
+		if rawComments != "" {
+			commentsJSON = rawComments
+		}
 
-	_, sha, _ := config.C().DB.GetPullRequest(args.Number, args.Repo)
+		_, sha, _ := config.C().DB.GetPullRequest(args.Number, args.Repo)
 
-	// Run plugins with force flag
-	metadataJSON, _ := json.Marshal(details.Metadata)
-	go RunPluginsForce(args.Owner, args.Repo, args.Number, sha, details.Diff, commentsJSON, string(metadataJSON), details.Metadata.HeadRef, true, args.Plugins)
+		metadataJSON, _ := json.Marshal(details.Metadata)
+		RunPluginsForce(args.Owner, args.Repo, args.Number, sha, details.Diff, commentsJSON, string(metadataJSON), details.Metadata.HeadRef, true, args.Plugins)
+	}()
 
 	reply.Okay = true
 	if len(args.Plugins) == 0 {
@@ -1281,6 +1292,12 @@ func (h *RPCHandler) RerunPlugins(args *RerunPluginsArgs, reply *RerunPluginsRep
 // experimental LLM ordering when enabled, otherwise to the default sort that
 // places test files last. LLM orderings are cached per PR SHA so the LLM is
 // queried at most once per revision.
+//
+// Rendering never waits on the LLM. On a cache miss the analysis is kicked off
+// in the background and this render falls back to the default sort; the
+// ordering is in place for the next render of the same revision. Blocking here
+// would put a multi-second network round trip in front of opening a review,
+// which is precisely the delay this path must not have.
 func orderDiffFiles(files []*utils.DiffFile, repo string, prNumber int, sha string) []*utils.DiffFile {
 	if !config.C().ExperimentalLLMFileOrdering {
 		return sortFilesTestsLast(files)
@@ -1288,8 +1305,9 @@ func orderDiffFiles(files []*utils.DiffFile, repo string, prNumber int, sha stri
 	if len(files) < 2 {
 		return files
 	}
-	if ordered, ok := llm.OrderedDiffFiles(files, repo, prNumber, sha); ok {
+	if ordered, ok := llm.CachedOrderedDiffFiles(files, repo, prNumber, sha); ok {
 		return ordered
 	}
+	go llm.EnsureDiffAnalysis(files, repo, prNumber, sha, llm.TriggerRender)
 	return sortFilesTestsLast(files)
 }

--- a/workflows/cache_warm_test.go
+++ b/workflows/cache_warm_test.go
@@ -3,7 +3,10 @@ package workflows
 import (
 	"crs/database"
 	"path/filepath"
+	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v74/github"
 )
@@ -121,5 +124,69 @@ func TestApplyCacheWarmRequirements(t *testing.T) {
 		if got := reqs[key]; got != (AuxDataRequirement{}) {
 			t.Errorf("unchanged PR should not be warmed, got %+v", got)
 		}
+	})
+
+	t.Run("reports only the warmed PRs", func(t *testing.T) {
+		// The returned keys drive the post-update hooks, so an unchanged PR
+		// appearing here would rerun plugins for a revision already handled.
+		db := warmTestDB(t)
+		unchanged := PRKey{Owner: "owner", Repo: repo, Number: 200}
+		if err := db.UpsertPullRequest(unchanged.Number, repo, "sha1", "", "cached diff"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		prObjects := map[PRKey]*github.PullRequest{
+			key:       prWithHeadSHA("sha1"),
+			unchanged: prWithHeadSHA("sha1"),
+		}
+
+		warmed := applyCacheWarmRequirements(db, prObjects, map[PRKey]AuxDataRequirement{})
+
+		if len(warmed) != 1 || warmed[0] != key {
+			t.Errorf("got warmed %+v, want only %+v", warmed, key)
+		}
+	})
+}
+
+func TestNotifyPRsUpdated(t *testing.T) {
+	key := PRKey{Owner: "owner", Repo: "code-review-server", Number: 100}
+
+	t.Run("fires the hook once per warmed PR", func(t *testing.T) {
+		var mu sync.Mutex
+		var got []PRKey
+		done := make(chan struct{}, 2)
+
+		SetPRUpdatedHook(func(owner, repo string, number int) {
+			mu.Lock()
+			got = append(got, PRKey{Owner: owner, Repo: repo, Number: number})
+			mu.Unlock()
+			done <- struct{}{}
+		})
+		t.Cleanup(func() { SetPRUpdatedHook(nil) })
+
+		other := PRKey{Owner: "owner", Repo: "code-review-server", Number: 200}
+		notifyPRsUpdated([]PRKey{key, other})
+
+		// The hooks run in their own goroutines; wait for both.
+		for i := 0; i < 2; i++ {
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for the PR-updated hooks to fire")
+			}
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(got) != 2 {
+			t.Fatalf("got %d hook calls, want 2", len(got))
+		}
+		if !slices.Contains(got, key) || !slices.Contains(got, other) {
+			t.Errorf("hook called with %+v, want both %+v and %+v", got, key, other)
+		}
+	})
+
+	t.Run("no hook registered is a no-op", func(t *testing.T) {
+		SetPRUpdatedHook(nil)
+		notifyPRsUpdated([]PRKey{key})
 	})
 }

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -22,6 +22,29 @@ import (
 	"github.com/google/go-github/v74/github"
 )
 
+// prUpdatedHook is called once per PR that a cycle newly added or re-fetched
+// after a push, after that PR's aux data has been written to the DB caches.
+// The server registers server.WarmPRAnalysis here so plugins and the LLM diff
+// analysis are computed off the back of the workflow rather than when a
+// reviewer opens the PR. It is a registered callback rather than a direct call
+// because server imports this package, so the dependency cannot run both ways.
+//
+// Nil when nothing is registered — a workflow-only process (`--oneoff` without
+// `--server`) exits as soon as the cycle finishes and would kill any hook work
+// in flight, leaving plugin results stuck at "pending" for that head SHA.
+var prUpdatedHook atomic.Pointer[func(owner, repo string, number int)]
+
+// SetPRUpdatedHook registers the callback invoked for each PR a cycle added or
+// updated. Call it during startup, before the manager runs. A nil fn clears
+// any registered hook.
+func SetPRUpdatedHook(fn func(owner, repo string, number int)) {
+	if fn == nil {
+		prUpdatedHook.Store(nil)
+		return
+	}
+	prUpdatedHook.Store(&fn)
+}
+
 // apiCallCounter tracks GitHub API calls by type for a single RunOnce cycle.
 type apiCallCounter struct {
 	PRList         atomic.Int64
@@ -802,7 +825,7 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 		}
 	}
 
-	applyCacheWarmRequirements(config.C().DB, prObjects, prRequirements)
+	warmed := applyCacheWarmRequirements(config.C().DB, prObjects, prRequirements)
 
 	// Fetch aux data in parallel, but bounded (see prefetchConcurrency).
 	var wg sync.WaitGroup
@@ -825,7 +848,26 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 	wg.Wait()
 
 	slog.Info("Pre-fetched auxiliary data", "pr_count", len(prRequirements))
+	notifyPRsUpdated(warmed)
 	return store
+}
+
+// notifyPRsUpdated fires the registered PR-updated hook for each PR this cycle
+// warmed. It runs after the aux fetches have finished, so the hook finds the
+// diff, comments and metadata it needs already in the DB.
+//
+// Each hook call gets its own goroutine and the cycle does not wait for them:
+// the hooks fan out to plugin subprocesses and LLM calls, which are slow by
+// nature and must not hold up the next workflow run.
+func notifyPRsUpdated(warmed []PRKey) {
+	hook := prUpdatedHook.Load()
+	if hook == nil || len(warmed) == 0 {
+		return
+	}
+	slog.Info("Dispatching post-update hooks for updated PRs", "pr_count", len(warmed))
+	for _, key := range warmed {
+		go (*hook)(key.Owner, key.Repo, key.Number)
+	}
 }
 
 // applyCacheWarmRequirements turns on the aux fields a reviewer needs to open a
@@ -840,10 +882,15 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 // forces Reviews on for open non-draft PRs: that override skips drafts and
 // closed PRs, so without this pass those PRs never get a PRReviews row written
 // by a workflow and every open of one logs a "reviews" cache miss.
+//
+// It returns the PRs it turned the warm on for. Those are exactly the ones
+// whose plugin results and LLM analysis are stale too, so the caller fires the
+// PR-updated hook for them once the fetches land.
 func applyCacheWarmRequirements(db *database.DB,
 	prObjects map[PRKey]*github.PullRequest,
-	prRequirements map[PRKey]AuxDataRequirement) {
+	prRequirements map[PRKey]AuxDataRequirement) []PRKey {
 
+	warmed := []PRKey{}
 	for key, pr := range prObjects {
 		if !prNeedsCacheWarm(db, key, pr) {
 			continue
@@ -854,7 +901,9 @@ func applyCacheWarmRequirements(db *database.DB,
 		req.Reviews = true
 		req.Comments = true
 		prRequirements[key] = req
+		warmed = append(warmed, key)
 	}
+	return warmed
 }
 
 // prNeedsCacheWarm reports whether we should proactively warm the caches for a


### PR DESCRIPTION
Opening a PR in the bun client sometimes stalled even with everything in
cache. The blocking work was the experimental LLM diff-file ordering:
formatDiff called llm.OrderedDiffFiles, which on a cache miss made a
synchronous Gemini round trip mid-render, with the reviewer waiting on it
(the call log labelled these "render").

Rendering is now cache-only. llm.CachedOrderedDiffFiles never contacts the
LLM; on a miss the render falls back to the tests-last sort and dispatches
the analysis in the background, so the ordering is in place for the next
render of that revision. EnsureDiffAnalysis takes a trigger label and
collapses concurrent calls for the same PR SHA, so the render dispatch and
the post-update hook can't both call out for the same revision.

Plugin runs were already dispatched asynchronously, but nothing bounded
their fan-out: loading the dashboard warms plugin output for every visible
PR, so one page load could launch dozens of plugin processes competing
with the request in front of the reviewer. Automatic runs now go through a
4-slot semaphore; explicit runs and on-demand plugins are never queued
behind it, since someone is waiting on those. RerunPlugins also no longer
blocks its RPC on a GetPRDetails that can reach GitHub.

Finally, fetchPR logs fetch and render timings, so the next slow open can
be attributed from the logs instead of inferred.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AYPK67q9SYc8QYWgw1pNUg