### PR TITLE
docs: add web client feature reference for bun_client

### DIFF
--- a/docs/building_clients.md
+++ b/docs/building_clients.md
@@ -6,6 +6,8 @@ If you want to build a new client (e.g. for VS Code, Vim, or a TUI), you should 
 
 The server binary `codereviewserver` should be spawned as a child process by your client. Your client send requests to the server's `stdin` and reads responses from `stdout`.
 
+If you are building a **web** client, [Web Client Features](web_client_features.md) inventories everything the shipped `bun_client` does — the HTTP/WebSocket bridge that fronts the stdio server, the full feature list, which protocol methods it uses (and which it doesn't), and the gotchas worth knowing before you reimplement diff parsing or comment positions.
+
 ## Offering Configuration Editing
 
 A client can let users manage the server's config without touching TOML by hand, via `RPCHandler.GetConfig` and `RPCHandler.UpdateConfig`.

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -6,6 +6,8 @@ Code Review Server ships with a web client, an Emacs client, and a TUI client, b
 
 The web client is packaged with bun, and has a bun backend with a react frontend. If you build and run the bun backend, you'll get a working webserver on `localhost:3000` which lists all of your PRs.
 
+For a full inventory of what this client does — architecture, HTTP surface, every feature, and the protocol details a reimplementation needs to get right — see [Web Client Features](web_client_features.md).
+
 ### Installation
 
 1. `cd` to `bun_client`

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -76,28 +76,33 @@ Fetches all review sections from the local database, rendered as org-mode format
 
 ---
 
-### `RPCHandler.GetPR`
+### The PR Payload
 
-Fetches a pull request from GitHub and returns it as rendered content (including diff, comments, conversations).
+Every method that returns a pull request's full state replies with the same shared
+body, described here once:
 
-**Arguments** (`GetPRstructArgs`):
-| Field    | Type   | Required | Description                          |
-|----------|--------|----------|--------------------------------------|
-| `Owner`  | string | Yes      | Repository owner (e.g., `"octocat"`) |
-| `Repo`   | string | Yes      | Repository name (e.g., `"hello"`)    |
-| `Number` | int    | Yes      | Pull request number                  |
+`GetPR`, `GetAdjacentPR`, `SyncPR`, `AddComment`, `EditComment`, `DeleteComment`,
+`SetFeedback`, `RemovePRComments`, and `SubmitReview`.
 
-**Reply** (`GetPRReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `Okay`     | bool         | `true` if the request succeeded                 |
-| `Content`  | string       | Formatted PR response (diff, comments, metadata)|
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
-| `annotations` | []PRAnnotation | Diff annotations aggregated from every plugin that has already executed successfully for this PR (see [Plugins](plugins.md#plugin-response-contract)) |
+Some of those methods add fields on top of it; those extras are listed with each
+method below. The payload is always complete — a mutation like `AddComment` returns
+the PR's whole refreshed state, not just the part that changed, so clients can apply
+the reply wholesale instead of patching local state.
+
+| Field               | Type           | Description                                                                 |
+|---------------------|----------------|-----------------------------------------------------------------------------|
+| `okay`              | bool           | `true` if the request succeeded                                             |
+| `content`           | string         | Formatted PR response (diff, comments, metadata)                            |
+| `metadata`          | PRMetadata     | Structured PR metadata                                                      |
+| `diff`              | string         | Raw diff content                                                            |
+| `comments`          | []CommentJSON  | Structured PR active comments                                               |
+| `outdated_comments` | []CommentJSON  | Structured PR outdated comments                                             |
+| `reviews`           | []ReviewJSON   | Submitted reviews                                                           |
+| `commits`           | []CommitJSON   | Commits on the PR                                                           |
+| `feedback`          | string         | The locally saved review feedback draft for this PR (see `SetFeedback`); empty when none has been saved |
+| `annotations`       | []PRAnnotation | Diff annotations aggregated from every plugin that has already executed successfully for this PR (see [Plugins](plugins.md#plugin-response-contract)) |
+
+Slice fields are normalized before sending: a client always sees `[]`, never `null`.
 
 #### PRAnnotation Object
 
@@ -132,9 +137,13 @@ Fetches a pull request from GitHub and returns it as rendered content (including
 | `ci_failures`          | []string | List of failed CI check names and messages                |
 | `body`                 | string   | PR description body                                       |
 | `url`                  | string   | GitHub HTML URL                                           |
+| `repo_path`            | string   | Absolute path to the local clone of the repository, when one exists under the configured `RepoLocation`. Empty when the repo isn't checked out locally. Distinct from `worktree_path`: this is the repository itself, not the PR's worktree. Clients use it to gate features that need local source, such as language-server lookups or a file browser |
 | `worktree_path`        | string   | Absolute path to the local git worktree (if managed by server) |
 | `release_status`       | string   | Release status from the configured release check command, if any |
 | `review_ease`          | string   | LLM rating of how easy the PR is to review: `easy`, `medium`, or `hard`. Empty unless `ExperimentalLLMReviewEase` is enabled in the config and a rating has been computed |
+| `changed_files`        | int      | Number of files changed by the PR                         |
+| `additions`            | int      | Lines added by the PR                                     |
+| `deletions`            | int      | Lines removed by the PR                                   |
 
 #### Using the Worktree
 
@@ -162,6 +171,20 @@ Comments are rendered inline within the diff or at the file headers. They use a 
 
 Each comment block includes the file path, timestamp, author(s), and comment ID, followed by the conversation thread.
 
+#### Comment Object (`CommentJSON`)
+
+| Field         | Type   | Description                                                                 |
+|---------------|--------|-----------------------------------------------------------------------------|
+| `id`          | string | Comment ID. For a local (pending) comment this is the local ID accepted by `EditComment` / `DeleteComment` |
+| `author`      | string | GitHub login of the author, or `local` for a pending comment not yet submitted |
+| `body`        | string | Comment body text                                                           |
+| `path`        | string | File the comment is attached to                                             |
+| `position`    | string | Position within the diff (not a file line number). `0` means the comment is on the file as a whole |
+| `in_reply_to` | int64  | ID of the comment this one replies to; `0` for a thread root                 |
+| `created_at`  | Time   | Creation timestamp                                                          |
+| `outdated`    | bool   | Whether the comment refers to a version of the code the current diff no longer matches |
+| `diff_hunk`   | string | The diff context the comment was made against — the only way to show an outdated comment in place |
+
 #### Review Object
 
 Represents a submitted review (e.g. APPROVED, CHANGES_REQUESTED).
@@ -174,6 +197,34 @@ Represents a submitted review (e.g. APPROVED, CHANGES_REQUESTED).
 | `state`        | string    | Review state (APPROVED, CHANGES_REQUESTED, etc.) |
 | `submitted_at` | Time      | Timestamp when the review was submitted          |
 | `html_url`     | string    | Link to the review on GitHub                     |
+
+#### Commit Object (`CommitJSON`)
+
+| Field     | Type   | Description                        |
+|-----------|--------|------------------------------------|
+| `sha`     | string | Commit SHA                         |
+| `message` | string | Commit message                     |
+| `author`  | string | Commit author                      |
+| `date`    | string | Commit date                        |
+| `url`     | string | Link to the commit on GitHub       |
+
+---
+
+### `RPCHandler.GetPR`
+
+Fetches a pull request from GitHub and returns it as rendered content (including diff, comments, conversations). Cached data is used where available; see `SyncPR` for a forced refresh.
+
+This is a read-only query as far as the caller is concerned: it never blocks on plugin execution or LLM analysis. Those are dispatched in the background, and their results arrive through `GetPluginOutput` (or on a later `GetPR`'s `annotations`).
+
+**Arguments** (`GetPRstructArgs`):
+| Field       | Type   | Required | Description                          |
+|-------------|--------|----------|--------------------------------------|
+| `Owner`     | string | Yes      | Repository owner (e.g., `"octocat"`) |
+| `Repo`      | string | Yes      | Repository name (e.g., `"hello"`)    |
+| `Number`    | int    | Yes      | Pull request number                  |
+| `SkipCache` | bool   | No       | If `true`, bypass the DB caches and fetch from GitHub |
+
+**Reply** (`GetPRReply`): [the PR payload](#the-pr-payload), with no extra fields.
 
 ---
 
@@ -190,9 +241,7 @@ Fetches the next or previous pull request relative to the given PR in the sorted
 | `SkipCache`| bool   | No       | If `true`, bypass cached data for the adjacent PR        |
 | `Previous` | bool   | No       | If `true`, return the previous PR; if `false` (default), return the next PR |
 
-**Reply** (`GetAdjacentPRReply`):
-
-All fields from `GetPRReply` (see above), plus:
+**Reply** (`GetAdjacentPRReply`): [the PR payload](#the-pr-payload), plus:
 
 | Field              | Type   | Description                                           |
 |--------------------|--------|-------------------------------------------------------|
@@ -224,7 +273,10 @@ All fields from `GetPRReply` (see above), plus:
     "diff": "...",
     "comments": [],
     "outdated_comments": [],
-    "reviews": []
+    "reviews": [],
+    "commits": [],
+    "feedback": "",
+    "annotations": []
   },
   "error": null,
   "id": 2
@@ -244,17 +296,63 @@ Forces a fresh fetch of the pull request from GitHub, bypassing any cache.
 | `Repo`   | string | Yes      | Repository name                      |
 | `Number` | int    | Yes      | Pull request number                  |
 
-**Reply** (`SyncPRReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `Okay`     | bool         | `true` if the request succeeded                 |
-| `updated`  | bool         | `true` if the sync pulled in a new head SHA or new comments compared to the previously cached state |
-| `Content`  | string       | Formatted PR response (freshly fetched)         |
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
+**Reply** (`SyncPRReply`): [the PR payload](#the-pr-payload), freshly fetched, plus:
+
+| Field     | Type | Description                                                                                         |
+|-----------|------|-----------------------------------------------------------------------------------------------------|
+| `updated` | bool | `true` if the sync pulled in a new head SHA or new comments compared to the previously cached state |
+
+---
+
+### `RPCHandler.GetHunkContext`
+
+Returns extra context lines immediately before or after a hunk boundary, so a client can expand the visible context around a diff without fetching the whole file.
+
+The lines come back as plain text, without the leading space that marks a context line in a unified diff — a client splicing them into a diff adds that itself. They are **not** part of the PR's canonical diff, so they must not consume a comment `position`: counting them would shift the position of every line below the expansion, and comments created while expanded would be stored against a position that no longer exists once the canonical diff is restored.
+
+**Arguments** (`GetHunkContextArgs`):
+| Field        | Type   | Required | Description                                                                 |
+|--------------|--------|----------|-----------------------------------------------------------------------------|
+| `Owner`      | string | Yes      | Repository owner                                                            |
+| `Repo`       | string | Yes      | Repository name                                                             |
+| `Number`     | int    | Yes      | Pull request number                                                         |
+| `Filename`   | string | Yes      | Path of the file within the repo                                            |
+| `Side`       | string | Yes      | Which version of the file to read from: `"old"` or `"new"`                   |
+| `AnchorLine` | int    | Yes      | 1-based line number **in the file** (not a diff position) to expand from. With `Direction: "before"`, lines above it are returned; with `"after"`, lines below it |
+| `Direction`  | string | Yes      | `"before"` or `"after"`                                                     |
+| `Count`      | int    | No       | Number of extra lines to fetch. Defaults to 20, capped at 100                |
+| `OrigStart`  | int    | Yes      | Current hunk's `@@ -OrigStart,OrigLength`                                    |
+| `OrigLength` | int    | Yes      | Current hunk's old-side length                                              |
+| `NewStart`   | int    | Yes      | Current hunk's `@@ +NewStart,NewLength`                                      |
+| `NewLength`  | int    | Yes      | Current hunk's new-side length                                              |
+| `HunkHeader` | string | No       | Text after the `@@` in the current hunk header (e.g. the enclosing function), preserved in the rewritten header |
+
+The four range fields and `HunkHeader` describe the hunk as it currently stands; the server uses them to compute the header the hunk should carry once expanded.
+
+**Reply** (`GetHunkContextReply`):
+| Field          | Type     | Description                                                        |
+|----------------|----------|--------------------------------------------------------------------|
+| `lines`        | []string | The extra context lines                                            |
+| `start_line`   | int      | 1-based line number of the first returned line                     |
+| `end_line`     | int      | 1-based line number of the last returned line                      |
+| `range_header` | string   | Updated `@@ -a,b +c,d @@` header for the expanded hunk; a client replaces the existing hunk header with this |
+
+`Direction` and `Side` are validated, and `AnchorLine` must be at least 1 — anything else is returned as an RPC error.
+
+**Example Request** (20 lines above a hunk starting at line 42 of the head file):
+```json
+{
+  "method": "RPCHandler.GetHunkContext",
+  "params": [{
+    "Owner": "octocat", "Repo": "Hello-World", "Number": 42,
+    "Filename": "server/server.go",
+    "Side": "new", "AnchorLine": 42, "Direction": "before", "Count": 20,
+    "OrigStart": 40, "OrigLength": 6, "NewStart": 42, "NewLength": 8,
+    "HunkHeader": "func (h *RPCHandler) GetPR("
+  }],
+  "id": 9
+}
+```
 
 ---
 
@@ -273,16 +371,11 @@ Adds a new local (pending) comment to a pull request. The comment is stored loca
 | `Body`      | string  | Yes      | Comment body text                                        |
 | `ReplyToID` | *int64  | No       | If replying to an existing comment, the comment ID       |
 
-**Reply** (`AddCommentReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `ID`       | int64        | Local ID of the newly created comment           |
-| `Content`  | string       | Formatted updated PR content                    |
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
+**Reply** (`AddCommentReply`): [the PR payload](#the-pr-payload), plus:
+
+| Field | Type  | Description                           |
+|-------|-------|---------------------------------------|
+| `id`  | int64 | Local ID of the newly created comment |
 
 ---
 
@@ -299,16 +392,7 @@ Edits an existing local (pending) comment.
 | `ID`     | int64  | Yes      | Local comment ID to edit             |
 | `Body`   | string | Yes      | New body text for the comment        |
 
-**Reply** (`EditCommentReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `Okay`     | bool         | `true` if the edit succeeded                    |
-| `Content`  | string       | Formatted updated PR content                    |
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
+**Reply** (`EditCommentReply`): [the PR payload](#the-pr-payload), with no extra fields.
 
 ---
 
@@ -324,16 +408,7 @@ Deletes a local (pending) comment.
 | `Number` | int    | Yes      | Pull request number                  |
 | `ID`     | int64  | Yes      | Local comment ID to delete           |
 
-**Reply** (`DeleteCommentReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `Okay`     | bool         | `true` if deletion succeeded                    |
-| `Content`  | string       | Formatted updated PR content                    |
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
+**Reply** (`DeleteCommentReply`): [the PR payload](#the-pr-payload), with no extra fields.
 
 ---
 
@@ -349,16 +424,11 @@ Sets the top-level feedback/review body for a pull request.
 | `Number` | int    | Yes      | Pull request number                  |
 | `Body`   | string | Yes      | Feedback/review body text            |
 
-**Reply** (`SetFeedbackReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `ID`       | int64        | ID of the feedback entry                        |
-| `Content`  | string       | Formatted updated PR content                    |
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
+**Reply** (`SetFeedbackReply`): [the PR payload](#the-pr-payload) — whose `feedback` field carries the body just saved — plus:
+
+| Field | Type  | Description              |
+|-------|-------|--------------------------|
+| `id`  | int64 | ID of the feedback entry |
 
 ---
 
@@ -373,16 +443,7 @@ Removes all local (pending) comments for a specific pull request.
 | `Repo`   | string | Yes      | Repository name                      |
 | `Number` | int    | Yes      | Pull request number                  |
 
-**Reply** (`RemovePRCommentsReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `Okay`     | bool         | `true` if removal succeeded                     |
-| `Content`  | string       | Formatted updated PR content                    |
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
+**Reply** (`RemovePRCommentsReply`): [the PR payload](#the-pr-payload), with no extra fields.
 
 ---
 
@@ -409,16 +470,7 @@ Submits a review to GitHub. This will:
 | `Event`  | string | Yes      | Review event type: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` |
 | `Body`   | string | No       | Top-level review body (optional)                         |
 
-**Reply** (`SubmitReviewReply`):
-| Field      | Type         | Description                                     |
-|------------|--------------|-------------------------------------------------|
-| `Okay`     | bool         | `true` if submission succeeded                  |
-| `Content`  | string       | Formatted updated PR content                    |
-| `metadata` | PRMetadata   | Structured PR metadata                          |
-| `diff`     | string       | Raw diff content                                |
-| `comments` | []CommentJSON| List of structured PR active comments           |
-| `outdated_comments` | []CommentJSON| List of structured PR outdated comments   |
-| `reviews`  | []ReviewJSON | List of submitted reviews                       |
+**Reply** (`SubmitReviewReply`): [the PR payload](#the-pr-payload), with no extra fields.
 
 ---
 
@@ -538,6 +590,40 @@ Retrieves the output and status of all plugins for a specific pull request.
 | `line`     | int    | 1-based line number the annotation applies to        |
 | `severity` | string | Free-form severity, e.g. `info`, `warning`, `error`  |
 | `content`  | string | The annotation text                                  |
+
+---
+
+### `RPCHandler.RerunPlugins`
+
+Clears cached plugin results for a pull request and runs the plugins again, bypassing the head-SHA cache check that normally makes a plugin skip a PR it has already seen.
+
+Execution happens in the background: the reply means the rerun was **accepted**, not that it finished. Poll `GetPluginOutput` for results — a plugin that is still running reports `pending`.
+
+**Arguments** (`RerunPluginsArgs`):
+| Field     | Type     | Required | Description                                                           |
+|-----------|----------|----------|------------------------------------------------------------------------|
+| `Owner`   | string   | Yes      | Repository owner                                                      |
+| `Repo`    | string   | Yes      | Repository name                                                       |
+| `Number`  | int      | Yes      | Pull request number                                                   |
+| `Plugins` | []string | No       | Names of specific plugins to rerun. Omitted or empty reruns all of them |
+
+**Reply** (`RerunPluginsReply`):
+| Field     | Type                    | Description                                              |
+|-----------|-------------------------|-----------------------------------------------------------|
+| `okay`    | bool                    | `true` if the rerun was accepted                          |
+| `message` | string                  | Human-readable status                                     |
+| `output`  | map[string]PluginOutput | Plugin results as they stood when the rerun was dispatched; see `GetPluginOutput` |
+
+Because dispatch is asynchronous, `output` will generally still show the cleared or previous state. Treat `GetPluginOutput` as the source of truth once the rerun has been accepted.
+
+**Example Request** (rerun a single plugin):
+```json
+{
+  "method": "RPCHandler.RerunPlugins",
+  "params": [{"Owner": "octocat", "Repo": "Hello-World", "Number": 42, "Plugins": ["security_check"]}],
+  "id": 10
+}
+```
 
 ---
 
@@ -777,6 +863,13 @@ A typical code review workflow using this API:
 6. **Sync**: Use `SyncPR` to fetch the latest state after submission
 7. **Navigate**: Use `GetAdjacentPR` to move to the next or previous PR in the review queue without returning to the list; navigation wraps around at both ends
 
+Alongside that loop:
+
+- **Expand context**: `GetHunkContext` fetches lines around a hunk boundary when the diff's own context isn't enough to judge a change.
+- **Plugin results**: `GetPluginOutput` polls for plugin results, which arrive asynchronously; `RerunPlugins` forces a re-execution.
+
+Steps 2–5 each return [the PR payload](#the-pr-payload) in full, so a client can apply the reply directly rather than tracking which parts of its local state a mutation invalidated.
+
 ---
 
 ## Error Handling
@@ -811,8 +904,9 @@ Errors are returned in the standard JSON-RPC format. Common error scenarios:
       "title": "Example PR",
       "author": "octocat",
       "state": "open",
-      "worktree_path": "/home/user/code/repo_worktrees/42_branch",
-      "description": "PR description..."
+      "body": "PR description...",
+      "repo_path": "/home/user/code/Hello-World",
+      "worktree_path": "/home/user/code/repo_worktrees/42_branch"
     },
     "diff": "--- a/file.txt\n+++ b/file.txt\n...",
     "comments": [
@@ -835,6 +929,25 @@ Errors are returned in the standard JSON-RPC format. Common error scenarios:
         "state": "APPROVED",
         "submitted_at": "2023-01-01T12:05:00Z",
         "html_url": "https://github.com/..."
+      }
+    ],
+    "commits": [
+      {
+        "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        "message": "Fix the thing",
+        "author": "octocat",
+        "date": "2023-01-01T11:00:00Z",
+        "url": "https://github.com/..."
+      }
+    ],
+    "feedback": "Draft review body saved locally, not yet submitted",
+    "annotations": [
+      {
+        "plugin": "security_check",
+        "filename": "file.txt",
+        "line": 12,
+        "severity": "warning",
+        "content": "Unvalidated input reaches the query"
       }
     ]
   },

--- a/docs/web_client_features.md
+++ b/docs/web_client_features.md
@@ -8,14 +8,10 @@ It is a **feature list**, not an API spec. Every server call named here is defin
 the [Protocol](protocol.md); read that document alongside this one. The general rules
 for spawning and talking to the server live in [Building Clients](building_clients.md).
 
-Two things worth knowing before you start:
-
-- The Go server speaks **JSON-RPC 1.0 over stdio only**. There is no HTTP server in
-  the Go binary. Any web client needs a process that owns the child process and
-  bridges it to the browser — that is what `bun_client/server.ts` is.
-- A handful of methods the web client relies on (`GetHunkContext`, `RerunPlugins`)
-  are not yet in [protocol.md](protocol.md); they are documented in
-  [Calls not yet in protocol.md](#calls-not-yet-in-protocolmd) below.
+One thing worth knowing before you start: the Go server speaks **JSON-RPC 1.0 over
+stdio only**. There is no HTTP server in the Go binary. Any web client needs a
+process that owns the child process and bridges it to the browser — that is what
+`bun_client/server.ts` is.
 
 ---
 
@@ -434,38 +430,29 @@ gaps if you're building a more complete one:
 | `Hello` | Health check / connection probe. |
 | `RemovePRComments` | "Discard all pending comments" button. |
 
-### Calls not yet in protocol.md
+### Two calls beyond the core review loop
 
-Two methods the web client depends on are missing from [protocol.md](protocol.md).
-Until it catches up, `server/server.go` is the source of truth.
+Both are documented in the protocol, but are easy to miss when scanning it for the
+basics:
 
-**`RPCHandler.GetHunkContext`** — extra context lines around a hunk boundary, so a
-client can expand a diff without fetching the whole file.
+- [`GetHunkContext`](protocol.md#rpchandlergethunkcontext) — extra context lines
+  around a hunk boundary, so a diff can be expanded without fetching the whole file.
+  Powers the ↑/↓ buttons on hunk headers.
+- [`RerunPlugins`](protocol.md#rpchandlerrerunplugins) — clears cached plugin results
+  and re-executes. The reply means "accepted", not "finished": poll
+  `GetPluginOutput` for results.
 
-Args: `Owner`, `Repo`, `Number`, `Filename`, `Side` (`"old"` or `"new"`),
-`AnchorLine` (1-based, in the file, not the diff), `Direction` (`"before"` or
-`"after"`), `Count` (defaults to 20, capped at 100), plus the current hunk range
-(`OrigStart`, `OrigLength`, `NewStart`, `NewLength`, `HunkHeader`) so the server can
-compute the updated header.
+### Reply fields worth knowing about
 
-Reply: `lines` (`[]string`), `start_line`, `end_line`, `range_header` (the rewritten
-`@@ -a,b +c,d @@` line for the expanded hunk).
-
-**`RPCHandler.RerunPlugins`** — clears cached plugin results and re-executes.
-
-Args: `Owner`, `Repo`, `Number`, `Plugins` (optional; empty means all).
-Reply: `okay`, `message`, `output`. Execution happens in a background goroutine — the
-reply means "accepted", not "finished", so poll `GetPluginOutput` for results.
-
-### Reply fields the client relies on
-
-Two fields the client depends on aren't in protocol.md's `PRMetadata` /
-`GetPRReply` tables either:
-
-- `metadata.repo_path` — absolute path to the local clone. The client uses it to gate
-  LSP and the code viewer; distinct from the documented `worktree_path`.
-- `feedback` (top level) — the saved review feedback draft, returned alongside the PR
-  so the client can restore it.
+- [`metadata.repo_path`](protocol.md#prmetadata-object) — absolute path to the local
+  clone, distinct from `worktree_path`. The client uses it to gate LSP and the code
+  viewer.
+- [`feedback`](protocol.md#the-pr-payload) — the saved review feedback draft,
+  returned with every PR payload so the client can restore the in-progress draft.
+- [`annotations`](protocol.md#the-pr-payload) — plugin annotations aggregated
+  server-side. The client derives its own from the plugin outputs instead (see
+  [3.10](#310-plugin-annotations-in-the-diff-annotation_utilsts)), but this field is
+  there for clients that don't poll plugins separately.
 
 ---
 

--- a/docs/web_client_features.md
+++ b/docs/web_client_features.md
@@ -1,0 +1,549 @@
+# Web Client Feature Reference (`bun_client`)
+
+This document inventories everything the shipped web client (`bun_client/`) does, so
+another engineer can build a web-based client of their own — a VS Code webview, a
+Next.js app, a different SPA — without reverse-engineering the existing one.
+
+It is a **feature list**, not an API spec. Every server call named here is defined in
+the [Protocol](protocol.md); read that document alongside this one. The general rules
+for spawning and talking to the server live in [Building Clients](building_clients.md).
+
+Two things worth knowing before you start:
+
+- The Go server speaks **JSON-RPC 1.0 over stdio only**. There is no HTTP server in
+  the Go binary. Any web client needs a process that owns the child process and
+  bridges it to the browser — that is what `bun_client/server.ts` is.
+- A handful of methods the web client relies on (`GetHunkContext`, `RerunPlugins`)
+  are not yet in [protocol.md](protocol.md); they are documented in
+  [Calls not yet in protocol.md](#calls-not-yet-in-protocolmd) below.
+
+---
+
+## 1. Architecture
+
+```
+browser (React SPA)
+    │  HTTP POST /api/*        (JSON)
+    │  WebSocket /api/lsp*     (LSP framing)
+    ▼
+bun_client/server.ts           ← the bridge; owns the child process
+    │  stdin/stdout, newline-delimited JSON-RPC 1.0
+    ▼
+codereviewserver --server      (spawned as `crs --server`)
+```
+
+**`server.ts`** — a Bun HTTP + WebSocket server (default port `5172`, override with
+`CRS_PORT`). Responsibilities:
+
+1. Spawn the backend once at startup (`Bun.which('crs')`, falling back to `crs`),
+   with `stdin: 'pipe'`, `stdout: 'pipe'`, `stderr: 'inherit'`, inheriting the
+   parent environment (so `CRS_GITHUB_TOKEN` flows through).
+2. Multiplex concurrent RPC calls over the single stdio pipe. Each request gets a
+   unique id; replies are matched back to a pending-promise map.
+3. Frame the response stream. `rpc_framing.ts` (`JsonRpcLineParser`) splits stdout on
+   newlines — Go's `net/rpc/jsonrpc` writes exactly one JSON object per line and
+   escapes newlines inside strings, so line splitting frames the stream exactly. It
+   buffers partial chunks, so a large diff split across reads reassembles correctly.
+4. Serve the frontend: dev-mode proxy to Vite (`localhost:5173`), then embedded
+   assets, then `frontend/dist` on disk, then an SPA fallback to `index.html`.
+5. Provide the non-RPC endpoints the browser can't do itself: local file reads,
+   repository file listing, and LSP WebSocket proxying.
+
+**`frontend/`** — React 19 + Vite SPA. Dependencies are deliberately thin:
+`react-markdown` and `react-syntax-highlighter` (Prism) are the only runtime ones.
+The UI is built on a small in-repo design system (`frontend/src/design/`) rather than
+a component library.
+
+**Packaging** — `bun run build` builds the frontend, generates
+`embedded_assets.ts` (`scripts/build.ts` walks `frontend/dist` and emits
+`import … with { type: 'file' }` entries), then compiles a single `crs-gui` binary
+with `bun build --compile`. A client that wants single-binary distribution can copy
+this pattern; if you don't, `server.ts` still serves from `frontend/dist`.
+
+### If you are building your own client
+
+You need the same three responsibilities, however you split them:
+
+- **Process ownership** — one long-lived `codereviewserver --server` child. Spawning
+  one per request is wasteful (the server caches in SQLite and holds GitHub rate
+  limit state) and racy.
+- **Request multiplexing** — the stdio pipe is shared; correlate by JSON-RPC `id`.
+- **Line framing** — do not assume one read = one message, in either direction.
+
+---
+
+## 2. HTTP surface exposed to the browser
+
+Everything below is served by `server.ts`. CORS is wide open (`*`), which is what
+lets the Vite dev server on `:5173` talk to the bridge on `:5172`.
+
+### RPC pass-through endpoints
+
+Each is a thin `POST` wrapper: the JSON body is forwarded verbatim as the single RPC
+parameter, and the reply is returned as `{ "result": … }` (or `{ "error": … }` with
+status 500).
+
+| Endpoint | RPC method | Notes |
+|---|---|---|
+| `/api/reviews` | `RPCHandler.GetAllReviews` | No body; sends `{}` |
+| `/api/get-pr` | `RPCHandler.GetPR` | |
+| `/api/get-adjacent-pr` | `RPCHandler.GetAdjacentPR` | |
+| `/api/sync-pr` | `RPCHandler.SyncPR` | |
+| `/api/add-comment` | `RPCHandler.AddComment` | |
+| `/api/edit-comment` | `RPCHandler.EditComment` | |
+| `/api/delete-comment` | `RPCHandler.DeleteComment` | |
+| `/api/remove-pr-comments` | `RPCHandler.RemovePRComments` | Bridged but unused by the current UI |
+| `/api/set-feedback` | `RPCHandler.SetFeedback` | |
+| `/api/submit-review` | `RPCHandler.SubmitReview` | |
+| `/api/list-plugins` | `RPCHandler.ListPlugins` | `GET` or `POST`; bridged but unused by the current UI |
+| `/api/get-plugin-output` | `RPCHandler.GetPluginOutput` | `GET` (query params `owner`/`repo`/`number`) or `POST` |
+| `/api/rerun-plugins` | `RPCHandler.RerunPlugins` | |
+| `/api/get-hunk-context` | `RPCHandler.GetHunkContext` | |
+| `/api/get-config` | `RPCHandler.GetConfig` | `GET` or `POST` |
+| `/api/update-config` | `RPCHandler.UpdateConfig` | |
+| `/api/rpc` | *any* | Generic escape hatch: `{ method, params, id }` |
+
+The frontend's `api.ts` routes known methods to their specialized path and falls back
+to `/api/rpc` for anything else, so **any** protocol method is reachable from the
+browser without touching `server.ts`. If you build a bridge, `/api/rpc` alone is a
+viable minimum; the specialized routes exist mostly for readability.
+
+### Non-RPC endpoints (bridge-local capabilities)
+
+These have no server-side RPC equivalent — they are the bridge doing local work the
+browser cannot. Reproduce them if you want the corresponding features.
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/read-file` | Read a file from disk. Accepts an absolute `filePath`, or `repoPath` + relative `filePath` (rejects paths that escape `repoPath`). Powers the code viewer. |
+| `POST /api/list-files` | Recursive file listing under `repoPath`, skipping `node_modules`, `.git`, `.next`, `dist`. Powers the code viewer's file tree. |
+| `GET /api/check-lsp` | Whether the `diff-lsp` binary is on `PATH`. |
+| `GET /api/check-lsp-file?lang=` | Whether a per-language server is on `PATH`. |
+| `POST /api/prepare-diff-lsp` | Writes the diff plus a `Project/Root/Worktree/Buffer/Type` header to a temp file and returns its path; `diff-lsp` consumes that file. |
+| `WS /api/lsp` | Proxies a `diff-lsp` process. |
+| `WS /api/lsp-file?lang=` | Proxies a plain language server (`gopls`, `typescript-language-server`, `rust-analyzer`, `pyright-langserver`), resolved at startup. |
+
+The WebSocket handlers translate between browser JSON messages and LSP's
+`Content-Length` framing in both directions, and kill the child process on close.
+
+---
+
+## 3. Feature inventory
+
+### 3.1 Review list (`PRList.tsx`)
+
+The landing view. Backed by a single `GetAllReviews` call; the client uses the
+structured `items` array (not the org-mode `content` string).
+
+- **Sectioned list** — items grouped by `item.section`, ungrouped items land in
+  "Other". Each section is collapsible, with a count badge, plus global
+  Collapse All / Expand All.
+- **Per-item card** — status badge (`TODO` / `WAITING` / `DONE`, mapped to a color
+  variant), `review_ease` badge when the LLM rating is enabled, title,
+  `owner/repo #number`, and author.
+- **Non-PR items** — items with `number <= 0` render as "Non-PR item" and are not
+  clickable.
+- **Actions per row** — Review (open in-app), Plugins (open the plugin view),
+  GitHub (open `item.url` in a new tab).
+- **Text filter** — matches title, author, owner, or repo.
+- **GitHub URL paste** — pasting `https://github.com/{owner}/{repo}/pull/{n}` into the
+  filter box opens that review directly instead of filtering.
+- **Faceted dropdowns** — Status (static list) plus Author / Owner / Repo, whose
+  options are derived from the loaded items. Clear-all button and a
+  "Showing N of M items" counter appear when any filter is active.
+- **Manual open form** — owner / repo / number, for PRs not in any section.
+- **Refresh** — re-issues `GetAllReviews`.
+- **Plugin warm-up** — after loading, the list fires a `GetPluginOutput` call for
+  every visible PR and ignores the results. This is deliberate: it starts deferred
+  plugin execution server-side so output is ready by the time a PR is opened.
+
+### 3.2 Routing and navigation (`App.tsx`)
+
+- **URL-driven state** — `?owner=&repo=&number=` opens the review view;
+  `&view=plugins` opens the plugin view. Set via `history.pushState`, and a
+  `popstate` listener makes browser back/forward work.
+- **Deep links** — any review is a shareable URL; the PR header has a Copy URL button.
+- **Modifier-aware links** — list rows and the home link are real `<a>` elements;
+  ctrl/cmd/shift/alt clicks fall through to normal browser behavior, plain clicks are
+  intercepted for SPA navigation.
+- **Prev / Next PR** — header buttons calling `GetAdjacentPR` with `Previous`
+  true/false. Navigation state is taken from `adjacent_owner` / `adjacent_repo` /
+  `adjacent_number` in the reply (never parsed out of `metadata.url`), and wraps at
+  both ends.
+- **Dynamic document title** — `Code Review` on the list, `{title} (#{number})` in a
+  review, `Plugins {owner}/{repo}::{number}` in the plugin view.
+
+### 3.3 PR header (`PRHeader.tsx`)
+
+Rendered from `GetPR`'s `metadata`:
+
+- State pill (open / closed / merged, or a Draft badge) and PR number.
+- Info grid: base ← head branch, author, CI status (color-coded by
+  success / pending / failure), requested reviewers and requested teams,
+  approved-by, changes-requested-by, commented-by.
+- Labels, assignees, milestone row.
+- Collapsible markdown description, with HTML comments stripped (PR templates are
+  full of them). Expanded by default.
+- CI failure list when `ci_failures` is non-empty.
+- Links out: GitHub button and Copy URL button.
+
+### 3.4 Review discussion (`ReviewDiscussion.tsx`)
+
+Chronological list of submitted reviews from `reviews[]` that have a body, rendered
+as markdown with the reviewer's state. Collapsed by default so the diff stays near
+the top.
+
+### 3.5 Diff rendering (`DiffView.tsx`, `diff_utils.ts`)
+
+This is the most intricate part of the client, and the part most worth copying
+carefully.
+
+**Parsing** — `parseDiff()` turns the raw unified diff into `ParsedLine[]`, tracking
+for every line: text, file, GitHub comment `position`, clickability, line type
+(`file-header` / `hunk` / `addition` / `deletion` / `code` / `skip`), file status
+(modified / new / deleted / renamed, with the original name for renames), the index
+into the raw diff, and both old- and new-side line numbers.
+
+Position accounting mirrors the backend exactly, and getting it wrong silently
+misplaces comments:
+
+- Position resets at each file. The **first** hunk header of a file does not consume
+  a position (matching the server's reset to 0); every subsequent hunk header does,
+  but hunk headers are never valid comment targets.
+- A file header carries `pos: 0`, which is how a whole-file comment is expressed.
+- Unrecognized lines default to `skip` and are dropped, so `git`'s metadata lines,
+  `\ No newline at end of file`, and the trailing empty string from `split('\n')`
+  never become phantom rows.
+- Renames, quoted paths, `/dev/null` on either side, and files with no `+++` header
+  all have explicit handling.
+
+**Rendering**:
+
+- Per-line syntax highlighting via Prism, with the language inferred from the file
+  extension (a ~60-entry map plus special cases for `Dockerfile`, `Makefile`,
+  `*.d.ts`). Files with more than `MAX_HIGHLIGHT_LINES_PER_FILE` (2000) changed lines
+  fall back to plain text so large diffs stay responsive.
+- Old/new line-number gutters, a `+`/`−` gutter, and per-file `+n/−m` counts.
+- Test files sort last (`sortParsedLinesTestsLast`) — `*.test.*`, `*.spec.*`,
+  `*_test.go`, `__tests__/`.
+- Per-file collapse plus Collapse All / Expand All.
+- Sticky file headers and hunk headers. `Review.tsx` measures the toolbar and one
+  file row with a `ResizeObserver` and publishes `--review-sticky-top` and
+  `--review-hunk-sticky-top`, so headers pin correctly at any font size. Each file's
+  rows are wrapped in a section element, which scopes the sticky containing block so
+  a header scrolls away with its own file.
+- Line wrap toggle (wrap on by default on mobile, off on desktop).
+- **Hunk expansion** — ↑ / ↓ buttons on each hunk header fetch more context via
+  `GetHunkContext` and splice it into the diff text. Expanded lines are tracked in
+  `expandedLineIndices` and passed back into `parseDiff`, where they render and
+  advance the line-number gutters but **do not consume a comment position** — they
+  aren't in the canonical diff, so counting them would shift every position below.
+- **File index** — a pill bar above the diff listing every changed file with its
+  status icon and `+/−` counts; clicking scrolls to that file, expanding it first,
+  with a flash highlight on arrival.
+- **Mobile layout** — the whole diff becomes a horizontally scrollable
+  `width: max-content` block so long lines can be read; inline cards are pinned to
+  the left edge with `position: sticky` so they stay readable while scrolled.
+
+### 3.6 Comments
+
+Local (pending) comments are stored server-side until the review is submitted; the
+client treats `author === 'local'` as "mine, still editable".
+
+- **Inline comment on any line** — clicking the `+`/`−` gutter opens an inline form
+  anchored to that row, pre-filled with the file and position.
+- **File-level comment** — clicking a file header comments on the file (position 0).
+- **Free-form comment modal** — the toolbar's `+ Comment` opens a modal where file
+  and position are typed manually.
+- **Threading** — comments are grouped by root (`in_reply_to`). Clicking a thread
+  replies to its last comment; clicking a local thread edits it instead.
+- **Collapsed by default** — threads render as a small indicator badge next to the
+  line, in a fixed-width gutter left of the line numbers so the diff never shifts.
+  Hovering previews the thread; clicking expands every thread on that row.
+- **Edit / delete** local comments; newly added comments auto-expand their thread.
+- **Outdated comments** — surfaced per file via a warning button on the file header,
+  which opens a right-hand drawer listing each outdated comment with its stored
+  `diff_hunk` as syntax-highlighted context.
+- **Review feedback draft** — a collapsible PR-level body persisted with
+  `SetFeedback`, which pre-fills the Submit Review modal.
+
+Calls used: `AddComment`, `EditComment`, `DeleteComment`, `SetFeedback`. Each returns
+a full refreshed PR payload, which the client applies wholesale rather than patching
+local state.
+
+### 3.7 Submitting a review
+
+- Modal with Comment / Approve / Request Changes and an optional body, pre-filled
+  from the saved feedback draft.
+- On mobile, a sticky bottom bar with thumb-sized Approve / Request / Comment buttons
+  that open the same modal pre-set to the chosen event.
+- After `SubmitReview` succeeds, the client immediately runs a `SyncPR` to pick up the
+  server-side state (local comments are gone, the review is on GitHub, section
+  membership may have changed).
+
+### 3.8 Sync
+
+The toolbar's Sync button calls `SyncPR` and reports the result through a transient
+toast, distinguishing "new commits or comments pulled in" from "already up to date"
+using the reply's `updated` flag. Plugin outputs are reloaded at the same time.
+
+### 3.9 Plugins
+
+Two surfaces, both reading `GetPluginOutput` (a `{pluginName: PluginOutput}` map):
+
+- **Plugins drawer** in the review view — right-hand drawer with each plugin's status
+  badge, rendered body, annotation list, and a Re-run / Execute button.
+- **Full-page plugin view** — reachable from the list's Plugins button or
+  `?view=plugins`, same content with more room.
+
+Behavior worth reproducing:
+
+- **Body contract** (`plugin_utils.ts`) — a plugin's `body` may be `markdown` or
+  `html`. Trust the server when it sends a recognized `body_type`, *including* an
+  empty body (annotations-only plugins are legitimate); fall back to rendering raw
+  `result` as markdown only when the body is missing or its type is unrecognized.
+- **Status handling** — `pending`, `success`, `error`, `deferred`. A `deferred` plugin
+  has never run and gets an **Execute** button; a `pending` one is in flight and gets
+  neither; everything else gets **Re-run**. Unknown future statuses are treated as
+  re-runnable rather than hidden.
+- **Re-run** uses `RerunPlugins` with a `Plugins: [name]` list, then re-polls
+  `GetPluginOutput`.
+
+### 3.10 Plugin annotations in the diff (`annotation_utils.ts`)
+
+Plugins can emit line-level annotations, and the client anchors them to diff rows:
+
+- Annotations are collected from the **loaded plugin outputs** (successful runs only),
+  not from the PR payload's identical `annotations` field, so re-running a plugin
+  refreshes the diff without a full PR reload. The payload field exists for clients
+  that don't load plugin output separately.
+- Matching is on the **head-side (new) line number**, since plugins read the PR head.
+  A leading `./` in a plugin's path is normalized away; anything else must match the
+  diff's path exactly.
+- Annotations pointing at a line the diff doesn't render (an unchanged region, or a
+  base-only line) fall back to a per-file bucket on the file header rather than
+  vanishing. Annotations for files not in the diff are dropped from the diff view and
+  remain visible in the plugins drawer.
+- Collapsed by default behind a badge pinned to the right edge of the row; the badge
+  takes the most severe variant in its bucket. Severity is free-form — `error` /
+  `critical` / `high` → danger, `warning` / `warn` / `medium` → warning, `info` /
+  `note` / `low` → info, anything else neutral.
+- A toolbar button expands or collapses every annotation at once, with a total count.
+
+### 3.11 LSP integration (`useLsp.ts`, `lsp.ts`, `LspPopover.tsx`)
+
+Optional, and degrades cleanly when the binaries or the local clone aren't there.
+
+- **Diff mode** — if `diff-lsp` is on `PATH` and `metadata.repo_path` exists, the
+  client posts the diff to `/api/prepare-diff-lsp`, opens the returned file over the
+  `/api/lsp` WebSocket, and clicking a code line issues hover, references,
+  definition, and typeDefinition in parallel. Coordinates are offset for the
+  five-line context header and the diff's `+`/`-` prefix column; the clicked column
+  is computed from the click's pixel position.
+- **File mode** — inside the code viewer, connects to a real language server for that
+  file's language via `/api/lsp-file?lang=`.
+- **Popover** — inline (inside the comment form) or floating, listing hover text,
+  definitions, type definitions and references. Clicking a reference opens a code
+  viewer at that file and line.
+- **Degradation** — the diff header shows "Repo not found locally. LSP disabled." or
+  "LSP not active" instead of failing.
+
+### 3.12 Code viewer and docking (`CodeViewerModal.tsx`, `dock_utils.ts`)
+
+- **Floating viewer** — draggable, resizable window showing a full source file with
+  syntax highlighting, virtualized rendering (`VirtualizedCodeBlock`) for large files,
+  jump-to-line, a browsable/expandable file tree from `/api/list-files`, and its own
+  LSP session. Full-screen and non-draggable on phones.
+- **Docking** — drag a floating viewer onto the dock zone, or click ⊞ on a file header
+  to open that file's diff as a tab. Tabs live beside a permanent "Review" tab.
+- **Split view** — two side-by-side panels; tabs can be dragged between them
+  (`application/x-tab` drag payload). Turning split off merges the right panel into
+  the left. Split is force-disabled on phones.
+- The docking state machine is pure and separately unit-tested (`dock_utils.test.ts`)
+  — worth reading if you implement something similar.
+
+### 3.13 Server configuration editor (`ConfigManager.tsx`, `config_utils.ts`)
+
+A full editor for `~/.config/codereviewserver.toml`, in the Preferences → Server
+Configuration tab. Built on `GetConfig` / `UpdateConfig`.
+
+- Global settings: repos, sync interval, GitHub username, repo location, Jira domain,
+  auto-worktree, desktop notifications.
+- Workflow list: collapsible cards, add / delete (with confirmation) / reorder.
+- **Pickers are built from the reply's `workflow_types` and `filters` registries**, not
+  hard-coded — so the editor keeps working when the server gains a type or filter.
+  Fields not used by the selected workflow type are hidden, and filters that require
+  an argument get a second input.
+- Validation runs client-side for immediate feedback and again on the server; both
+  produce the same `{workflow, field, message}` shape, and messages are attached to
+  the offending field. Messages stay hidden until the first save attempt.
+- Server-side rejections (`okay: false` with `errors`) are rendered as field errors,
+  not as an opaque failure. Stale server errors clear as soon as the draft changes.
+- Dirty tracking, so Save is meaningful.
+
+### 3.14 Preferences and theming
+
+Client-side only, persisted in `localStorage`:
+
+- **Theme** — 21 options (One Dark/Light, GitHub, Gruvbox, Solarized, Monokai,
+  Dracula, Nord, Night Owl, Tokyo Night, the four Catppuccins, Everforest, Rosé Pine,
+  SynthWave '84), applied as `data-theme` on `<html>` with CSS custom
+  properties; initial value follows `prefers-color-scheme`. Legacy stored values are
+  migrated through `resolveTheme`. The Prism diff theme is derived from the active
+  theme.
+- **Preferred review location** — clicking a PR title opens it in-app or on GitHub.
+- **Diff font size** — five steps published as `--diff-font-size`; line numbers,
+  gutters and hunk headers size in `em` off it so the whole diff scales together. The
+  preference panel shows a live preview line.
+
+### 3.15 Responsive / mobile behavior
+
+`useMediaQuery` / `useIsMobile` drive real behavioral changes, not just CSS: line
+wrapping defaults on, the diff becomes horizontally scrollable, line-number gutters
+are hidden, split view is disabled, the code viewer goes full-screen, inline cards
+stick to the left edge, and the bottom review action bar appears.
+
+### 3.16 Miscellaneous
+
+- **Escape** closes the plugins drawer, comment modal, submit modal, inline comment
+  form, LSP popover, and outdated-comments drawer.
+- Transient toasts for sync results; `alert()` for errors (a gap worth improving in a
+  new client).
+- Loading states on every async button.
+
+---
+
+## 4. Protocol methods used — and not used
+
+Called by the current client:
+
+`GetAllReviews`, `GetPR`, `GetAdjacentPR`, `SyncPR`, `AddComment`, `EditComment`,
+`DeleteComment`, `SetFeedback`, `SubmitReview`, `GetPluginOutput`, `RerunPlugins`,
+`GetHunkContext`, `GetConfig`, `UpdateConfig`.
+
+Bridged in `server.ts` but not called by the UI: `RemovePRComments`, `ListPlugins`.
+
+**Available in the protocol but unimplemented in this client** — the obvious feature
+gaps if you're building a more complete one:
+
+| Method | What you'd get |
+|---|---|
+| `MergePR` | Merge from the review view. Note the protocol's warning: check `merged` and `message`, don't infer success from the absence of an error. |
+| `GetRateLimitStatus` | A rate-limit indicator; the server throttles below 100 remaining and blocks below 10. |
+| `CheckRepoExists` | A cleaner LSP-availability check than relying on `metadata.repo_path`. |
+| `Hello` | Health check / connection probe. |
+| `RemovePRComments` | "Discard all pending comments" button. |
+
+### Calls not yet in protocol.md
+
+Two methods the web client depends on are missing from [protocol.md](protocol.md).
+Until it catches up, `server/server.go` is the source of truth.
+
+**`RPCHandler.GetHunkContext`** — extra context lines around a hunk boundary, so a
+client can expand a diff without fetching the whole file.
+
+Args: `Owner`, `Repo`, `Number`, `Filename`, `Side` (`"old"` or `"new"`),
+`AnchorLine` (1-based, in the file, not the diff), `Direction` (`"before"` or
+`"after"`), `Count` (defaults to 20, capped at 100), plus the current hunk range
+(`OrigStart`, `OrigLength`, `NewStart`, `NewLength`, `HunkHeader`) so the server can
+compute the updated header.
+
+Reply: `lines` (`[]string`), `start_line`, `end_line`, `range_header` (the rewritten
+`@@ -a,b +c,d @@` line for the expanded hunk).
+
+**`RPCHandler.RerunPlugins`** — clears cached plugin results and re-executes.
+
+Args: `Owner`, `Repo`, `Number`, `Plugins` (optional; empty means all).
+Reply: `okay`, `message`, `output`. Execution happens in a background goroutine — the
+reply means "accepted", not "finished", so poll `GetPluginOutput` for results.
+
+### Reply fields the client relies on
+
+Two fields the client depends on aren't in protocol.md's `PRMetadata` /
+`GetPRReply` tables either:
+
+- `metadata.repo_path` — absolute path to the local clone. The client uses it to gate
+  LSP and the code viewer; distinct from the documented `worktree_path`.
+- `feedback` (top level) — the saved review feedback draft, returned alongside the PR
+  so the client can restore it.
+
+---
+
+## 5. Reimplementation gotchas
+
+Ordered roughly by how much time they'll cost you if missed.
+
+1. **Comment positions are diff positions, not line numbers.** Follow the counting
+   rules in [3.5](#35-diff-rendering-diffviewtsx-diff_utilsts) precisely, and
+   exclude on-demand expanded context from the count.
+2. **Cache keys use the short repo name.** Pass `Repo` as `code-review-server`, not
+   `C-Hipple/code-review-server` — see the Cache Key Convention in the project's
+   `CLAUDE.md`. Full names miss the DB caches and hit GitHub every time.
+3. **Nothing on the read path blocks on plugins or the LLM.** `GetPR` returns
+   immediately with whatever is cached; plugin output arrives via separate polling.
+   Design your UI for results that show up late, and consider the list-view warm-up
+   trick in [3.1](#31-review-list-prlisttsx).
+4. **Mutations return the whole PR.** `AddComment`, `EditComment`, `DeleteComment`,
+   `SetFeedback`, `SubmitReview` all reply with a full payload. Applying it wholesale
+   is simpler and less error-prone than patching local state.
+5. **`GetAdjacentPR` tells you where you landed.** Use `adjacent_owner` /
+   `adjacent_repo` / `adjacent_number`, not `metadata.url`.
+6. **`UpdateConfig` rejections are not RPC errors.** A refused config comes back
+   `okay: false` with `errors`. Treat it as field-level validation feedback.
+7. **`UpdateConfig` is partial, except `Workflows`.** Omitted fields keep their
+   on-disk value; sending `Workflows` replaces the entire list.
+8. **Build config pickers from the registries.** `workflow_types` and `filters` come
+   with every `GetConfig` reply; hard-coded lists rot.
+9. **Framing.** One JSON object per line on stdout; buffer partial reads. Monitor
+   `stderr` — the server logs there.
+10. **Plugin bodies can legitimately be empty.** Only fall back to raw `result` when
+    `body_type` is missing or unrecognized.
+11. **Annotations anchor to head-side line numbers**, and need a fallback bucket for
+    lines the diff doesn't render.
+
+---
+
+## 6. Development and testing
+
+```bash
+cd bun_client
+bun install
+
+bun run dev          # bridge on :5172 + Vite on :5173 (bridge proxies to Vite)
+bun start            # bridge only, serving frontend/dist
+
+bun run build        # frontend → embedded assets → single `crs-gui` binary
+
+bun run test         # frontend tests + bridge tests (bun:test)
+bun run lint         # ESLint (frontend) + Biome (bridge)
+bun run format:check # Prettier
+bun run type-check   # tsc --noEmit
+```
+
+CI runs lint, format, type-check, and test for changes under `bun_client/`.
+
+Testing approach worth borrowing: the hard logic is factored into pure modules with
+unit tests, so it can be verified without rendering anything —
+`diff_utils` (diff parsing and positions), `annotation_utils` (anchoring),
+`plugin_utils` (response contract), `dock_utils` (tab/split state), `config_utils`
+(config validation), `theme`, and `rpc_framing` (stdio framing). Several tests are
+named `repro_*` and pin down specific past bugs — comment positions, statuses,
+PR-specific parsing.
+
+---
+
+## 7. Suggested build order for a new client
+
+1. **Bridge + list.** Spawn the server, frame stdio, call `GetAllReviews`, render the
+   sections. This alone is a useful client.
+2. **Read-only review.** `GetPR` → header, diff parsing, syntax highlighting, existing
+   comments. Get positions right here; everything else depends on it.
+3. **Write path.** `AddComment` / `EditComment` / `DeleteComment` → `SubmitReview`,
+   plus `SyncPR` afterward.
+4. **Navigation.** `GetAdjacentPR`, URL state, deep links.
+5. **Plugins.** `GetPluginOutput` polling, the body contract, `RerunPlugins`.
+6. **Extras.** Annotations in the diff, hunk expansion, the config editor, LSP, the
+   code viewer.
+
+Steps 1–4 give you a client comparable to the existing ones. Steps 5–6 are what make
+the web client distinct.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Reviewing Code: reviewing.md
   - Protocol: protocol.md
   - Building Clients: building_clients.md
+  - Web Client Features: web_client_features.md
   - GitHub API Notes: github_api_notes.md
 
 markdown_extensions:


### PR DESCRIPTION
Inventories everything bun_client does so another engineer can build a
web-based client without reverse-engineering it: the bridge architecture
(stdio JSON-RPC -> HTTP/WebSocket), the full HTTP surface, a feature list
per surface (list, diff, comments, plugins, annotations, LSP, docking,
config editor, preferences, mobile), which protocol methods it uses and
which it leaves unimplemented, and the reimplementation gotchas around
comment positions, cache keys, and the plugin body contract.

Also documents GetHunkContext and RerunPlugins, which the client depends
on but protocol.md does not yet cover, and links the new page from
clients.md, building_clients.md, and the mkdocs nav.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qsmsrm2iGMZSW6B8xJ1czr