### PR TITLE
Rebuild the review list, and run with no config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ Full documentation is available at [https://code-review-server.readthedocs.io/en
 
 2.  **Configure environment**
 
-    Create your config at `~/.config/codereviewserver.toml` (see [Configuration](docs/configuration.md)).
-
     ```bash
     export CRS_GITHUB_TOKEN="Github Token"  # Required.
     export GEMINI_API_KEY="Gemini Token"  # Only necessary for plugin use.
     ```
 
-    Minimal `~/.config/codereviewserver.toml`:
+    That token is the only required setup. With no config file, the server runs a built-in default configuration — a **Waiting On Me** section and a **Review Requested** section, found through GitHub search and identified by whoever the token belongs to. No repo list, no username.
+
+    To customize, start from those defaults and edit (see [Configuration](docs/configuration.md)):
+
+    ```bash
+    codereviewserver -print-default-config > ~/.config/codereviewserver.toml
+    ```
+
+    A fuller `~/.config/codereviewserver.toml`, once you know which repos you care about:
     ```toml
     Repos = ["owner/repo"]
     GithubUsername = "your-username"

--- a/bun_client/frontend/src/App.css
+++ b/bun_client/frontend/src/App.css
@@ -3,31 +3,536 @@
     outline: 1px solid var(--border);
 }
 
-.pr-item-card:hover {
-    border-color: var(--accent) !important;
-    transform: translateY(-2px);
-    background: var(--bg-tertiary) !important;
-    box-shadow: var(--shadow-md);
+/* ============================================================
+   App chrome — top bar shared by every view
+   ============================================================ */
+
+.app-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    height: var(--topbar-height);
+    padding: 0 16px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+    z-index: 20;
+}
+
+/* Active-view tab, styled after the underlined nav in the reference design.
+   It sits flush with the bar's bottom border, so it needs the bar's height. */
+.app-tab {
+    display: inline-flex;
+    align-items: center;
+    height: var(--topbar-height);
+    margin-bottom: -1px;
+    padding: 0 2px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+    border-bottom: 2px solid var(--accent);
+}
+
+/* ============================================================
+   Review list — sidebar + dense, borderless PR rows
+   ============================================================ */
+
+.crs-list {
+    display: flex;
+    align-items: flex-start;
+    min-height: calc(100vh - var(--topbar-height));
+}
+
+.crs-sidebar {
+    position: sticky;
+    top: var(--topbar-height);
+    flex: 0 0 260px;
+    width: 260px;
+    height: calc(100vh - var(--topbar-height));
+    overflow-y: auto;
+    padding: 16px 12px;
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border);
+}
+
+.crs-sidebar-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 8px 14px;
+}
+
+.crs-sidebar-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.crs-sidebar-subtitle {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.crs-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.crs-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 7px 10px;
+    background: transparent;
+    border: none;
+    border-left: 2px solid transparent;
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-family: inherit;
+    font-size: 14px;
+    text-align: left;
+    cursor: pointer;
+    transition:
+        background 0.12s ease,
+        color 0.12s ease;
+}
+
+.crs-nav-item:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.crs-nav-item[aria-current='true'] {
+    background: var(--bg-tertiary);
+    border-left-color: var(--accent);
+    border-radius: 0 6px 6px 0;
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.crs-nav-count {
+    margin-left: auto;
+    font-size: 12px;
+    color: var(--text-tertiary);
+    font-variant-numeric: tabular-nums;
+}
+
+.crs-sidebar-section {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+}
+
+.crs-sidebar-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 2px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    cursor: default;
+}
+
+details > summary.crs-sidebar-label {
+    cursor: pointer;
+    list-style: none;
+}
+
+details > summary.crs-sidebar-label::-webkit-details-marker {
+    display: none;
+}
+
+/* The default disclosure triangle is dropped by `display: flex` on the
+   summary, so the marker is drawn explicitly. */
+details > summary.crs-sidebar-label::after {
+    content: '▸';
+    margin-left: auto;
+    font-size: 10px;
+}
+
+details[open] > summary.crs-sidebar-label::after {
+    content: '▾';
+}
+
+.crs-narrow,
+.crs-goto-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.crs-narrow select {
+    width: 100%;
+}
+
+/* Checkable repo / author lists. Ten rows fit; the rest scroll. */
+.crs-facet {
+    --facet-row-height: 28px;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(10 * var(--facet-row-height));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.crs-facet-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 0 0 auto;
+    height: var(--facet-row-height);
+    padding: 0 6px;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 13px;
     cursor: pointer;
 }
 
-.pr-item-card button:hover {
-    filter: brightness(1.1);
-    transform: scale(1.05);
+.crs-facet-item:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
 }
 
-.pr-title {
+.crs-facet-item:has(input:checked) {
+    color: var(--text-primary);
+}
+
+.crs-facet-item input {
+    flex: 0 0 auto;
+    width: 13px;
+    height: 13px;
+    margin: 0;
+    accent-color: var(--accent);
     cursor: pointer;
-    transition: color 0.2s ease;
 }
 
-.pr-title:hover {
+.crs-facet-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Stands in for the clear link when the list is folded into a disclosure. */
+.crs-facet-selected {
+    margin-left: auto;
     color: var(--accent);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+}
+
+.crs-facet-count {
+    margin-left: auto;
+    padding-left: 6px;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+}
+
+.crs-link-btn {
+    margin-left: auto;
+    padding: 0;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-family: inherit;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
+.crs-link-btn:hover {
     text-decoration: underline;
 }
 
-.pr-item-card button:active {
-    transform: scale(0.95);
+.crs-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.crs-toolbar {
+    position: sticky;
+    top: var(--topbar-height);
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    background: var(--bg-primary);
+    border-bottom: 1px solid var(--border);
+}
+
+.crs-count {
+    font-size: 12px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.crs-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex: 0 0 auto;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.crs-icon-btn:hover:not(:disabled) {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.crs-icon-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.crs-spin {
+    display: inline-flex;
+    animation: spin 0.9s linear infinite;
+}
+
+.crs-section-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 16px;
+    background: var(--bg-secondary);
+    border: none;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-secondary);
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    text-align: left;
+    cursor: pointer;
+}
+
+.crs-section-header:hover {
+    color: var(--text-primary);
+}
+
+.crs-chevron {
+    display: inline-flex;
+    transition: transform 0.15s ease;
+}
+
+.crs-section-count {
+    margin-left: auto;
+    color: var(--text-tertiary);
+    font-variant-numeric: tabular-nums;
+}
+
+.crs-row {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+}
+
+.crs-row:hover {
+    background: var(--bg-secondary);
+}
+
+.crs-row-link {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    flex: 1;
+    min-width: 0;
+    padding: 10px 16px;
+    color: inherit;
+    text-decoration: none;
+}
+
+/* Fixed-width state column so every title starts on the same vertical line. */
+.crs-row-state {
+    flex: 0 0 62px;
+    margin-top: 1px;
+    padding: 2px 0;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-size: 11px;
+    text-align: center;
+    text-transform: lowercase;
+}
+
+.crs-row-body {
+    min-width: 0;
+}
+
+.crs-row-title-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.crs-row-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.crs-row:hover .crs-row-title {
+    color: var(--accent);
+}
+
+.crs-row-ease {
+    padding: 1px 6px;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.crs-row-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 3px;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.crs-row-repo {
+    font-family: var(--font-mono);
+}
+
+.crs-row-number {
+    color: var(--text-tertiary);
+    font-variant-numeric: tabular-nums;
+}
+
+/* Row actions stay out of the way until the row is hovered or tabbed into.
+   `pointer-events: none` while hidden so an invisible button can't swallow a
+   click meant for the row; keyboard focus still reveals them. */
+.crs-row-actions {
+    display: flex;
+    gap: 4px;
+    padding-right: 12px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+}
+
+.crs-row:hover .crs-row-actions,
+.crs-row:focus-within .crs-row-actions {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.crs-empty {
+    padding: 48px 20px;
+    text-align: center;
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.crs-empty-hint {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--text-tertiary);
+}
+
+.crs-empty-actions {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+@media (max-width: 768px) {
+    .crs-list {
+        flex-direction: column;
+    }
+
+    .crs-sidebar {
+        position: static;
+        flex: none;
+        width: 100%;
+        height: auto;
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+    }
+
+    /* State buckets become a horizontally scrolling strip above the list. */
+    .crs-nav {
+        flex-direction: row;
+        gap: 6px;
+        overflow-x: auto;
+        padding-bottom: 4px;
+    }
+
+    .crs-nav-item {
+        flex: 0 0 auto;
+        width: auto;
+        border-left: none;
+        border-bottom: 2px solid transparent;
+        border-radius: 6px;
+    }
+
+    .crs-nav-item[aria-current='true'] {
+        border-left: none;
+        border-bottom-color: var(--accent);
+        border-radius: 6px;
+    }
+
+    .crs-nav-count {
+        margin-left: 4px;
+    }
+
+    .crs-narrow {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .crs-narrow > * {
+        flex: 1 1 140px;
+    }
+
+    /* Finger-sized facet rows, and a shorter list so the sidebar doesn't push
+       the reviews themselves off the screen. */
+    .crs-facet {
+        --facet-row-height: 36px;
+        max-height: calc(6 * var(--facet-row-height));
+    }
+
+    .crs-facet-item input {
+        width: 16px;
+        height: 16px;
+    }
+
+    .crs-toolbar {
+        position: static;
+    }
+
+    .crs-row {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .crs-row-actions {
+        opacity: 1;
+        pointer-events: auto;
+        padding: 0 12px 10px 92px;
+    }
 }
 
 /* Plugin output markdown styling */

--- a/bun_client/frontend/src/App.tsx
+++ b/bun_client/frontend/src/App.tsx
@@ -192,19 +192,16 @@ function App() {
     return (
         <div
             className="app-container"
-            style={{ minHeight: '100vh', padding: isMobile ? '12px' : '20px' }}
+            style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}
         >
             <header
-                style={{
-                    marginBottom: isMobile ? '16px' : '30px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    gap: '8px',
-                    flexWrap: 'wrap',
-                }}
+                className="app-topbar"
+                // Only the list pins its bar: the review view's own sticky
+                // toolbar measures itself against the viewport top, so a pinned
+                // bar there would cover it.
+                style={{ position: view === 'LIST' ? 'sticky' : 'static', top: 0 }}
             >
-                <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '16px', minWidth: 0 }}>
                     <a
                         href="/"
                         onClick={e => {
@@ -225,20 +222,79 @@ function App() {
                         <h1
                             style={{
                                 margin: 0,
-                                fontSize: '24px',
+                                fontSize: '18px',
                                 fontWeight: 600,
                                 cursor: 'pointer',
+                                whiteSpace: 'nowrap',
                             }}
                         >
                             <span style={{ color: 'var(--accent)' }}>Code</span>Review
                         </h1>
                     </a>
+                    {view === 'LIST' && !isMobile && <span className="app-tab">Pull Requests</span>}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                    {view === 'REVIEW' && (
+                        <>
+                            <button
+                                onClick={() => handleNavigatePR(true)}
+                                disabled={navigating}
+                                style={{
+                                    background: 'transparent',
+                                    border: '1px solid var(--border)',
+                                    color: 'var(--text-secondary)',
+                                    padding: '6px 12px',
+                                    borderRadius: '6px',
+                                    fontSize: '14px',
+                                    cursor: navigating ? 'not-allowed' : 'pointer',
+                                    opacity: navigating ? 0.5 : 1,
+                                }}
+                                title="Previous PR"
+                            >
+                                {isMobile ? '←' : '← Prev PR'}
+                            </button>
+                            <button
+                                onClick={() => handleNavigatePR(false)}
+                                disabled={navigating}
+                                style={{
+                                    background: 'transparent',
+                                    border: '1px solid var(--border)',
+                                    color: 'var(--text-secondary)',
+                                    padding: '6px 12px',
+                                    borderRadius: '6px',
+                                    fontSize: '14px',
+                                    cursor: navigating ? 'not-allowed' : 'pointer',
+                                    opacity: navigating ? 0.5 : 1,
+                                }}
+                                title="Next PR"
+                            >
+                                {isMobile ? '→' : 'Next PR →'}
+                            </button>
+                        </>
+                    )}
+                    {(view === 'REVIEW' || view === 'PLUGIN_OUTPUT') && (
+                        <button
+                            onClick={handleBack}
+                            style={{
+                                background: 'transparent',
+                                border: '1px solid var(--border)',
+                                color: 'var(--text-secondary)',
+                                padding: '6px 12px',
+                                borderRadius: '6px',
+                                fontSize: '14px',
+                                cursor: 'pointer',
+                            }}
+                            title="Back to list"
+                        >
+                            {isMobile ? '☰ List' : '← Back to List'}
+                        </button>
+                    )}
                     <button
                         onClick={() => setShowPrefs(true)}
                         style={{
                             background: 'transparent',
                             border: 'none',
-                            fontSize: '20px',
+                            fontSize: '18px',
                             cursor: 'pointer',
                             color: 'var(--text-secondary)',
                             display: 'flex',
@@ -251,66 +307,15 @@ function App() {
                         ⚙️
                     </button>
                 </div>
-                {(view === 'REVIEW' || view === 'PLUGIN_OUTPUT') && (
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                        {view === 'REVIEW' && (
-                            <>
-                                <button
-                                    onClick={() => handleNavigatePR(true)}
-                                    disabled={navigating}
-                                    style={{
-                                        background: 'transparent',
-                                        border: '1px solid var(--border)',
-                                        color: 'var(--text-secondary)',
-                                        padding: '8px 16px',
-                                        borderRadius: '6px',
-                                        fontSize: '14px',
-                                        cursor: navigating ? 'not-allowed' : 'pointer',
-                                        opacity: navigating ? 0.5 : 1,
-                                    }}
-                                    title="Previous PR"
-                                >
-                                    {isMobile ? '←' : '← Prev PR'}
-                                </button>
-                                <button
-                                    onClick={() => handleNavigatePR(false)}
-                                    disabled={navigating}
-                                    style={{
-                                        background: 'transparent',
-                                        border: '1px solid var(--border)',
-                                        color: 'var(--text-secondary)',
-                                        padding: '8px 16px',
-                                        borderRadius: '6px',
-                                        fontSize: '14px',
-                                        cursor: navigating ? 'not-allowed' : 'pointer',
-                                        opacity: navigating ? 0.5 : 1,
-                                    }}
-                                    title="Next PR"
-                                >
-                                    {isMobile ? '→' : 'Next PR →'}
-                                </button>
-                            </>
-                        )}
-                        <button
-                            onClick={handleBack}
-                            style={{
-                                background: 'transparent',
-                                border: '1px solid var(--border)',
-                                color: 'var(--text-secondary)',
-                                padding: '8px 16px',
-                                borderRadius: '6px',
-                                fontSize: '14px',
-                                cursor: 'pointer',
-                            }}
-                            title="Back to list"
-                        >
-                            {isMobile ? '☰ List' : '← Back to List'}
-                        </button>
-                    </div>
-                )}
             </header>
 
-            <main>
+            <main
+                style={{
+                    flex: 1,
+                    minWidth: 0,
+                    padding: view === 'LIST' ? 0 : isMobile ? '12px' : '20px',
+                }}
+            >
                 {view === 'LIST' && (
                     <PRList
                         onOpenReview={handleOpenReview}

--- a/bun_client/frontend/src/components/ConfigManager.tsx
+++ b/bun_client/frontend/src/components/ConfigManager.tsx
@@ -46,6 +46,9 @@ export default function ConfigManager() {
     const [workflowTypes, setWorkflowTypes] = useState<WorkflowTypeInfo[]>([]);
     const [filters, setFilters] = useState<FilterInfo[]>([]);
     const [path, setPath] = useState('');
+    // No config file yet: what's shown is the server's built-in default, and
+    // saving is what creates the file.
+    const [usingDefaults, setUsingDefaults] = useState(false);
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [loadError, setLoadError] = useState('');
@@ -67,6 +70,7 @@ export default function ConfigManager() {
             setWorkflowTypes(reply.workflow_types ?? []);
             setFilters(reply.filters ?? []);
             setPath(reply.path);
+            setUsingDefaults(reply.using_defaults ?? false);
             setServerProblems([]);
             setShowProblems(false);
             setStatus(reply.okay ? null : { kind: 'error', text: reply.message });
@@ -178,6 +182,7 @@ export default function ConfigManager() {
             setSaved(applied);
             setServerProblems([]);
             setPath(reply.path);
+            setUsingDefaults(reply.using_defaults ?? false);
             setStatus({
                 kind: 'ok',
                 text: `${reply.message}. Workflow changes take effect on the next sync.`,
@@ -211,10 +216,18 @@ export default function ConfigManager() {
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.xl }}>
-            <div style={{ fontSize: fontSize.sm, color: colors.textTertiary }}>
-                Editing <code>{path}</code>. The previous file is kept alongside it as{' '}
-                <code>.bak</code>; comments in the file are not preserved.
-            </div>
+            {usingDefaults ? (
+                <div style={{ fontSize: fontSize.sm, color: colors.textSecondary }}>
+                    No config file yet — these are the server&apos;s built-in defaults, which need
+                    nothing but a GitHub token. Saving writes them, along with your changes, to{' '}
+                    <code>{path}</code>.
+                </div>
+            ) : (
+                <div style={{ fontSize: fontSize.sm, color: colors.textTertiary }}>
+                    Editing <code>{path}</code>. The previous file is kept alongside it as{' '}
+                    <code>.bak</code>; comments in the file are not preserved.
+                </div>
+            )}
 
             <section style={{ display: 'flex', flexDirection: 'column', gap: spacing.md }}>
                 <SectionHeading>Global Settings</SectionHeading>

--- a/bun_client/frontend/src/components/PRList.tsx
+++ b/bun_client/frontend/src/components/PRList.tsx
@@ -1,17 +1,29 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { rpcCall } from '../api';
 import { useIsMobile } from '../hooks/useMediaQuery';
 import {
     Button,
-    Badge,
-    Card,
     Input,
     Select,
-    mapStatusToVariant,
+    getStatusTone,
     mapReviewEase,
     Theme,
     ReviewLocation,
 } from '../design';
+import {
+    PR_STATES,
+    authorLogin,
+    countByState,
+    facetsByOpenCount,
+    formatAbsoluteTime,
+    formatRelativeTime,
+    groupBySection,
+    itemMatchesQuery,
+    parseGitHubPRUrl,
+    prState,
+    uniqueValues,
+} from '../pr_list_utils';
+import type { Facet, PRState, ReviewItem } from '../pr_list_utils';
 
 interface PRListProps {
     onOpenReview: (owner: string, repo: string, number: number) => void;
@@ -21,59 +33,139 @@ interface PRListProps {
     onThemeChange: (theme: Theme) => void;
 }
 
-// Matches the ReviewItem struct from the Go backend
-interface ReviewItem {
-    section: string;
-    status: string;
-    title: string;
-    owner: string;
-    repo: string;
-    number: number;
-    author: string;
-    url: string;
-    review_ease: string; // LLM review-ease rating: "easy", "medium", "hard", or ""
-}
-
 interface GetReviewsResponse {
     content: string;
     items: ReviewItem[];
 }
 
-// Group items by section
-interface Section {
-    name: string;
-    items: ReviewItem[];
+/** The sidebar's lifecycle buckets, plus the catch-all. */
+type StateFilter = PRState | 'all';
+
+const STATE_FILTER_KEY = 'prListStateFilter';
+
+const STATE_LABELS: Record<StateFilter, string> = {
+    open: 'Open',
+    draft: 'Draft',
+    merged: 'Merged',
+    closed: 'Closed',
+    all: 'Everything',
+};
+
+/**
+ * Stand-in value for the dropdowns when the facet list below them has several
+ * boxes checked — a single-value control has nothing truthful to show, so it
+ * names the size of the selection and does nothing when picked.
+ */
+const MULTIPLE = '__multiple__';
+
+function selectValue(selection: Set<string>): string {
+    if (selection.size === 1) return Array.from(selection)[0];
+    return selection.size > 1 ? MULTIPLE : '';
 }
 
-// Status options for the dropdown filter (static options)
-const STATUS_OPTIONS = [
-    { value: '', label: 'All Statuses' },
-    { value: 'TODO', label: 'TODO' },
-    { value: 'PROGRESS', label: 'In Progress' },
-    { value: 'DONE', label: 'Done' },
-    { value: 'CANCELLED', label: 'Cancelled' },
-];
-
-// Configuration for dynamic dropdown filters
-// Each filter extracts unique values from the items based on a field
-interface DynamicFilterConfig {
-    key: keyof ReviewItem; // Field to filter on
-    label: string; // Display label
-    allLabel: string; // "All X" label
+function selectionFor(value: string): (prev: Set<string>) => Set<string> {
+    return prev => (value === MULTIPLE ? prev : new Set(value ? [value] : []));
 }
 
-const DYNAMIC_FILTERS: DynamicFilterConfig[] = [
-    { key: 'author', label: 'Author', allLabel: 'All Authors' },
-    { key: 'owner', label: 'Owner', allLabel: 'All Owners' },
-    { key: 'repo', label: 'Repo', allLabel: 'All Repos' },
-];
-
-// Helper to extract unique sorted values for a field from items
-function getUniqueValues(items: ReviewItem[], field: keyof ReviewItem): string[] {
-    return Array.from(
-        new Set(items.map(item => String(item[field] || '')).filter(val => val.trim() !== ''))
-    ).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+function repoHeading(selection: Set<string>): string {
+    if (selection.size === 1) return Array.from(selection)[0];
+    return selection.size > 1 ? `${selection.size} repositories` : 'All repositories';
 }
+
+/** Dim tone per lifecycle state, borrowed from the shared status palette. */
+function stateTone(state: PRState) {
+    switch (state) {
+        case 'open':
+            return getStatusTone('success');
+        case 'merged':
+            return {
+                fg: 'var(--text-merged)',
+                bg: 'var(--bg-merged-dim)',
+                border: 'var(--border-merged-dim)',
+            };
+        case 'closed':
+            return getStatusTone('danger');
+        default:
+            return getStatusTone('neutral');
+    }
+}
+
+function Icon({ children, size = 16 }: { children: ReactNode; size?: number }) {
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            style={{ flex: '0 0 auto' }}
+        >
+            {children}
+        </svg>
+    );
+}
+
+/** One glyph per sidebar bucket: open, draft, merged, closed, everything. */
+const STATE_ICONS: Record<StateFilter, ReactNode> = {
+    open: (
+        <Icon>
+            <circle cx="8" cy="8" r="5.25" />
+            <circle cx="8" cy="8" r="1.6" fill="currentColor" stroke="none" />
+        </Icon>
+    ),
+    draft: (
+        <Icon>
+            <circle cx="8" cy="8" r="5.25" strokeDasharray="2.2 2.2" />
+            <circle cx="8" cy="8" r="1.6" fill="currentColor" stroke="none" />
+        </Icon>
+    ),
+    merged: (
+        <Icon>
+            <circle cx="5" cy="3.6" r="1.7" />
+            <circle cx="5" cy="12.4" r="1.7" />
+            <circle cx="11.4" cy="5.4" r="1.7" />
+            <path d="M5 5.3v5.4" />
+            <path d="M10.4 7c-.7 1.9-2.5 3.1-5.4 3.4" />
+        </Icon>
+    ),
+    closed: (
+        <Icon>
+            <circle cx="8" cy="8" r="5.25" />
+            <path d="M6.2 6.2l3.6 3.6M9.8 6.2l-3.6 3.6" />
+        </Icon>
+    ),
+    all: (
+        <Icon>
+            <path d="M2.8 4.5h10.4M2.8 8h10.4M2.8 11.5h10.4" />
+        </Icon>
+    ),
+};
+
+const REPO_ICON = (
+    <Icon>
+        <rect x="2.4" y="2.8" width="11.2" height="3.2" rx="1" />
+        <path d="M3.6 6.4v6a1 1 0 0 0 1 1h6.8a1 1 0 0 0 1-1v-6" />
+        <path d="M6.6 9.2h2.8" />
+    </Icon>
+);
+
+const SEARCH_ICON = (
+    <Icon>
+        <circle cx="7" cy="7" r="4.3" />
+        <path d="M10.2 10.2L14 14" />
+    </Icon>
+);
+
+const REFRESH_ICON = (
+    <Icon>
+        <path d="M13.3 8a5.3 5.3 0 1 1-1.7-3.9" />
+        <path d="M13.4 2.6v3.6H9.8" />
+    </Icon>
+);
 
 export default function PRList({
     onOpenReview,
@@ -83,106 +175,32 @@ export default function PRList({
     onThemeChange: _onThemeChange,
 }: PRListProps) {
     const isMobile = useIsMobile();
-    const [sections, setSections] = useState<Section[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [filterText, setFilterText] = useState('');
-    const [statusFilter, setStatusFilter] = useState('');
+    const [items, setItems] = useState<ReviewItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [loadError, setLoadError] = useState(false);
+    const [query, setQuery] = useState('');
+    // Repo / author narrowing is a set: the checkable facet lists select several,
+    // and the dropdowns above them are single-value shortcuts into the same set,
+    // so the two controls can never disagree about what is filtered.
+    const [repoFilters, setRepoFilters] = useState<Set<string>>(new Set());
+    const [authorFilters, setAuthorFilters] = useState<Set<string>>(new Set());
     const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
 
-    // Dynamic filters state - one value per filter key
-    const [dynamicFilters, setDynamicFilters] = useState<Record<string, string>>(() => {
-        const initial: Record<string, string> = {};
-        DYNAMIC_FILTERS.forEach(f => {
-            initial[f.key] = '';
-        });
-        return initial;
+    // The list opens on the PRs that still need a review; the choice sticks so
+    // someone who lives in "Everything" isn't reset on every visit.
+    const [stateFilter, setStateFilter] = useState<StateFilter>(() => {
+        const saved = localStorage.getItem(STATE_FILTER_KEY) as StateFilter | null;
+        return saved && saved in STATE_LABELS ? saved : 'open';
     });
 
-    // Manual form state
-    const [owner, setOwner] = useState('C-Hipple'); // Default based on user context
+    // Manual "go to PR" form
+    const [owner, setOwner] = useState('C-Hipple');
     const [repo, setRepo] = useState('code-review-server');
     const [prNumber, setPrNumber] = useState('');
 
-    // Get all items flattened for computing unique values
-    const allItems = sections.flatMap(s => s.items);
-
-    // Check if any filters are active
-    const hasActiveFilters =
-        filterText.trim() !== '' ||
-        statusFilter !== '' ||
-        Object.values(dynamicFilters).some(v => v !== '');
-
-    // Filter items based on all active filters
-    const filterItem = (item: ReviewItem): boolean => {
-        // Status filter
-        if (statusFilter && item.status !== statusFilter) {
-            return false;
-        }
-
-        // Dynamic filters
-        for (const config of DYNAMIC_FILTERS) {
-            const filterValue = dynamicFilters[config.key];
-            if (filterValue && String(item[config.key]) !== filterValue) {
-                return false;
-            }
-        }
-
-        // Text search filter
-        if (!filterText.trim()) return true;
-        const search = filterText.toLowerCase();
-        return (
-            item.title.toLowerCase().includes(search) ||
-            item.author.toLowerCase().includes(search) ||
-            item.owner.toLowerCase().includes(search) ||
-            item.repo.toLowerCase().includes(search)
-        );
-    };
-
-    // Update a single dynamic filter
-    const setDynamicFilter = (key: string, value: string) => {
-        setDynamicFilters(prev => ({ ...prev, [key]: value }));
-    };
-
-    // Clear all filters
-    const clearAllFilters = () => {
-        setFilterText('');
-        setStatusFilter('');
-        setDynamicFilters(() => {
-            const cleared: Record<string, string> = {};
-            DYNAMIC_FILTERS.forEach(f => {
-                cleared[f.key] = '';
-            });
-            return cleared;
-        });
-    };
-
-    // Get filtered sections (only sections with matching items)
-    const filteredSections = sections
-        .map(section => ({
-            ...section,
-            items: section.items.filter(filterItem),
-        }))
-        .filter(section => section.items.length > 0);
-
-    const toggleSection = (name: string) => {
-        setCollapsedSections(prev => {
-            const next = new Set(prev);
-            if (next.has(name)) {
-                next.delete(name);
-            } else {
-                next.add(name);
-            }
-            return next;
-        });
-    };
-
-    const collapseAll = () => {
-        setCollapsedSections(new Set(sections.map(s => s.name)));
-    };
-
-    const expandAll = () => {
-        setCollapsedSections(new Set());
-    };
+    useEffect(() => {
+        localStorage.setItem(STATE_FILTER_KEY, stateFilter);
+    }, [stateFilter]);
 
     useEffect(() => {
         loadList();
@@ -192,29 +210,13 @@ export default function PRList({
         setLoading(true);
         try {
             const res = await rpcCall<GetReviewsResponse>('RPCHandler.GetAllReviews', [{}]);
-            const items = res.items || [];
-
-            // Group items by section
-            const sectionMap = new Map<string, ReviewItem[]>();
-            for (const item of items) {
-                const sectionName = item.section || 'Other';
-                if (!sectionMap.has(sectionName)) {
-                    sectionMap.set(sectionName, []);
-                }
-                sectionMap.get(sectionName)!.push(item);
-            }
-
-            // Convert to array
-            const sectionList: Section[] = [];
-            for (const [name, items] of sectionMap) {
-                sectionList.push({ name, items });
-            }
-
-            setSections(sectionList);
+            const loaded = res.items || [];
+            setItems(loaded);
+            setLoadError(false);
 
             // Warm up plugin output for every visible PR so execution is already
             // underway by the time the user opens a PR or its plugin panel.
-            for (const item of items) {
+            for (const item of loaded) {
                 if (item.owner && item.repo && item.number) {
                     rpcCall('RPCHandler.GetPluginOutput', [
                         { Owner: item.owner, Repo: item.repo, Number: item.number },
@@ -223,10 +225,85 @@ export default function PRList({
             }
         } catch (e) {
             console.error(e);
-            setSections([]);
+            setItems([]);
+            setLoadError(true);
         } finally {
             setLoading(false);
         }
+    };
+
+    const repoOptions = useMemo(() => uniqueValues(items, 'repo'), [items]);
+    const authorOptions = useMemo(
+        () =>
+            Array.from(new Set(items.map(i => authorLogin(i.author)).filter(Boolean))).sort(
+                (a, b) => a.toLowerCase().localeCompare(b.toLowerCase())
+            ),
+        [items]
+    );
+    const repoFacets = useMemo(() => facetsByOpenCount(items, i => i.repo), [items]);
+    const authorFacets = useMemo(
+        () => facetsByOpenCount(items, i => authorLogin(i.author)),
+        [items]
+    );
+
+    // Narrowing (repo / author / text) applies first, so the sidebar counts
+    // describe what the current search would actually turn up. An empty set
+    // means "no constraint" rather than "nothing matches".
+    const narrowed = useMemo(
+        () =>
+            items.filter(
+                item =>
+                    (repoFilters.size === 0 || repoFilters.has(item.repo)) &&
+                    (authorFilters.size === 0 || authorFilters.has(authorLogin(item.author))) &&
+                    itemMatchesQuery(item, query)
+            ),
+        [items, repoFilters, authorFilters, query]
+    );
+
+    const counts = useMemo(() => countByState(narrowed), [narrowed]);
+
+    const visible = useMemo(
+        () =>
+            stateFilter === 'all'
+                ? narrowed
+                : narrowed.filter(item => prState(item) === stateFilter),
+        [narrowed, stateFilter]
+    );
+
+    const sections = useMemo(() => groupBySection(visible), [visible]);
+
+    const hasNarrowFilters = query.trim() !== '' || repoFilters.size > 0 || authorFilters.size > 0;
+    const allCollapsed = sections.length > 0 && collapsedSections.size >= sections.length;
+
+    const clearFilters = () => {
+        setQuery('');
+        setRepoFilters(new Set());
+        setAuthorFilters(new Set());
+    };
+
+    const toggleFacet = (
+        setFilters: React.Dispatch<React.SetStateAction<Set<string>>>,
+        value: string
+    ) => {
+        setFilters(prev => {
+            const next = new Set(prev);
+            if (next.has(value)) next.delete(value);
+            else next.add(value);
+            return next;
+        });
+    };
+
+    const toggleSection = (name: string) => {
+        setCollapsedSections(prev => {
+            const next = new Set(prev);
+            if (next.has(name)) next.delete(name);
+            else next.add(name);
+            return next;
+        });
+    };
+
+    const toggleAllSections = () => {
+        setCollapsedSections(allCollapsed ? new Set() : new Set(sections.map(s => s.name)));
     };
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -237,491 +314,478 @@ export default function PRList({
         }
     };
 
+    const navItem = (filter: StateFilter, count: number) => (
+        <button
+            key={filter}
+            type="button"
+            className="crs-nav-item"
+            aria-current={stateFilter === filter}
+            onClick={() => setStateFilter(filter)}
+        >
+            {STATE_ICONS[filter]}
+            <span>{STATE_LABELS[filter]}</span>
+            <span className="crs-nav-count">{count}</span>
+        </button>
+    );
+
+    const gotoForm = (
+        <form onSubmit={handleSubmit} className="crs-goto-form">
+            <Input
+                type="text"
+                value={owner}
+                onChange={e => setOwner(e.target.value)}
+                placeholder="owner"
+                aria-label="Owner"
+                style={{ padding: '6px 8px', fontSize: '13px' }}
+            />
+            <Input
+                type="text"
+                value={repo}
+                onChange={e => setRepo(e.target.value)}
+                placeholder="repo"
+                aria-label="Repo"
+                style={{ padding: '6px 8px', fontSize: '13px' }}
+            />
+            <Input
+                type="number"
+                value={prNumber}
+                onChange={e => setPrNumber(e.target.value)}
+                placeholder="number"
+                aria-label="PR number"
+                style={{ padding: '6px 8px', fontSize: '13px' }}
+            />
+            <Button type="submit" size="sm" variant="secondary" style={{ width: '100%' }}>
+                Open PR
+            </Button>
+        </form>
+    );
+
     return (
-        <div className="pr-list">
-            <Card padding="lg" style={{ marginBottom: '20px' }}>
-                <div
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        marginBottom: '15px',
-                    }}
-                >
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-                        <h2 style={{ margin: 0, fontSize: '18px' }}>Your Reviews</h2>
-                        {!loading && sections.length > 0 && (
-                            <div style={{ display: 'flex', gap: '8px' }}>
-                                <Button
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={
-                                        collapsedSections.size === sections.length
-                                            ? expandAll
-                                            : collapseAll
-                                    }
-                                >
-                                    {collapsedSections.size === sections.length
-                                        ? 'Expand All'
-                                        : 'Collapse All'}
-                                </Button>
-                            </div>
-                        )}
-                    </div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                        <Button onClick={loadList} variant="secondary" loading={loading}>
-                            Refresh
-                        </Button>
+        <div className="crs-list">
+            <aside className="crs-sidebar">
+                <div className="crs-sidebar-head">
+                    <span style={{ color: 'var(--accent)' }}>{REPO_ICON}</span>
+                    <div style={{ minWidth: 0 }}>
+                        <div className="crs-sidebar-title">{repoHeading(repoFilters)}</div>
+                        <div className="crs-sidebar-subtitle">
+                            {loading ? 'Loading…' : `${items.length} reviews tracked`}
+                        </div>
                     </div>
                 </div>
 
-                {/* Filter Bar */}
-                <div style={{ marginBottom: '20px' }}>
-                    {/* Search Input */}
-                    <Input
-                        type="text"
-                        value={filterText}
-                        onChange={e => {
-                            const value = e.target.value;
-                            const githubMatch = value.match(
-                                /https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/
-                            );
-                            if (githubMatch) {
-                                onOpenReview(
-                                    githubMatch[1],
-                                    githubMatch[2],
-                                    parseInt(githubMatch[3], 10)
-                                );
-                                return;
-                            }
-                            setFilterText(value);
-                        }}
-                        placeholder="Filter by title, author, owner, or repo... (or paste a GitHub PR URL)"
-                        icon={<span>⌕</span>}
-                        clearable
-                        onClear={() => setFilterText('')}
-                    />
+                <nav className="crs-nav" aria-label="Filter by state">
+                    {PR_STATES.map(state => navItem(state, counts[state]))}
+                    {navItem('all', narrowed.length)}
+                </nav>
 
-                    {/* Filter Dropdowns Row */}
-                    <div
-                        style={{
-                            display: 'flex',
-                            gap: '12px',
-                            marginTop: '12px',
-                            flexWrap: 'wrap',
-                            alignItems: 'flex-end',
-                        }}
-                    >
-                        {/* Status Filter (static options) */}
-                        <Select
-                            label="Status"
-                            value={statusFilter}
-                            onChange={e => setStatusFilter(e.target.value)}
-                            options={STATUS_OPTIONS}
-                        />
-
-                        {/* Dynamic Filters (generated from data) */}
-                        {DYNAMIC_FILTERS.map(config => {
-                            const options = getUniqueValues(allItems, config.key);
-                            return (
-                                <Select
-                                    key={config.key}
-                                    label={config.label}
-                                    value={dynamicFilters[config.key]}
-                                    onChange={e => setDynamicFilter(config.key, e.target.value)}
-                                >
-                                    <option value="">{config.allLabel}</option>
-                                    {options.map(val => (
-                                        <option key={val} value={val}>
-                                            {val}
-                                        </option>
-                                    ))}
-                                </Select>
-                            );
-                        })}
-
-                        {/* Clear All Filters Button */}
-                        {hasActiveFilters && (
-                            <Button
-                                onClick={clearAllFilters}
-                                variant="secondary"
-                                size="sm"
-                                style={{ marginLeft: 'auto' }}
-                            >
-                                <span>×</span> Clear filters
-                            </Button>
+                <div className="crs-sidebar-section">
+                    <div className="crs-sidebar-label">
+                        Narrow
+                        {hasNarrowFilters && (
+                            <button type="button" className="crs-link-btn" onClick={clearFilters}>
+                                clear
+                            </button>
                         )}
                     </div>
-
-                    {/* Results count */}
-                    {hasActiveFilters && (
-                        <div
-                            style={{
-                                fontSize: '12px',
-                                color: 'var(--text-secondary)',
-                                marginTop: '12px',
-                            }}
+                    <div className="crs-narrow">
+                        <Select
+                            aria-label="Filter by repo"
+                            value={selectValue(repoFilters)}
+                            onChange={e => setRepoFilters(selectionFor(e.target.value))}
                         >
-                            Showing {filteredSections.reduce((acc, s) => acc + s.items.length, 0)}{' '}
-                            of {sections.reduce((acc, s) => acc + s.items.length, 0)} items
+                            <option value="">All repos</option>
+                            {repoFilters.size > 1 && (
+                                <option value={MULTIPLE}>{repoFilters.size} repos selected</option>
+                            )}
+                            {repoOptions.map(value => (
+                                <option key={value} value={value}>
+                                    {value}
+                                </option>
+                            ))}
+                        </Select>
+                        <Select
+                            aria-label="Filter by author"
+                            value={selectValue(authorFilters)}
+                            onChange={e => setAuthorFilters(selectionFor(e.target.value))}
+                        >
+                            <option value="">All authors</option>
+                            {authorFilters.size > 1 && (
+                                <option value={MULTIPLE}>
+                                    {authorFilters.size} authors selected
+                                </option>
+                            )}
+                            {authorOptions.map(value => (
+                                <option key={value} value={value}>
+                                    {value}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+                </div>
+
+                <FacetList
+                    label="Repos"
+                    facets={repoFacets}
+                    selected={repoFilters}
+                    onToggle={value => toggleFacet(setRepoFilters, value)}
+                    onClear={() => setRepoFilters(new Set())}
+                    collapsible={isMobile}
+                />
+                <FacetList
+                    label="Authors"
+                    facets={authorFacets}
+                    selected={authorFilters}
+                    onToggle={value => toggleFacet(setAuthorFilters, value)}
+                    onClear={() => setAuthorFilters(new Set())}
+                    collapsible={isMobile}
+                />
+
+                {/* Collapsed by default: reaching a PR no workflow tracks is the
+                    exception, and the filter box already opens pasted PR URLs. */}
+                <details className="crs-sidebar-section">
+                    <summary className="crs-sidebar-label">Open a PR by number</summary>
+                    {gotoForm}
+                </details>
+            </aside>
+
+            <div className="crs-main">
+                <div className="crs-toolbar">
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                        <Input
+                            type="text"
+                            value={query}
+                            onChange={e => {
+                                const value = e.target.value;
+                                const pasted = parseGitHubPRUrl(value);
+                                if (pasted) {
+                                    onOpenReview(pasted.owner, pasted.repo, pasted.number);
+                                    return;
+                                }
+                                setQuery(value);
+                            }}
+                            placeholder="Filter by title, repo, author, number… (or paste a GitHub PR URL)"
+                            aria-label="Filter reviews"
+                            icon={SEARCH_ICON}
+                            clearable
+                            onClear={() => setQuery('')}
+                        />
+                    </div>
+                    <span className="crs-count">
+                        {visible.length} of {items.length}
+                    </span>
+                    <button
+                        type="button"
+                        className="crs-icon-btn"
+                        onClick={toggleAllSections}
+                        disabled={sections.length === 0}
+                        title={allCollapsed ? 'Expand all sections' : 'Collapse all sections'}
+                        aria-label={allCollapsed ? 'Expand all sections' : 'Collapse all sections'}
+                    >
+                        <Icon>
+                            {allCollapsed ? (
+                                <path d="M4.5 6.2L8 9.8l3.5-3.6" />
+                            ) : (
+                                <path d="M4.5 9.8L8 6.2l3.5 3.6" />
+                            )}
+                        </Icon>
+                    </button>
+                    <button
+                        type="button"
+                        className="crs-icon-btn"
+                        onClick={loadList}
+                        disabled={loading}
+                        title="Refresh"
+                        aria-label="Refresh"
+                    >
+                        <span className={loading ? 'crs-spin' : undefined}>{REFRESH_ICON}</span>
+                    </button>
+                </div>
+
+                {loading && items.length === 0 ? (
+                    <div className="crs-empty">Loading reviews…</div>
+                ) : loadError ? (
+                    <div className="crs-empty">
+                        <div>Couldn&apos;t load reviews.</div>
+                        <div className="crs-empty-hint">
+                            The server may not be running — check the bridge and try again.
                         </div>
+                        <div className="crs-empty-actions">
+                            <Button size="sm" variant="secondary" onClick={loadList}>
+                                Retry
+                            </Button>
+                        </div>
+                    </div>
+                ) : sections.length === 0 ? (
+                    <div className="crs-empty">
+                        {items.length === 0 ? (
+                            <>
+                                <div>No reviews tracked yet.</div>
+                                <div className="crs-empty-hint">
+                                    Workflows populate this list on their next run.
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                <div>
+                                    No {stateFilter === 'all' ? '' : STATE_LABELS[stateFilter]} PRs
+                                    match{hasNarrowFilters ? ' the current filters' : ''}.
+                                </div>
+                                <div className="crs-empty-actions">
+                                    {hasNarrowFilters && (
+                                        <Button
+                                            size="sm"
+                                            variant="secondary"
+                                            onClick={clearFilters}
+                                        >
+                                            Clear filters
+                                        </Button>
+                                    )}
+                                    {stateFilter !== 'all' && narrowed.length > visible.length && (
+                                        <Button
+                                            size="sm"
+                                            variant="secondary"
+                                            onClick={() => setStateFilter('all')}
+                                        >
+                                            Show everything ({narrowed.length})
+                                        </Button>
+                                    )}
+                                </div>
+                            </>
+                        )}
+                    </div>
+                ) : (
+                    sections.map(section => {
+                        const isCollapsed = collapsedSections.has(section.name);
+                        return (
+                            <section key={section.name} className="crs-section">
+                                <button
+                                    type="button"
+                                    className="crs-section-header"
+                                    onClick={() => toggleSection(section.name)}
+                                    aria-expanded={!isCollapsed}
+                                >
+                                    <span
+                                        className="crs-chevron"
+                                        style={{
+                                            transform: isCollapsed
+                                                ? 'rotate(-90deg)'
+                                                : 'rotate(0deg)',
+                                        }}
+                                    >
+                                        <Icon size={12}>
+                                            <path d="M4 6l4 4 4-4" />
+                                        </Icon>
+                                    </span>
+                                    <span>{section.name}</span>
+                                    <span className="crs-section-count">
+                                        {section.items.length}
+                                    </span>
+                                </button>
+                                {!isCollapsed &&
+                                    section.items.map(item => (
+                                        <PRRow
+                                            key={`${item.section}-${item.repo}-${item.number}-${item.title}`}
+                                            item={item}
+                                            reviewLocation={reviewLocation}
+                                            onOpenReview={onOpenReview}
+                                            onOpenPluginOutput={onOpenPluginOutput}
+                                        />
+                                    ))}
+                            </section>
+                        );
+                    })
+                )}
+            </div>
+        </div>
+    );
+}
+
+interface FacetListProps {
+    label: string;
+    facets: Facet[];
+    selected: Set<string>;
+    onToggle: (value: string) => void;
+    onClear: () => void;
+    /** Fold into a disclosure — on phones the lists would bury the reviews. */
+    collapsible: boolean;
+}
+
+/**
+ * A checkable list of values with their open-PR counts. Ten rows are visible
+ * (see `--facet-row-height` in App.css); the rest scroll.
+ */
+function FacetList({ label, facets, selected, onToggle, onClear, collapsible }: FacetListProps) {
+    if (facets.length === 0) return null;
+
+    const header = (
+        <>
+            {label}
+            {selected.size > 0 &&
+                (collapsible ? (
+                    // A button inside a <summary> would toggle the disclosure.
+                    <span className="crs-facet-selected">{selected.size} selected</span>
+                ) : (
+                    <button type="button" className="crs-link-btn" onClick={onClear}>
+                        clear
+                    </button>
+                ))}
+        </>
+    );
+
+    const list = (
+        <div className="crs-facet">
+            {facets.map(facet => (
+                <label className="crs-facet-item" key={facet.value}>
+                    <input
+                        type="checkbox"
+                        checked={selected.has(facet.value)}
+                        onChange={() => onToggle(facet.value)}
+                    />
+                    <span className="crs-facet-name" title={facet.value}>
+                        {facet.value}
+                    </span>
+                    <span
+                        className="crs-facet-count"
+                        title={`${facet.openCount} open ${facet.openCount === 1 ? 'PR' : 'PRs'}`}
+                    >
+                        {facet.openCount}
+                    </span>
+                </label>
+            ))}
+        </div>
+    );
+
+    return collapsible ? (
+        <details className="crs-sidebar-section">
+            <summary className="crs-sidebar-label">{header}</summary>
+            {list}
+        </details>
+    ) : (
+        <div className="crs-sidebar-section">
+            <div className="crs-sidebar-label">{header}</div>
+            {list}
+        </div>
+    );
+}
+
+interface PRRowProps {
+    item: ReviewItem;
+    reviewLocation: ReviewLocation;
+    onOpenReview: (owner: string, repo: string, number: number) => void;
+    onOpenPluginOutput: (owner: string, repo: string, number: number) => void;
+}
+
+function PRRow({ item, reviewLocation, onOpenReview, onOpenPluginOutput }: PRRowProps) {
+    const isPR = item.number > 0;
+    const state = prState(item);
+    const tone = stateTone(state);
+    const ease = mapReviewEase(item.review_ease);
+    const easeTone = ease ? getStatusTone(ease.variant) : null;
+    const relative = formatRelativeTime(item.created_at);
+    // Rows open wherever the preference points; the action buttons cover the
+    // other destination so both are always one click away.
+    const rowOpensGitHub = reviewLocation === 'github';
+
+    const openRow = () => {
+        if (!isPR) return;
+        if (rowOpensGitHub) window.open(item.url, '_blank');
+        else onOpenReview(item.owner, item.repo, item.number);
+    };
+
+    return (
+        <div className="crs-row">
+            <a
+                className="crs-row-link"
+                href={
+                    rowOpensGitHub
+                        ? item.url
+                        : `/?owner=${item.owner}&repo=${item.repo}&number=${item.number}`
+                }
+                onClick={e => {
+                    if (!isPR) {
+                        e.preventDefault();
+                        return;
+                    }
+                    // Let ctrl/cmd/shift/alt clicks behave like normal links.
+                    if (e.button === 0 && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey) {
+                        e.preventDefault();
+                        openRow();
+                    }
+                }}
+            >
+                <span
+                    className="crs-row-state"
+                    style={{ color: tone.fg, background: tone.bg, borderColor: tone.border }}
+                >
+                    {isPR ? state : 'item'}
+                </span>
+                <span className="crs-row-body">
+                    <span className="crs-row-title-line">
+                        <span className="crs-row-title">{item.title}</span>
+                        {ease && easeTone && (
+                            <span
+                                className="crs-row-ease"
+                                style={{
+                                    color: easeTone.fg,
+                                    background: easeTone.bg,
+                                    borderColor: easeTone.border,
+                                }}
+                                title={`Review ease: ${ease.label.toLowerCase()}`}
+                            >
+                                {ease.label}
+                            </span>
+                        )}
+                    </span>
+                    <span className="crs-row-meta">
+                        {isPR ? (
+                            <>
+                                <span className="crs-row-repo" title={`${item.owner}/${item.repo}`}>
+                                    {item.repo}
+                                </span>
+                                <span className="crs-row-number">#{item.number}</span>
+                                {item.author && (
+                                    <span title={item.author}>{authorLogin(item.author)}</span>
+                                )}
+                                {relative && (
+                                    <span title={formatAbsoluteTime(item.created_at)}>
+                                        {relative}
+                                    </span>
+                                )}
+                            </>
+                        ) : (
+                            <span style={{ fontStyle: 'italic' }}>Non-PR item</span>
+                        )}
+                    </span>
+                </span>
+            </a>
+            {isPR && (
+                <div className="crs-row-actions">
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onOpenPluginOutput(item.owner, item.repo, item.number)}
+                    >
+                        Plugins
+                    </Button>
+                    {rowOpensGitHub ? (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onOpenReview(item.owner, item.repo, item.number)}
+                        >
+                            Review
+                        </Button>
+                    ) : (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => window.open(item.url, '_blank')}
+                        >
+                            GitHub
+                        </Button>
                     )}
                 </div>
-
-                {loading ? (
-                    <div>Loading...</div>
-                ) : (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
-                        {filteredSections.length === 0 && hasActiveFilters ? (
-                            <div
-                                style={{
-                                    fontSize: '14px',
-                                    color: 'var(--text-secondary)',
-                                    fontStyle: 'italic',
-                                    textAlign: 'center',
-                                    padding: '40px 20px',
-                                }}
-                            >
-                                No items match the current filters
-                            </div>
-                        ) : (
-                            filteredSections.map((section, sIdx) => {
-                                const isCollapsed = collapsedSections.has(section.name);
-                                return (
-                                    <div key={sIdx}>
-                                        <h3
-                                            onClick={() => toggleSection(section.name)}
-                                            style={{
-                                                fontSize: '13px',
-                                                textTransform: 'uppercase',
-                                                letterSpacing: '0.05em',
-                                                color: 'var(--text-secondary)',
-                                                marginBottom: isCollapsed ? '0' : '12px',
-                                                display: 'flex',
-                                                alignItems: 'center',
-                                                gap: '8px',
-                                                borderBottom: '1px solid var(--border)',
-                                                paddingBottom: '8px',
-                                                cursor: 'pointer',
-                                                userSelect: 'none',
-                                            }}
-                                            className="hover-line"
-                                        >
-                                            <span
-                                                style={{
-                                                    display: 'inline-block',
-                                                    transition: 'transform 0.2s ease',
-                                                    transform: isCollapsed
-                                                        ? 'rotate(-90deg)'
-                                                        : 'rotate(0deg)',
-                                                    fontSize: '10px',
-                                                }}
-                                            >
-                                                ▼
-                                            </span>
-                                            <Badge
-                                                size="sm"
-                                                variant="neutral"
-                                                style={{ opacity: 0.7 }}
-                                            >
-                                                {section.items.length}
-                                            </Badge>
-                                            {section.name}
-                                        </h3>
-                                        {!isCollapsed && (
-                                            <div
-                                                style={{
-                                                    display: 'flex',
-                                                    flexDirection: 'column',
-                                                    gap: '8px',
-                                                }}
-                                            >
-                                                {section.items.length === 0 ? (
-                                                    <div
-                                                        style={{
-                                                            fontSize: '14px',
-                                                            color: 'var(--text-secondary)',
-                                                            fontStyle: 'italic',
-                                                            paddingLeft: '10px',
-                                                        }}
-                                                    >
-                                                        No items in this section
-                                                    </div>
-                                                ) : (
-                                                    section.items.map((item, iIdx) => {
-                                                        const easeDisplay = mapReviewEase(
-                                                            item.review_ease
-                                                        );
-                                                        return (
-                                                            <Card
-                                                                key={iIdx}
-                                                                variant="outlined"
-                                                                padding="md"
-                                                                hover
-                                                                className="pr-item-card"
-                                                                style={{
-                                                                    display: 'flex',
-                                                                    flexDirection: isMobile
-                                                                        ? 'column'
-                                                                        : 'row',
-                                                                    justifyContent: 'space-between',
-                                                                    alignItems: isMobile
-                                                                        ? 'stretch'
-                                                                        : 'center',
-                                                                    padding: 0, // Remove padding from card to allow <a> to fill area
-                                                                    overflow: 'hidden',
-                                                                }}
-                                                            >
-                                                                <a
-                                                                    href={
-                                                                        reviewLocation === 'github'
-                                                                            ? item.url
-                                                                            : `/?owner=${item.owner}&repo=${item.repo}&number=${item.number}`
-                                                                    }
-                                                                    onClick={e => {
-                                                                        if (item.number <= 0) {
-                                                                            e.preventDefault();
-                                                                            return;
-                                                                        }
-                                                                        // Only handle standard left-click without modifiers for SPA navigation
-                                                                        if (
-                                                                            e.button === 0 &&
-                                                                            !e.ctrlKey &&
-                                                                            !e.metaKey &&
-                                                                            !e.shiftKey &&
-                                                                            !e.altKey
-                                                                        ) {
-                                                                            e.preventDefault();
-                                                                            if (
-                                                                                reviewLocation ===
-                                                                                'github'
-                                                                            ) {
-                                                                                window.open(
-                                                                                    item.url,
-                                                                                    '_blank'
-                                                                                );
-                                                                            } else {
-                                                                                onOpenReview(
-                                                                                    item.owner,
-                                                                                    item.repo,
-                                                                                    item.number
-                                                                                );
-                                                                            }
-                                                                        }
-                                                                    }}
-                                                                    style={{
-                                                                        flex: 1,
-                                                                        textDecoration: 'none',
-                                                                        color: 'inherit',
-                                                                        padding: '16px',
-                                                                        display: 'block',
-                                                                    }}
-                                                                >
-                                                                    <div style={{ flex: 1 }}>
-                                                                        <div
-                                                                            style={{
-                                                                                display: 'flex',
-                                                                                alignItems:
-                                                                                    'center',
-                                                                                gap: '10px',
-                                                                                marginBottom: '4px',
-                                                                            }}
-                                                                        >
-                                                                            {easeDisplay && (
-                                                                                <Badge
-                                                                                    variant={
-                                                                                        easeDisplay.variant
-                                                                                    }
-                                                                                    size="sm"
-                                                                                >
-                                                                                    {
-                                                                                        easeDisplay.label
-                                                                                    }
-                                                                                </Badge>
-                                                                            )}
-                                                                            <Badge
-                                                                                variant={mapStatusToVariant(
-                                                                                    item.status
-                                                                                )}
-                                                                                size="sm"
-                                                                            >
-                                                                                {item.status}
-                                                                            </Badge>
-                                                                            <span
-                                                                                className={
-                                                                                    item.number > 0
-                                                                                        ? 'pr-title'
-                                                                                        : ''
-                                                                                }
-                                                                                style={{
-                                                                                    fontWeight: 500,
-                                                                                    fontSize:
-                                                                                        '15px',
-                                                                                }}
-                                                                            >
-                                                                                {item.title}
-                                                                            </span>
-                                                                        </div>
-                                                                        {item.number ? (
-                                                                            <div
-                                                                                style={{
-                                                                                    fontSize:
-                                                                                        '13px',
-                                                                                    color: 'var(--text-secondary)',
-                                                                                    fontFamily:
-                                                                                        'var(--font-mono)',
-                                                                                }}
-                                                                            >
-                                                                                {item.owner}/
-                                                                                {item.repo}{' '}
-                                                                                <span
-                                                                                    style={{
-                                                                                        color: 'var(--accent)',
-                                                                                    }}
-                                                                                >
-                                                                                    #{item.number}
-                                                                                </span>
-                                                                                {item.author && (
-                                                                                    <span
-                                                                                        style={{
-                                                                                            marginLeft:
-                                                                                                '8px',
-                                                                                            color: 'var(--text-secondary)',
-                                                                                        }}
-                                                                                    >
-                                                                                        by{' '}
-                                                                                        {
-                                                                                            item.author
-                                                                                        }
-                                                                                    </span>
-                                                                                )}
-                                                                            </div>
-                                                                        ) : (
-                                                                            <div
-                                                                                style={{
-                                                                                    fontSize:
-                                                                                        '12px',
-                                                                                    color: 'var(--text-secondary)',
-                                                                                    fontStyle:
-                                                                                        'italic',
-                                                                                }}
-                                                                            >
-                                                                                Non-PR item
-                                                                            </div>
-                                                                        )}
-                                                                    </div>
-                                                                </a>
-                                                                {item.number > 0 && (
-                                                                    <div
-                                                                        style={{
-                                                                            display: 'flex',
-                                                                            gap: '12px',
-                                                                            marginLeft: isMobile
-                                                                                ? 0
-                                                                                : 'auto',
-                                                                            padding: '16px',
-                                                                            paddingTop: isMobile
-                                                                                ? 0
-                                                                                : '16px',
-                                                                            paddingLeft: isMobile
-                                                                                ? '16px'
-                                                                                : 0,
-                                                                        }}
-                                                                    >
-                                                                        <Button
-                                                                            onClick={e => {
-                                                                                e.stopPropagation();
-                                                                                onOpenPluginOutput(
-                                                                                    item.owner,
-                                                                                    item.repo,
-                                                                                    item.number
-                                                                                );
-                                                                            }}
-                                                                            variant="ghost"
-                                                                            size="sm"
-                                                                        >
-                                                                            Plugins
-                                                                        </Button>
-                                                                        <Button
-                                                                            onClick={e => {
-                                                                                e.stopPropagation();
-                                                                                window.open(
-                                                                                    item.url,
-                                                                                    '_blank'
-                                                                                );
-                                                                            }}
-                                                                            variant="secondary"
-                                                                            size="sm"
-                                                                        >
-                                                                            GitHub
-                                                                        </Button>
-                                                                        <Button
-                                                                            onClick={e => {
-                                                                                e.stopPropagation();
-                                                                                onOpenReview(
-                                                                                    item.owner,
-                                                                                    item.repo,
-                                                                                    item.number
-                                                                                );
-                                                                            }}
-                                                                            size="sm"
-                                                                        >
-                                                                            Review
-                                                                        </Button>
-                                                                    </div>
-                                                                )}
-                                                            </Card>
-                                                        );
-                                                    })
-                                                )}
-                                            </div>
-                                        )}
-                                    </div>
-                                );
-                            })
-                        )}
-                    </div>
-                )}
-            </Card>
-
-            <Card padding="lg">
-                <h2 style={{ marginTop: 0, fontSize: '18px' }}>Open Review Manually</h2>
-                <form
-                    onSubmit={handleSubmit}
-                    style={{
-                        display: 'flex',
-                        flexDirection: isMobile ? 'column' : 'row',
-                        gap: '12px',
-                        alignItems: isMobile ? 'stretch' : 'flex-end',
-                        flexWrap: 'wrap',
-                    }}
-                >
-                    <Input
-                        label="Owner"
-                        type="text"
-                        value={owner}
-                        onChange={e => setOwner(e.target.value)}
-                        style={{ width: isMobile ? '100%' : '150px' }}
-                    />
-                    <Input
-                        label="Repo"
-                        type="text"
-                        value={repo}
-                        onChange={e => setRepo(e.target.value)}
-                        style={{ width: isMobile ? '100%' : '150px' }}
-                    />
-                    <Input
-                        label="PR #"
-                        type="number"
-                        value={prNumber}
-                        onChange={e => setPrNumber(e.target.value)}
-                        style={{ width: isMobile ? '100%' : '150px' }}
-                    />
-                    <Button type="submit" style={isMobile ? { width: '100%' } : undefined}>
-                        Go
-                    </Button>
-                </form>
-            </Card>
+            )}
         </div>
     );
 }

--- a/bun_client/frontend/src/config_utils.ts
+++ b/bun_client/frontend/src/config_utils.ts
@@ -79,6 +79,8 @@ export interface ConfigReply {
     message: string;
     path: string;
     config: ServerConfig;
+    /** True when no config file exists yet and the server is running its defaults. */
+    using_defaults?: boolean;
     workflow_types: WorkflowTypeInfo[];
     filters: FilterInfo[];
     /** Only present on UpdateConfig replies. */

--- a/bun_client/frontend/src/index.css
+++ b/bun_client/frontend/src/index.css
@@ -5,6 +5,10 @@
         'JetBrains Mono', 'Fira Code', source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
         monospace;
 
+    /* Height of the app's top bar. The review list pins its sidebar and
+       toolbar directly beneath it, so both read this rather than a literal. */
+    --topbar-height: 52px;
+
     /* Cross-theme fallbacks; individual themes can override these */
     --diff-line-no-bg: rgba(127, 127, 127, 0.04);
     --diff-line-no-color: rgba(127, 127, 127, 0.85);

--- a/bun_client/frontend/src/main.tsx
+++ b/bun_client/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import './App.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>

--- a/bun_client/frontend/src/pr_list_utils.test.ts
+++ b/bun_client/frontend/src/pr_list_utils.test.ts
@@ -1,0 +1,244 @@
+import { expect, test, describe } from 'bun:test';
+import {
+    authorLogin,
+    countByState,
+    facetsByOpenCount,
+    formatRelativeTime,
+    groupBySection,
+    itemMatchesQuery,
+    parseGitHubPRUrl,
+    parseTags,
+    prState,
+    uniqueValues,
+} from './pr_list_utils';
+import type { ReviewItem } from './pr_list_utils';
+
+function item(overrides: Partial<ReviewItem> = {}): ReviewItem {
+    return {
+        section: 'Open PRs',
+        status: 'TODO',
+        tags: 'code-review-server',
+        title: 'Add test files',
+        owner: 'C-Hipple',
+        repo: 'code-review-server',
+        number: 83,
+        author: 'C-Hipple',
+        url: 'https://github.com/C-Hipple/code-review-server/pull/83',
+        ...overrides,
+    };
+}
+
+describe('parseTags', () => {
+    test('splits and normalizes the comma-joined tag string', () => {
+        expect(parseTags('code-review-server, Merged ')).toEqual(['code-review-server', 'merged']);
+    });
+
+    test('returns an empty list for missing tags', () => {
+        expect(parseTags(undefined)).toEqual([]);
+        expect(parseTags('')).toEqual([]);
+    });
+});
+
+describe('prState', () => {
+    test('TODO is open', () => {
+        expect(prState(item({ status: 'TODO' }))).toBe('open');
+    });
+
+    test('WAITING is a draft', () => {
+        expect(prState(item({ status: 'WAITING' }))).toBe('draft');
+    });
+
+    test('DONE with a merged tag is merged', () => {
+        expect(prState(item({ status: 'DONE', tags: 'code-review-server,merged' }))).toBe('merged');
+    });
+
+    test('DONE without a merged tag is closed', () => {
+        expect(prState(item({ status: 'DONE' }))).toBe('closed');
+    });
+
+    test('CANCELLED is closed', () => {
+        expect(prState(item({ status: 'CANCELLED' }))).toBe('closed');
+    });
+
+    test('falls back to the tags for statuses the server does not emit', () => {
+        expect(prState(item({ status: 'PROGRESS', tags: 'repo,draft' }))).toBe('draft');
+        expect(prState(item({ status: 'PROGRESS', tags: 'repo,merged' }))).toBe('merged');
+    });
+
+    test('treats an unknown status as open rather than dropping the item', () => {
+        expect(prState(item({ status: 'BLOCKED' }))).toBe('open');
+        expect(prState(item({ status: '' }))).toBe('open');
+    });
+
+    test('does not confuse a repo named like a tag with the tag itself', () => {
+        expect(prState(item({ status: 'TODO', tags: 'mergedeep' }))).toBe('open');
+    });
+});
+
+describe('countByState', () => {
+    test('buckets every item', () => {
+        const counts = countByState([
+            item({ status: 'TODO' }),
+            item({ status: 'TODO' }),
+            item({ status: 'WAITING' }),
+            item({ status: 'DONE', tags: 'repo,merged' }),
+            item({ status: 'DONE' }),
+        ]);
+        expect(counts).toEqual({ open: 2, draft: 1, merged: 1, closed: 1 });
+    });
+
+    test('is all zeroes for no items', () => {
+        expect(countByState([])).toEqual({ open: 0, draft: 0, merged: 0, closed: 0 });
+    });
+});
+
+describe('authorLogin', () => {
+    test('strips the parenthesized full name', () => {
+        expect(authorLogin('C-Hipple (Chris Hipple)')).toBe('C-Hipple');
+    });
+
+    test('leaves a bare login alone', () => {
+        expect(authorLogin('test-user-afk')).toBe('test-user-afk');
+        expect(authorLogin(undefined)).toBe('');
+    });
+});
+
+describe('formatRelativeTime', () => {
+    const now = new Date('2026-08-06T12:00:00');
+
+    test('sub-minute is "just now"', () => {
+        expect(formatRelativeTime('2026-08-06T11:59:30', now)).toBe('just now');
+    });
+
+    test('minutes within the hour', () => {
+        expect(formatRelativeTime('2026-08-06T11:46:00', now)).toBe('14m');
+    });
+
+    test('earlier the same calendar day is "today"', () => {
+        expect(formatRelativeTime('2026-08-06T02:00:00', now)).toBe('today');
+    });
+
+    test('the previous calendar day is "yesterday"', () => {
+        expect(formatRelativeTime('2026-08-05T23:00:00', now)).toBe('yesterday');
+    });
+
+    test('days, weeks, months and years', () => {
+        expect(formatRelativeTime('2026-08-03T12:00:00', now)).toBe('3d');
+        expect(formatRelativeTime('2026-07-20T12:00:00', now)).toBe('2w');
+        expect(formatRelativeTime('2026-03-06T12:00:00', now)).toBe('5mo');
+        expect(formatRelativeTime('2024-08-06T12:00:00', now)).toBe('2y');
+    });
+
+    test('empty for missing, unparseable, or zero timestamps', () => {
+        expect(formatRelativeTime(undefined, now)).toBe('');
+        expect(formatRelativeTime('', now)).toBe('');
+        expect(formatRelativeTime('not a date', now)).toBe('');
+        expect(formatRelativeTime('0001-01-01T00:00:00Z', now)).toBe('');
+    });
+});
+
+describe('itemMatchesQuery', () => {
+    test('matches title, repo, owner and author case-insensitively', () => {
+        expect(itemMatchesQuery(item(), 'test files')).toBe(true);
+        expect(itemMatchesQuery(item(), 'CODE-REVIEW')).toBe(true);
+        expect(itemMatchesQuery(item(), 'c-hipple')).toBe(true);
+        expect(itemMatchesQuery(item(), 'nothing here')).toBe(false);
+    });
+
+    test('matches the PR number by prefix, with or without a leading hash', () => {
+        expect(itemMatchesQuery(item({ number: 83 }), '#83')).toBe(true);
+        expect(itemMatchesQuery(item({ number: 83 }), '83')).toBe(true);
+        expect(itemMatchesQuery(item({ number: 830 }), '83')).toBe(true);
+        expect(itemMatchesQuery(item({ number: 83 }), '99')).toBe(false);
+    });
+
+    test('an empty query matches everything', () => {
+        expect(itemMatchesQuery(item(), '   ')).toBe(true);
+    });
+});
+
+describe('facetsByOpenCount', () => {
+    const items = [
+        item({ repo: 'diff-lsp', status: 'TODO' }),
+        item({ repo: 'diff-lsp', status: 'TODO' }),
+        item({ repo: 'diff-lsp', status: 'DONE', tags: 'diff-lsp,merged' }),
+        item({ repo: 'gtdbot', status: 'TODO' }),
+        item({ repo: 'archived', status: 'DONE', tags: 'archived,merged' }),
+        item({ repo: 'code-review-server', status: 'TODO' }),
+    ];
+
+    test('orders by open count, then alphabetically', () => {
+        expect(facetsByOpenCount(items, i => i.repo)).toEqual([
+            { value: 'diff-lsp', openCount: 2 },
+            { value: 'code-review-server', openCount: 1 },
+            { value: 'gtdbot', openCount: 1 },
+            { value: 'archived', openCount: 0 },
+        ]);
+    });
+
+    test('keeps values whose PRs are all closed, at a count of zero', () => {
+        const facets = facetsByOpenCount(items, i => i.repo);
+        expect(facets.find(f => f.value === 'archived')).toEqual({
+            value: 'archived',
+            openCount: 0,
+        });
+    });
+
+    test('keys through a projection, so authors fold to their login', () => {
+        const authors = [
+            item({ author: 'zoe (Zoe Q)', status: 'TODO' }),
+            item({ author: 'zoe', status: 'TODO' }),
+            item({ author: '', status: 'TODO' }),
+        ];
+        expect(facetsByOpenCount(authors, i => authorLogin(i.author))).toEqual([
+            { value: 'zoe', openCount: 2 },
+        ]);
+    });
+
+    test('is empty for no items', () => {
+        expect(facetsByOpenCount([], i => i.repo)).toEqual([]);
+    });
+});
+
+describe('uniqueValues', () => {
+    test('dedupes, sorts case-insensitively, and drops blanks', () => {
+        const items = [
+            item({ author: 'zoe' }),
+            item({ author: 'Adam' }),
+            item({ author: 'zoe' }),
+            item({ author: '' }),
+        ];
+        expect(uniqueValues(items, 'author')).toEqual(['Adam', 'zoe']);
+    });
+});
+
+describe('groupBySection', () => {
+    test('keeps the order the server sent sections in', () => {
+        const grouped = groupBySection([
+            item({ section: 'Open PRs', number: 1 }),
+            item({ section: 'WaitingOnAuthor', number: 2 }),
+            item({ section: 'Open PRs', number: 3 }),
+        ]);
+        expect(grouped.map(s => s.name)).toEqual(['Open PRs', 'WaitingOnAuthor']);
+        expect(grouped[0].items.map(i => i.number)).toEqual([1, 3]);
+    });
+
+    test('files section-less items under Other', () => {
+        expect(groupBySection([item({ section: '' })])[0].name).toBe('Other');
+    });
+});
+
+describe('parseGitHubPRUrl', () => {
+    test('parses a pull request URL', () => {
+        expect(parseGitHubPRUrl('https://github.com/C-Hipple/diff-lsp/pull/12')).toEqual({
+            owner: 'C-Hipple',
+            repo: 'diff-lsp',
+            number: 12,
+        });
+    });
+
+    test('returns null for anything else', () => {
+        expect(parseGitHubPRUrl('diff-lsp')).toBeNull();
+        expect(parseGitHubPRUrl('https://github.com/C-Hipple/diff-lsp')).toBeNull();
+    });
+});

--- a/bun_client/frontend/src/pr_list_utils.ts
+++ b/bun_client/frontend/src/pr_list_utils.ts
@@ -1,0 +1,214 @@
+/**
+ * Pure helpers for the review list.
+ *
+ * The list view groups PRs by lifecycle state (open / draft / merged / closed),
+ * which the backend does not send as a field — it has to be derived from the
+ * `status` + `tags` pair the way the server itself does in `prStatusOrder`
+ * (server/server.go). Everything here is deliberately side-effect free so the
+ * derivations can be unit tested without rendering.
+ */
+
+/** Matches the ReviewItem struct from the Go backend. */
+export interface ReviewItem {
+    section: string;
+    status: string;
+    /** Comma-joined org tags: always the head repo name, plus "draft" / "merged". */
+    tags?: string;
+    title: string;
+    owner: string;
+    repo: string;
+    number: number;
+    author: string;
+    url: string;
+    /** LLM review-ease rating: "easy", "medium", "hard", or "". */
+    review_ease?: string;
+    /** RFC3339 time the item was first recorded by a workflow. */
+    created_at?: string;
+}
+
+/** The lifecycle states the sidebar buckets PRs into. */
+export type PRState = 'open' | 'draft' | 'merged' | 'closed';
+
+export const PR_STATES: readonly PRState[] = ['open', 'draft', 'merged', 'closed'];
+
+export type StateCounts = Record<PRState, number>;
+
+/** Split the backend's comma-joined tag string into normalized tags. */
+export function parseTags(tags: string | undefined): string[] {
+    return (tags || '')
+        .split(',')
+        .map(tag => tag.trim().toLowerCase())
+        .filter(Boolean);
+}
+
+/**
+ * Derive a PR's lifecycle state. Mirrors the server's own bucketing: TODO is
+ * open, WAITING is a draft, and DONE is merged or closed depending on whether
+ * the workflow tagged it "merged". Items from other org sources can carry
+ * statuses the server doesn't emit, so the tags are used as a fallback and
+ * anything left over is treated as open rather than being dropped.
+ */
+export function prState(item: ReviewItem): PRState {
+    const status = (item.status || '').toUpperCase();
+    const tags = parseTags(item.tags);
+
+    if (status === 'WAITING' || tags.includes('draft')) return 'draft';
+    if (status === 'DONE' || status === 'CANCELLED') {
+        return tags.includes('merged') ? 'merged' : 'closed';
+    }
+    if (tags.includes('merged')) return 'merged';
+    return 'open';
+}
+
+/** Count items per lifecycle state. */
+export function countByState(items: ReviewItem[]): StateCounts {
+    const counts: StateCounts = { open: 0, draft: 0, merged: 0, closed: 0 };
+    for (const item of items) {
+        counts[prState(item)]++;
+    }
+    return counts;
+}
+
+/**
+ * The backend renders authors as `login` or `login (Full Name)`. Rows are dense,
+ * so show just the login and keep the full string for the tooltip.
+ */
+export function authorLogin(author: string | undefined): string {
+    return (author || '').replace(/\s*\(.*\)\s*$/, '').trim();
+}
+
+/**
+ * Compact relative time for a row's timestamp: "just now", "14m", "today",
+ * "yesterday", "3d", "2w", "5mo", "2y". Returns '' for missing or unparseable
+ * timestamps (including Go's zero time, which arrives as year 1).
+ */
+export function formatRelativeTime(iso: string | undefined, now: Date = new Date()): string {
+    if (!iso) return '';
+    const then = new Date(iso);
+    const thenMs = then.getTime();
+    if (!Number.isFinite(thenMs)) return '';
+    // Go serializes an unset time.Time as year 1; treat anything pre-1971 as unset.
+    if (then.getFullYear() < 1971) return '';
+
+    const diffMs = now.getTime() - thenMs;
+    if (diffMs < 60_000) return 'just now';
+
+    const minutes = Math.floor(diffMs / 60_000);
+    if (minutes < 60) return `${minutes}m`;
+
+    const days = calendarDaysBetween(then, now);
+    if (days <= 0) return 'today';
+    if (days === 1) return 'yesterday';
+    if (days < 7) return `${days}d`;
+    if (days < 30) return `${Math.floor(days / 7)}w`;
+    if (days < 365) return `${Math.floor(days / 30)}mo`;
+    return `${Math.floor(days / 365)}y`;
+}
+
+/** Whole calendar days from `from` to `to`, in local time. */
+function calendarDaysBetween(from: Date, to: Date): number {
+    const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    return Math.round((startOfDay(to) - startOfDay(from)) / 86_400_000);
+}
+
+/** Absolute timestamp for a row's tooltip. */
+export function formatAbsoluteTime(iso: string | undefined): string {
+    if (!iso) return '';
+    const date = new Date(iso);
+    if (!Number.isFinite(date.getTime()) || date.getFullYear() < 1971) return '';
+    return date.toLocaleString();
+}
+
+/**
+ * Free-text match across the fields shown in a row: title, repo, owner, author,
+ * and PR number. A numeric query (with or without a leading `#`) matches the
+ * number by prefix, so the list narrows as the number is typed.
+ */
+export function itemMatchesQuery(item: ReviewItem, query: string): boolean {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return true;
+
+    const fields = [item.title, item.repo, item.owner, item.author];
+    if (fields.some(field => (field || '').toLowerCase().includes(needle))) {
+        return true;
+    }
+    const numeric = needle.replace(/^#/, '');
+    return /^\d+$/.test(numeric) && String(item.number).startsWith(numeric);
+}
+
+export interface Facet {
+    value: string;
+    /** How many of this value's rows are open PRs. */
+    openCount: number;
+}
+
+/**
+ * Build the checkable facet list for a field — every distinct value, ordered by
+ * how many open PRs it has (busiest first) and alphabetically within a tie.
+ *
+ * Counts are rows, not distinct PRs: a PR that several workflows surface appears
+ * once per section, exactly like the state counts in the sidebar above. They are
+ * also taken over all items rather than the filtered set, so checking a box
+ * never reshuffles the list under the pointer.
+ */
+export function facetsByOpenCount(items: ReviewItem[], key: (item: ReviewItem) => string): Facet[] {
+    const counts = new Map<string, number>();
+    for (const item of items) {
+        const value = key(item).trim();
+        if (!value) continue;
+        const open = prState(item) === 'open' ? 1 : 0;
+        counts.set(value, (counts.get(value) ?? 0) + open);
+    }
+    return Array.from(counts, ([value, openCount]) => ({ value, openCount })).sort(
+        (a, b) =>
+            b.openCount - a.openCount || a.value.toLowerCase().localeCompare(b.value.toLowerCase())
+    );
+}
+
+/** Unique, case-insensitively sorted values of a field across items. */
+export function uniqueValues(items: ReviewItem[], field: keyof ReviewItem): string[] {
+    const values = new Set<string>();
+    for (const item of items) {
+        const value = String(item[field] ?? '').trim();
+        if (value) values.add(value);
+    }
+    return Array.from(values).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}
+
+export interface Section {
+    name: string;
+    items: ReviewItem[];
+}
+
+/**
+ * Group items into sections, preserving the order the server sent them in
+ * (sections are already ordered by priority) and dropping empty groups.
+ */
+export function groupBySection(items: ReviewItem[]): Section[] {
+    const sections: Section[] = [];
+    const byName = new Map<string, Section>();
+    for (const item of items) {
+        const name = item.section || 'Other';
+        let section = byName.get(name);
+        if (!section) {
+            section = { name, items: [] };
+            byName.set(name, section);
+            sections.push(section);
+        }
+        section.items.push(item);
+    }
+    return sections;
+}
+
+export interface ParsedPRUrl {
+    owner: string;
+    repo: string;
+    number: number;
+}
+
+/** Parse a github.com pull request URL, so pasting one can open it directly. */
+export function parseGitHubPRUrl(value: string): ParsedPRUrl | null {
+    const match = value.match(/https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    if (!match) return null;
+    return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+}

--- a/cmd/debug_waiting_on_me/main.go
+++ b/cmd/debug_waiting_on_me/main.go
@@ -27,6 +27,10 @@ import (
 )
 
 func main() {
+	// Same identity fallback the server uses, so this tool diagnoses the
+	// configuration that actually runs rather than the file's literal contents.
+	config.LoginResolver = git_tools.GetAuthenticatedLogin
+
 	if err := config.Initialize(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize configuration: %v\n", err)
 		os.Exit(1)
@@ -36,13 +40,17 @@ func main() {
 	cfg := config.C()
 
 	fmt.Println("== Configuration ==")
+	if cfg.UsingDefaults {
+		fmt.Println("No config file — running the built-in defaults.")
+	}
 	fmt.Printf("GithubUsername (root): %q\n", cfg.GithubUsername)
 	if cfg.GithubUsername == "" {
-		fmt.Println("  !! Not set. Every identity filter (FilterWaitingOnMe, FilterMyPRs,")
-		fmt.Println("     FilterNotMyPRs, FilterMyReviewRequested) compares PRs against an empty")
-		fmt.Println("     login, so they match nothing and their sections stay empty.")
+		fmt.Println("  !! No login available: GithubUsername is unset and the API token could")
+		fmt.Println("     not be resolved to a user. Every identity filter (FilterWaitingOnMe,")
+		fmt.Println("     FilterMyPRs, FilterNotMyPRs, FilterMyReviewRequested) then compares")
+		fmt.Println("     PRs against an empty login, matching nothing.")
 	}
-	hasToken := os.Getenv("CRS_GITHUB_TOKEN") != ""
+	hasToken := git_tools.HasToken()
 	if !hasToken {
 		fmt.Println("  !! CRS_GITHUB_TOKEN is not set in this shell.")
 	}
@@ -53,10 +61,9 @@ func main() {
 	if len(repos) == 0 {
 		repos = resolveRepos(cfg)
 	}
-	if len(repos) == 0 {
-		fmt.Println("\nNo repositories configured. Set a root-level Repos list or pass owner/repo arguments.")
-		return
-	}
+	// No repos is normal now: WaitingOnMeWorkflow finds its PRs by search
+	// instead, so fall back to the same candidate set it uses.
+	useSearch := len(repos) == 0
 	if login == "" {
 		login = cfg.GithubUsername
 	}
@@ -88,6 +95,20 @@ func main() {
 	client := git_tools.GetGithubClient()
 	totalPRs, totalMatched := 0, 0
 
+	if useSearch {
+		fmt.Println("\nNo repositories configured, so these are the search candidates")
+		fmt.Println("WaitingOnMeWorkflow works from. Pass owner/repo arguments to scan a")
+		fmt.Println("repository's whole open PR list instead.")
+		prs, err := searchCandidates(login)
+		if err != nil {
+			fmt.Printf("\nSEARCH FAILED — %v\n", err)
+			fmt.Println("A workflow hitting this leaves its section untouched for the cycle.")
+			os.Exit(1)
+		}
+		matched, total := printDecisions("search candidates", prs, login, interacted)
+		totalMatched, totalPRs = matched, total
+	}
+
 	for _, entry := range repos {
 		owner, repo, err := git_tools.ParseRepoName(entry)
 		if err != nil {
@@ -106,26 +127,8 @@ func main() {
 			continue
 		}
 
-		fmt.Printf("\n%s: %d open PRs\n", entry, len(prs))
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "  MATCH\t#\tAUTHOR\tREQUESTED REVIEWERS\tTEAMS\tREASON")
-		matched := 0
-		for _, pr := range prs {
-			decision, reason := explain(pr, login, interacted)
-			if decision {
-				matched++
-			}
-			mark := "-"
-			if decision {
-				mark = "YES"
-			}
-			fmt.Fprintf(w, "  %s\t%d\t%s\t%s\t%s\t%s\n",
-				mark, pr.GetNumber(), pr.GetUser().GetLogin(),
-				joinReviewers(pr), joinTeams(pr), reason)
-		}
-		w.Flush()
-		fmt.Printf("  %d of %d matched\n", matched, len(prs))
-		totalPRs += len(prs)
+		matched, total := printDecisions(entry, prs, login, interacted)
+		totalPRs += total
 		totalMatched += matched
 	}
 
@@ -136,6 +139,29 @@ func main() {
 		fmt.Println("TEAMS instead and FilterWaitingOnMe does not match it (use the workflow's")
 		fmt.Println("Teams field for that).")
 	}
+}
+
+// printDecisions prints one table of per-PR decisions and returns how many
+// matched out of how many were checked.
+func printDecisions(label string, prs []*github.PullRequest, login string, interacted git_tools.InteractionSet) (int, int) {
+	fmt.Printf("\n%s: %d open PRs\n", label, len(prs))
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "  MATCH\t#\tAUTHOR\tREQUESTED REVIEWERS\tTEAMS\tREASON")
+	matched := 0
+	for _, pr := range prs {
+		decision, reason := explain(pr, login, interacted)
+		mark := "-"
+		if decision {
+			matched++
+			mark = "YES"
+		}
+		fmt.Fprintf(w, "  %s\t%d\t%s\t%s\t%s\t%s\n",
+			mark, pr.GetNumber(), pr.GetUser().GetLogin(),
+			joinReviewers(pr), joinTeams(pr), reason)
+	}
+	w.Flush()
+	fmt.Printf("  %d of %d matched\n", matched, len(prs))
+	return matched, len(prs)
 }
 
 // explain reruns the filter's checks for one PR — in the same order the
@@ -178,6 +204,22 @@ func explain(pr *github.PullRequest, login string, interacted git_tools.Interact
 	return true, strings.Join(reasons, "; ")
 }
 
+// usesWaitingOnMe reports whether a workflow applies FilterWaitingOnMe, either
+// because it lists the filter or because it is the search-driven workflow type
+// built around it.
+func usesWaitingOnMe(raw config.RawWorkflow) bool {
+	if raw.WorkflowType == "WaitingOnMeWorkflow" {
+		return true
+	}
+	for _, entry := range raw.Filters {
+		name, _ := workflows.ParseFilterString(strings.TrimSpace(entry))
+		if name == "FilterWaitingOnMe" {
+			return true
+		}
+	}
+	return false
+}
+
 // reportWorkflows prints the workflows that use FilterWaitingOnMe and returns
 // the login the first of them would filter with.
 func reportWorkflows(cfg config.Config) string {
@@ -185,15 +227,7 @@ func reportWorkflows(cfg config.Config) string {
 	login := ""
 	found := 0
 	for _, raw := range cfg.RawWorkflows {
-		uses := false
-		for _, entry := range raw.Filters {
-			name, _ := workflows.ParseFilterString(strings.TrimSpace(entry))
-			if name == "FilterWaitingOnMe" {
-				uses = true
-				break
-			}
-		}
-		if !uses {
+		if !usesWaitingOnMe(raw) {
 			continue
 		}
 		found++
@@ -228,16 +262,13 @@ func resolveRepos(cfg config.Config) []string {
 	seen := map[string]bool{}
 	repos := []string{}
 	for _, raw := range cfg.RawWorkflows {
-		for _, entry := range raw.Filters {
-			name, _ := workflows.ParseFilterString(strings.TrimSpace(entry))
-			if name != "FilterWaitingOnMe" {
-				continue
-			}
-			for _, r := range workflowRepos(raw, cfg) {
-				if !seen[r] {
-					seen[r] = true
-					repos = append(repos, r)
-				}
+		if !usesWaitingOnMe(raw) {
+			continue
+		}
+		for _, r := range workflowRepos(raw, cfg) {
+			if !seen[r] {
+				seen[r] = true
+				repos = append(repos, r)
 			}
 		}
 	}
@@ -245,6 +276,24 @@ func resolveRepos(cfg config.Config) []string {
 		return cfg.Repos
 	}
 	return repos
+}
+
+// searchCandidates is the candidate set WaitingOnMeWorkflow works from when no
+// repositories are configured: open review requests (mine and my teams') plus
+// every open PR I have reviewed or commented on.
+func searchCandidates(login string) ([]*github.PullRequest, error) {
+	requested, err := git_tools.ReviewRequestedRefs(login)
+	if err != nil {
+		return nil, err
+	}
+	interacted, err := git_tools.MyInteractionRefs(login)
+	if err != nil {
+		return nil, err
+	}
+	refs := git_tools.DedupeRefs(append(requested, interacted...))
+	fmt.Printf("Search found %d candidate PRs (%d review requests, %d with my reviews or comments).\n",
+		len(refs), len(requested), len(interacted))
+	return git_tools.GetPRsForRefs(git_tools.GetGithubClient(), refs)
 }
 
 func joinReviewers(pr *github.PullRequest) string {

--- a/config/config.go
+++ b/config/config.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"crs/database"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
@@ -75,8 +77,21 @@ type Config struct {
 	// file ordering. The rating is exposed as the review_ease field in PR
 	// metadata and review list items. Off by default; requires GEMINI_API_KEY.
 	ExperimentalLLMReviewEase bool
-	DB                        *database.DB
+	// UsingDefaults is true when no config file exists and the server is
+	// running DefaultConfigTOML. Nothing behaves differently because of it; it
+	// exists so clients can say so.
+	UsingDefaults bool
+	DB            *database.DB
 }
+
+// LoginResolver looks up the GitHub login the configured API token belongs to,
+// so a config that never names a user still has an identity for the filters
+// that compare PRs against "me". main wires this to
+// git_tools.GetAuthenticatedLogin; it is a variable because config cannot
+// import git_tools (git_tools reads config). A nil resolver, or one that
+// returns "", simply leaves GithubUsername empty — the behavior before this
+// existed.
+var LoginResolver func() string
 
 var (
 	c  Config
@@ -172,6 +187,17 @@ func parseConfig(data []byte) (*Config, error) {
 		pluginNames[p.Name] = true
 	}
 
+	// Fill in who "me" is from the API token when the config doesn't say. This
+	// runs before the per-workflow copy below, so a resolved login reaches the
+	// identity filters the same way a configured one does. Nothing is written
+	// back to disk: the file stays as the user wrote it.
+	if intermediate_config.GithubUsername == "" && LoginResolver != nil {
+		if login := strings.TrimSpace(LoginResolver()); login != "" {
+			slog.Debug("Using the API token's user as GithubUsername", "login", login)
+			intermediate_config.GithubUsername = login
+		}
+	}
+
 	for i := range intermediate_config.Workflows {
 		if intermediate_config.Workflows[i].GithubUsername == "" {
 			intermediate_config.Workflows[i].GithubUsername = intermediate_config.GithubUsername
@@ -221,6 +247,17 @@ func loadConfig() (*Config, error) {
 
 	the_bytes, err := os.ReadFile(configPath)
 	if err != nil {
+		// A missing config file is a first run, not a failure: the built-in
+		// defaults need nothing but a token, so the server comes up and starts
+		// filling a dashboard instead of exiting with a message about a file
+		// the user has never heard of.
+		if errors.Is(err, os.ErrNotExist) {
+			slog.Warn("No configuration file found; running with the built-in defaults",
+				"path", configPath,
+				"sections", "Waiting On Me, Review Requested",
+				"customize", "codereviewserver -print-default-config > "+configPath)
+			return DefaultConfig()
+		}
 		return nil, fmt.Errorf("failed to read config file at %s: %w", configPath, err)
 	}
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,0 +1,52 @@
+package config
+
+// DefaultConfigTOML is the configuration the server runs when no config file
+// exists. It is a real TOML document, parsed through the same path as a file on
+// disk, so what runs by default is exactly what a user gets by writing this out
+// and editing it — `codereviewserver -print-default-config` does just that.
+//
+// Neither default workflow names a repository or a user: both find their PRs
+// through GitHub search, and the login they search for is taken from the API
+// token when GithubUsername is unset. That makes a valid CRS_GITHUB_TOKEN the
+// only setup step.
+const DefaultConfigTOML = `# code-review-server configuration.
+#
+# This is the built-in default, used when this file does not exist. Both
+# workflows find their pull requests through GitHub search instead of a
+# repository list, and identify you from CRS_GITHUB_TOKEN, so there is nothing
+# here you must fill in. See https://github.com/C-Hipple/code-review-server
+# (docs/configuration.md) for everything you can add: Repos, more workflows,
+# filters, plugins, and section ordering.
+
+# Minutes between background syncs.
+SleepDuration = 10
+
+# Lower numbers sort first in the client.
+[SectionPriority]
+"Waiting On Me" = 1
+"Review Requested" = 2
+
+# PRs that need something from you right now.
+[[Workflows]]
+WorkflowType = "WaitingOnMeWorkflow"
+Name = "waiting-on-me"
+SectionTitle = "Waiting On Me"
+
+# Everything you or your teams have been asked to review, whether or not it is
+# your turn yet — the same list as github.com's "Review requests".
+[[Workflows]]
+WorkflowType = "MyReviewRequestsWorkflow"
+Name = "review-requested"
+SectionTitle = "Review Requested"
+`
+
+// DefaultConfig parses DefaultConfigTOML. The returned Config is flagged with
+// UsingDefaults so clients can tell that nothing was configured.
+func DefaultConfig() (*Config, error) {
+	cfg, err := parseConfig([]byte(DefaultConfigTOML))
+	if err != nil {
+		return nil, err
+	}
+	cfg.UsingDefaults = true
+	return cfg, nil
+}

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -1,0 +1,208 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// isolateConfigHome points config lookups at a temp directory so a test never
+// reads (or writes) the developer's real ~/.config.
+func isolateConfigHome(t *testing.T) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	t.Setenv("CRS_HOME", tempDir)
+	oldUserHomeDir := UserHomeDir
+	t.Cleanup(func() { UserHomeDir = oldUserHomeDir })
+	UserHomeDir = func() (string, error) { return tempDir, nil }
+	return tempDir
+}
+
+func TestDefaultConfigParses(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("the built-in default config does not parse: %v", err)
+	}
+
+	if !cfg.UsingDefaults {
+		t.Error("DefaultConfig should flag itself as defaults")
+	}
+	if cfg.SleepDuration != 10*time.Minute {
+		t.Errorf("SleepDuration = %v, want 10m", cfg.SleepDuration)
+	}
+	if len(cfg.Repos) != 0 {
+		t.Errorf("defaults should need no Repos, got %v", cfg.Repos)
+	}
+
+	if len(cfg.RawWorkflows) != 2 {
+		t.Fatalf("expected 2 default workflows, got %d", len(cfg.RawWorkflows))
+	}
+	want := []struct{ workflowType, section string }{
+		{"WaitingOnMeWorkflow", "Waiting On Me"},
+		{"MyReviewRequestsWorkflow", "Review Requested"},
+	}
+	for i, w := range want {
+		got := cfg.RawWorkflows[i]
+		if got.WorkflowType != w.workflowType {
+			t.Errorf("workflow %d type = %q, want %q", i, got.WorkflowType, w.workflowType)
+		}
+		if got.SectionTitle != w.section {
+			t.Errorf("workflow %d section = %q, want %q", i, got.SectionTitle, w.section)
+		}
+		if got.Name == "" {
+			t.Errorf("workflow %d has no Name", i)
+		}
+	}
+
+	// Both sections are ordered, so a first run doesn't get an arbitrary one.
+	for _, section := range []string{"Waiting On Me", "Review Requested"} {
+		if _, ok := cfg.SectionPriority[section]; !ok {
+			t.Errorf("SectionPriority has no entry for %q", section)
+		}
+	}
+}
+
+func TestDefaultConfigPassesRootValidation(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	// workflows.ValidateWorkflows covers the type/filter registries and runs in
+	// that package's tests; this is the half config owns.
+	if problems := Validate(cfg); len(problems) > 0 {
+		t.Errorf("the default config must validate cleanly, got %v", problems)
+	}
+}
+
+func TestLoadConfigFallsBackToDefaultsWhenFileMissing(t *testing.T) {
+	isolateConfigHome(t)
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("a missing config file must not be an error, got %v", err)
+	}
+	if !cfg.UsingDefaults {
+		t.Error("expected the defaults to be flagged as such")
+	}
+	if len(cfg.RawWorkflows) != 2 {
+		t.Errorf("expected the 2 default workflows, got %d", len(cfg.RawWorkflows))
+	}
+}
+
+func TestLoadConfigStillFailsOnUnparseableFile(t *testing.T) {
+	tempDir := isolateConfigHome(t)
+	path := filepath.Join(tempDir, "codereviewserver.toml")
+	if err := os.WriteFile(path, []byte("this is not = = toml"), 0o644); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+
+	if _, err := loadConfig(); err == nil {
+		t.Error("a malformed config file must still be reported, not silently replaced by defaults")
+	}
+}
+
+func TestLoadConfigUsesFileWhenPresent(t *testing.T) {
+	tempDir := isolateConfigHome(t)
+	path := filepath.Join(tempDir, "codereviewserver.toml")
+	content := `Repos = ["owner/repo"]
+
+[[Workflows]]
+WorkflowType = "SyncReviewRequestsWorkflow"
+Name = "mine"
+SectionTitle = "Mine"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.UsingDefaults {
+		t.Error("a config file exists; UsingDefaults should be false")
+	}
+	if len(cfg.RawWorkflows) != 1 || cfg.RawWorkflows[0].Name != "mine" {
+		t.Errorf("expected the file's own workflow, got %+v", cfg.RawWorkflows)
+	}
+}
+
+// Editing one setting from a client while the server is running on defaults
+// must not throw the default workflows away: the first save writes out the
+// configuration the user was actually looking at.
+func TestRenderSeedsTheDefaultsWhenNoFileExists(t *testing.T) {
+	isolateConfigHome(t)
+
+	sleep := 15
+	_, cfg, err := Update{SleepDuration: &sleep}.Render()
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	if cfg.SleepDuration != 15*time.Minute {
+		t.Errorf("SleepDuration = %v, want the update's 15m", cfg.SleepDuration)
+	}
+	if len(cfg.RawWorkflows) != 2 {
+		t.Fatalf("the default workflows must survive the first save, got %d", len(cfg.RawWorkflows))
+	}
+	if cfg.RawWorkflows[0].WorkflowType != "WaitingOnMeWorkflow" {
+		t.Errorf("unexpected first workflow %+v", cfg.RawWorkflows[0])
+	}
+	if len(cfg.SectionPriority) != 2 {
+		t.Errorf("section ordering should survive too, got %v", cfg.SectionPriority)
+	}
+}
+
+func TestLoginResolverFillsMissingUsername(t *testing.T) {
+	old := LoginResolver
+	t.Cleanup(func() { LoginResolver = old })
+	LoginResolver = func() string { return "resolved-user" }
+
+	cfg, err := parseConfig([]byte(`
+[[Workflows]]
+WorkflowType = "SyncReviewRequestsWorkflow"
+Name = "mine"
+SectionTitle = "Mine"
+`))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.GithubUsername != "resolved-user" {
+		t.Errorf("GithubUsername = %q, want the resolved login", cfg.GithubUsername)
+	}
+	// The workflow-level copy has to see the resolved value too, since that is
+	// what the identity filters are built from.
+	if cfg.RawWorkflows[0].GithubUsername != "resolved-user" {
+		t.Errorf("workflow GithubUsername = %q, want the resolved login", cfg.RawWorkflows[0].GithubUsername)
+	}
+}
+
+func TestLoginResolverDoesNotOverrideConfiguredUsername(t *testing.T) {
+	old := LoginResolver
+	t.Cleanup(func() { LoginResolver = old })
+	LoginResolver = func() string { return "resolved-user" }
+
+	cfg, err := parseConfig([]byte("GithubUsername = \"configured-user\"\n"))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.GithubUsername != "configured-user" {
+		t.Errorf("GithubUsername = %q, want the configured value to win", cfg.GithubUsername)
+	}
+}
+
+func TestParseConfigWithoutResolverLeavesUsernameEmpty(t *testing.T) {
+	old := LoginResolver
+	t.Cleanup(func() { LoginResolver = old })
+	LoginResolver = nil
+
+	cfg, err := parseConfig([]byte("Repos = [\"owner/repo\"]\n"))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.GithubUsername != "" {
+		t.Errorf("GithubUsername = %q, want empty when nothing can resolve it", cfg.GithubUsername)
+	}
+}

--- a/config/file.go
+++ b/config/file.go
@@ -77,13 +77,18 @@ func (u Update) Render() ([]byte, *Config, error) {
 	if err != nil && !os.IsNotExist(err) {
 		return nil, nil, fmt.Errorf("failed to read config file at %s: %w", path, err)
 	}
-	if err == nil {
-		if err := toml.Unmarshal(existing, &doc); err != nil {
-			return nil, nil, fmt.Errorf("failed to parse config file at %s: %w", path, err)
-		}
-		if doc == nil {
-			doc = map[string]any{}
-		}
+	if os.IsNotExist(err) {
+		// There is no file yet, so the server is running the built-in defaults.
+		// Seed the document with them: the first save has to materialize the
+		// configuration the user has been looking at, otherwise changing one
+		// unrelated setting would silently drop the default workflows.
+		existing = []byte(DefaultConfigTOML)
+	}
+	if err := toml.Unmarshal(existing, &doc); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse config file at %s: %w", path, err)
+	}
+	if doc == nil {
+		doc = map[string]any{}
 	}
 
 	setKey(doc, "Repos", u.Repos)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,9 @@ codereviewserver -list-sections
 
 # Get details for a specific PR
 codereviewserver -pr owner/repo/123
+
+# Print the built-in default configuration
+codereviewserver -print-default-config
 ```
 
 ## Flags
@@ -75,6 +78,16 @@ URL: https://github.com/myorg/myrepo/pull/123
 State: open
 ...
 ```
+
+### `-print-default-config`
+
+Prints the configuration the server runs when `~/.config/codereviewserver.toml` does not exist (see [Configuration](configuration.md#running-without-a-config-file)) and exits. Unlike the other flags this one touches neither the config file nor the database, so it works on a machine that has neither — which is the point:
+
+```bash
+codereviewserver -print-default-config > ~/.config/codereviewserver.toml
+```
+
+Logs go to stderr, so the redirect above captures only TOML.
 
 ## Use Cases
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,37 @@ code-review-server works from a toml config expected at the path `~/.config/code
 export CRS_GITHUB_TOKEN="Github Token"
 ```
 
+## Running Without a Config File
+
+The config file is optional. With a token set and no `~/.config/codereviewserver.toml`, the server logs a warning naming the path it looked at and runs a built-in default configuration:
+
+| Section | What it holds |
+| --- | --- |
+| **Waiting On Me** | PRs in your court right now: an open review request (yours or one of your teams'), an approval that CODEOWNERS dismissed, or a comment thread waiting on your reply. |
+| **Review Requested** | Everything you or your teams have been asked to review, whether or not it is your turn — the same list as github.com's "Review requests". |
+
+Neither default names a repository or a user. They find their PRs through GitHub search rather than by listing configured repos, and the login they search for comes from the API token (see [Identity](#identity)), so a token is the only setup step.
+
+Print the defaults to start your own config from them:
+
+```bash
+codereviewserver -print-default-config > ~/.config/codereviewserver.toml
+```
+
+Editing the config from a client while running on defaults writes the same thing: the first save materializes the default workflows alongside whatever you changed, so nothing disappears out from under you.
+
+Note that a config file which *exists* but can't be parsed is still an error — the defaults are only a fallback for "no file at all", never a silent replacement for a config you meant to work.
+
+## Identity
+
+Several filters, and both default workflows, compare pull requests against *you*. That identity is resolved in this order:
+
+1. The workflow's own `GithubUsername`.
+2. The root-level `GithubUsername`.
+3. The user the `CRS_GITHUB_TOKEN` belongs to, looked up from the GitHub API at startup and cached.
+
+The looked-up login is never written to your config file. Setting `GithubUsername` explicitly is still worth doing if the token belongs to a bot or a shared account, since it takes precedence.
+
 ## General Fields
 
 The basic format is root level config for general fields:
@@ -57,7 +88,7 @@ Per workflow:
 - A filter is not one this server knows, an argument-taking filter (`FilterByLabel`, `FilterByAuthor`, `FilterExcludeAuthor`) is missing its argument, or an argument is given to a filter that takes none.
 - A `Repos` entry is not in `owner/repo` form, or a `Teams` entry is empty.
 - `PRState` is set to something other than `open`, `closed`, or `all`.
-- The workflow has no repositories to work with: neither its own `Repos` nor a root-level `Repos` list.
+- The workflow has no repositories to work with: neither its own `Repos` nor a root-level `Repos` list. (The search-driven types — `WaitingOnMeWorkflow` and `MyReviewRequestsWorkflow` — need no repositories and are exempt.)
 - `ProjectListWorkflow` is missing `JiraEpic`, or `SingleRepoSyncReviewRequestsWorkflow` is missing a valid `Repo`.
 
 ## Workflows
@@ -84,6 +115,8 @@ The `GithubUsername` can be set at the top level of the config file. If a workfl
 
 The WorkflowType is one of the following strings:
 - `SyncReviewRequestsWorkflow`
+- `WaitingOnMeWorkflow`
+- `MyReviewRequestsWorkflow`
 - `SingleRepoSyncReviewRequestsWorkflow` (deprecated, use `SyncReviewRequestsWorkflow` with single-element `Repos`)
 - `ListMyPRsWorkflow` (deprecated, use `SyncReviewRequestsWorkflow` with `FilterMyPRs` in filters)
 - `ProjectListWorkflow`
@@ -95,6 +128,27 @@ The WorkflowType is one of the following strings:
 > This will make the file get very long very quickly. I recommend only using this for specific workflows which target your non-main reviews org file.
 
 ### Workflow Specific Configurations
+
+#### WaitingOnMeWorkflow and MyReviewRequestsWorkflow (search-driven)
+
+These are the two workflows the [default configuration](#running-without-a-config-file) runs, and they are ordinary workflow types you can put in your own config:
+
+```toml
+[[Workflows]]
+WorkflowType = "MyReviewRequestsWorkflow"
+Name = "review-requested"
+SectionTitle = "Review Requested"
+Filters = ["FilterNotDraft"]   # optional, further narrows the section
+```
+
+They take no `Repos`, `Teams`, or `PRState`. Instead of listing the open PRs of configured repositories, they ask GitHub search:
+
+- `MyReviewRequestsWorkflow` runs `review-requested:<you>` plus `team-review-requested:<org>/<team>` for every team you belong to, since the direct qualifier does not expand to team membership. Archived repos are excluded, matching github.com's own list. Teams past the first ten are skipped, to stay inside the search API's 30-requests-per-minute budget.
+- `WaitingOnMeWorkflow` takes those same review requests plus `reviewed-by:<you>` and `commenter:<you>` as its candidates, then applies `FilterWaitingOnMe` (the same filter you can use in any other workflow) to keep only the PRs actually in your court.
+
+Search results carry no reviewer or branch data, so each candidate PR is then fetched individually — one API call per candidate, capped at 250 per cycle. That is more per-PR traffic than listing a repo, and the reason to prefer an explicit `Repos` list with `SyncReviewRequestsWorkflow` once you know exactly which repositories you care about.
+
+If a search fails (rate limit, outage), the workflow logs the failure and leaves its section exactly as it was rather than treating "no results" as "everything went away".
 
 #### SingleRepoSyncReviewRequestsWorkflow (Deprecated)
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -21,9 +21,11 @@ Each workflow can use the available filters to customize which PRs are included.
 
 ## Filters that need your GitHub username
 
-`FilterMyReviewRequested`, `FilterMyPRs`, `FilterNotMyPRs`, `FilterWaitingOnMe` and `FilterWaitingOnAuthor` compare each PR against *your* GitHub login. They read `GithubUsername` from the workflow, falling back to the root-level setting.
+`FilterMyReviewRequested`, `FilterMyPRs`, `FilterNotMyPRs`, `FilterWaitingOnMe` and `FilterWaitingOnAuthor` compare each PR against *your* GitHub login. They read `GithubUsername` from the workflow, falling back to the root-level setting, and finally to the user your `CRS_GITHUB_TOKEN` belongs to — looked up from the GitHub API and never written to your config file.
 
-If neither is set, a workflow using one of these filters is **skipped at startup** with an explanatory log line, and the config editor reports the same problem. (Previously the filter simply matched nothing, leaving the section silently empty.)
+So in the common case you don't have to set `GithubUsername` at all. Set it anyway when the token belongs to a bot or a shared account, since an explicit value wins.
+
+If none of the three yields a login — no `GithubUsername` and no usable token — a workflow using one of these filters is **skipped at startup** with an explanatory log line, and the config editor reports the same problem. (Previously the filter simply matched nothing, leaving the section silently empty.)
 
 To see what the filter decides for each of your open PRs, run:
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -643,10 +643,13 @@ Returns the server's configuration file, re-read from disk so the client sees ed
 | `message`        | string             | Empty on success; explains the problem when the file can't be read |
 | `path`           | string             | Absolute path of the TOML file being read and written              |
 | `config`         | Config             | The current configuration (see below)                              |
+| `using_defaults` | bool               | `true` when no file exists at `path` and the built-in defaults are running |
 | `workflow_types` | []WorkflowTypeInfo | Workflow types this server can run                                 |
 | `filters`        | []FilterInfo       | Filters a workflow may use                                         |
 
 If the file on disk no longer parses, `okay` is `false` and `config` describes the configuration still running in memory.
+
+When `using_defaults` is `true` there is no file yet; `config` describes the built-in defaults (see [Configuration](configuration.md#running-without-a-config-file)). Any `UpdateConfig` call writes them out along with the change, so a client can present them as an ordinary editable configuration.
 
 #### `Config` Object
 

--- a/docs/web_client_features.md
+++ b/docs/web_client_features.md
@@ -131,24 +131,44 @@ The WebSocket handlers translate between browser JSON messages and LSP's
 The landing view. Backed by a single `GetAllReviews` call; the client uses the
 structured `items` array (not the org-mode `content` string).
 
+Laid out as a fixed sidebar of filters beside a dense, full-width list of rows.
+
+- **State sidebar** — Open / Draft / Merged / Closed / Everything, each with a live
+  count. The state is derived client-side from `status` + `tags`, mirroring the
+  server's own bucketing (`prStatusOrder`): `TODO` is open, `WAITING` is a draft,
+  `DONE` is merged when tagged `merged` and closed otherwise; anything else falls
+  back to the tags and then to open, so no item is ever dropped. The list opens on
+  **Open** and remembers the last choice in `localStorage`.
 - **Sectioned list** — items grouped by `item.section`, ungrouped items land in
-  "Other". Each section is collapsible, with a count badge, plus global
-  Collapse All / Expand All.
-- **Per-item card** — status badge (`TODO` / `WAITING` / `DONE`, mapped to a color
-  variant), `review_ease` badge when the LLM rating is enabled, title,
-  `owner/repo #number`, and author.
+  "Other", in the order the server sent them. Each section is a collapsible header
+  with its own count, plus a global collapse/expand toggle in the toolbar.
+- **Per-item row** — lifecycle pill (open / draft / merged / closed, in a fixed-width
+  column so titles align), title, `review_ease` pill when the LLM rating is enabled,
+  and a meta line of repo, `#number`, author login, and a relative timestamp from
+  `created_at` (full timestamp on hover).
 - **Non-PR items** — items with `number <= 0` render as "Non-PR item" and are not
   clickable.
-- **Actions per row** — Review (open in-app), Plugins (open the plugin view),
-  GitHub (open `item.url` in a new tab).
-- **Text filter** — matches title, author, owner, or repo.
+- **Actions per row** — revealed on hover or keyboard focus: Plugins (open the plugin
+  view) plus whichever of Review / GitHub the row click doesn't already go to, which
+  depends on the Preferred Review Location preference.
+- **Text filter** — matches title, repo, owner, author, and PR number (with or
+  without a leading `#`, by prefix). A "N of M" counter sits beside it.
 - **GitHub URL paste** — pasting `https://github.com/{owner}/{repo}/pull/{n}` into the
   filter box opens that review directly instead of filtering.
-- **Faceted dropdowns** — Status (static list) plus Author / Owner / Repo, whose
-  options are derived from the loaded items. Clear-all button and a
-  "Showing N of M items" counter appear when any filter is active.
-- **Manual open form** — owner / repo / number, for PRs not in any section.
-- **Refresh** — re-issues `GetAllReviews`.
+- **Repo / author narrowing** — a checkable list per field, each value shown with its
+  open-PR count and ordered by it (busiest first, alphabetical within a tie); ten rows
+  are visible before the list scrolls. Counts are row counts over all items, like the
+  state counts, and are computed independently of the current filters so checking a
+  box never reorders the list under the pointer. Several boxes OR together within a
+  field and AND across fields. The All repos / All authors dropdowns above them are
+  single-value shortcuts into the same selection — picking one replaces the selection,
+  and they read "N repos selected" when the list holds more than one — so the two
+  controls can't disagree. Narrowing (and the text filter) is applied before the state
+  counts, so the sidebar describes what the current search holds. On phones both lists
+  fold into disclosures so they don't bury the reviews.
+- **Manual open form** — a collapsed disclosure in the sidebar taking owner / repo /
+  number, for PRs not in any section.
+- **Refresh** — re-issues `GetAllReviews`; a failed load offers a retry.
 - **Plugin warm-up** — after loading, the list fires a `GetPluginOutput` call for
   every visible PR and ignores the results. This is deliberate: it starts deferred
   plugin execution server-side so output is ready by the time a PR is opened.
@@ -168,6 +188,10 @@ structured `items` array (not the org-mode `content` string).
   both ends.
 - **Dynamic document title** — `Code Review` on the list, `{title} (#{number})` in a
   review, `Plugins {owner}/{repo}::{number}` in the plugin view.
+- **Top bar** — wordmark, the active view's tab, the prev / next / back controls, and
+  preferences. Pinned on the list (whose sidebar and toolbar stick beneath it, offset
+  by `--topbar-height`); static in the review view, whose own sticky toolbar measures
+  itself against the viewport top.
 
 ### 3.3 PR header (`PRHeader.tsx`)
 
@@ -397,7 +421,9 @@ Client-side only, persisted in `localStorage`:
 `useMediaQuery` / `useIsMobile` drive real behavioral changes, not just CSS: line
 wrapping defaults on, the diff becomes horizontally scrollable, line-number gutters
 are hidden, split view is disabled, the code viewer goes full-screen, inline cards
-stick to the left edge, and the bottom review action bar appears.
+stick to the left edge, and the bottom review action bar appears. The review list
+restacks in CSS alone: the sidebar becomes a header, its state buckets a horizontally
+scrolling strip, and row actions stay visible instead of waiting for a hover.
 
 ### 3.16 Miscellaneous
 

--- a/docs/web_client_features.md
+++ b/docs/web_client_features.md
@@ -389,6 +389,9 @@ Configuration tab. Built on `GetConfig` / `UpdateConfig`.
 
 - Global settings: repos, sync interval, GitHub username, repo location, Jira domain,
   auto-worktree, desktop notifications.
+- **Defaults banner** — when the reply's `using_defaults` is true there is no config file
+  yet and the editor is showing the server's built-in defaults; the usual "editing
+  `<path>`" line is replaced by one saying that saving is what creates the file.
 - Workflow list: collapsible cards, add / delete (with confirmation) / reorder.
 - **Pickers are built from the reply's `workflow_types` and `filters` registries**, not
   hard-coded — so the editor keeps working when the server gains a type or filter.

--- a/git_tools/identity.go
+++ b/git_tools/identity.go
@@ -1,0 +1,109 @@
+package git_tools
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/go-github/v74/github"
+)
+
+const (
+	// authenticatedLoginTTL caches the token→login lookup. The answer only
+	// changes when the token does, so this is really just a guard against
+	// asking again on every config reload.
+	authenticatedLoginTTL = 1 * time.Hour
+
+	// authenticatedLoginErrTTL caches a failed lookup briefly, so a bad or
+	// rate-limited token doesn't produce a request per config reload while
+	// still recovering within a cycle or two.
+	authenticatedLoginErrTTL = 2 * time.Minute
+
+	myTeamsTTL = 30 * time.Minute
+)
+
+// HasToken reports whether a GitHub token is configured. GetGithubClient exits
+// the process without one, so anything that runs before the server has proven
+// it can talk to GitHub — config loading, in particular — checks this first.
+func HasToken() bool {
+	return os.Getenv("CRS_GITHUB_TOKEN") != ""
+}
+
+// GetAuthenticatedLogin returns the GitHub login that CRS_GITHUB_TOKEN belongs
+// to, so a user doesn't have to tell the config who they are. Returns "" when
+// there is no token or the lookup fails; callers treat that as "identity
+// unknown" rather than an error, because every one of them has a configured
+// GithubUsername to fall back on.
+func GetAuthenticatedLogin() string {
+	if !HasToken() {
+		slog.Warn("No CRS_GITHUB_TOKEN set; cannot look up which GitHub user this server is running as")
+		return ""
+	}
+
+	const cacheKey = "authenticated_login"
+	if val, found := GlobalCache.Get(cacheKey); found {
+		return val.(string)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// An empty user asks for the user the token authenticates as.
+	user, _, err := GetGithubClient().Users.Get(ctx, "")
+	if err != nil {
+		slog.Error("Failed to look up the authenticated GitHub user; identity filters need GithubUsername in the config", "error", err)
+		GlobalCache.Set(cacheKey, "", authenticatedLoginErrTTL)
+		return ""
+	}
+
+	login := user.GetLogin()
+	if login == "" {
+		slog.Error("GitHub returned no login for the authenticated user")
+		GlobalCache.Set(cacheKey, "", authenticatedLoginErrTTL)
+		return ""
+	}
+	slog.Info("Resolved GitHub identity from the API token", "login", login)
+	GlobalCache.Set(cacheKey, login, authenticatedLoginTTL)
+	return login
+}
+
+// GetMyTeamRefs returns every team the authenticated user belongs to as
+// "org/team-slug" — the form GitHub's team-review-requested: search qualifier
+// takes. GetMyTeams returns bare slugs instead, which is what the Teams config
+// field matches against.
+func GetMyTeamRefs() []string {
+	if !HasToken() {
+		return nil
+	}
+
+	const cacheKey = "my_team_refs"
+	if val, found := GlobalCache.Get(cacheKey); found {
+		return val.([]string)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	teams, err := listAllPages(func(opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+		return GetGithubClient().Teams.ListUserTeams(ctx, opts)
+	})
+	if err != nil {
+		slog.Error("Failed to list the teams you belong to; team review requests will be missed", "error", err)
+		return nil
+	}
+
+	refs := []string{}
+	for _, team := range teams {
+		if team == nil || team.GetSlug() == "" || team.GetOrganization() == nil {
+			continue
+		}
+		org := team.GetOrganization().GetLogin()
+		if org == "" {
+			continue
+		}
+		refs = append(refs, org+"/"+team.GetSlug())
+	}
+	GlobalCache.Set(cacheKey, refs, myTeamsTTL)
+	return refs
+}

--- a/git_tools/pr_search.go
+++ b/git_tools/pr_search.go
@@ -1,0 +1,241 @@
+// Search-driven PR discovery.
+//
+// The rest of this package finds pull requests by listing the configured
+// repositories. That requires a Repos list, which is the bulk of what a new
+// user has to write down before the server does anything useful. GitHub's
+// search API answers the two questions a review dashboard actually starts from
+// — "who wants a review from me?" and "which PRs have I touched?" — across
+// every repository the token can see, with no repo list at all.
+//
+// Search results are issues, not pull requests: they carry the repository only
+// as an API URL and none of the reviewer/branch data the filters read. So the
+// helpers here return PRRefs and callers fetch the full PR for the ones they
+// still care about (GetPRsForRefs). That fetch is one core API call per
+// candidate, which is why the candidate searches are kept narrow and the result
+// is capped (maxCandidateRefs).
+
+package git_tools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// PRRef identifies a single pull request.
+type PRRef struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+func (r PRRef) String() string {
+	return fmt.Sprintf("%s/%s#%d", r.Owner, r.Repo, r.Number)
+}
+
+const (
+	searchRefsPageSize = 100
+	// searchRefsMaxPages bounds a single search at 5×100 results. Anything
+	// past that means the query matched far more than a review queue, and a
+	// silently truncated list is worse than a loud failure.
+	searchRefsMaxPages = 5
+
+	// maxTeamSearches bounds how many team-review-requested: searches one
+	// cycle issues. The search API allows 30 requests a minute; someone in
+	// dozens of teams would otherwise spend the whole budget here.
+	maxTeamSearches = 10
+
+	// maxCandidateRefs caps how many PRs a workflow will fetch in one cycle,
+	// since each ref costs a core API call. Well past any real review queue.
+	maxCandidateRefs = 250
+
+	// candidateRefsTTL is short enough that a new review request shows up on
+	// the next cycle, long enough that workflows sharing a search in the same
+	// cycle only pay for it once.
+	candidateRefsTTL = 2 * time.Minute
+
+	// prFetchConcurrency caps the parallel PR fetches behind GetPRsForRefs.
+	prFetchConcurrency = 8
+)
+
+// Seams for tests; production always points these at the real lookups.
+var (
+	searchPRRefs = searchPRRefsFromGithub
+	myTeamRefs   = GetMyTeamRefs
+)
+
+// ReviewRequestedRefs returns the open PRs GitHub is asking login to review —
+// both the requests made of them directly and the requests made of a team they
+// belong to. That union is what github.com's own "Review requests" list shows,
+// and the two halves need separate search qualifiers: review-requested: does
+// not expand to team membership.
+func ReviewRequestedRefs(login string) ([]PRRef, error) {
+	if login == "" {
+		return nil, fmt.Errorf("cannot search for review requests without a GitHub login")
+	}
+	return cachedRefSearch("review_requested:"+strings.ToLower(login), func() []string {
+		return ReviewRequestedQueries(login, myTeamRefs())
+	})
+}
+
+// MyInteractionRefs returns the open PRs login has reviewed or commented on.
+// These are the PRs that can be waiting on login for a reason other than an
+// open review request: a dismissed approval, or a thread of theirs that needs
+// an answer. See interaction_prefilter.go for why it takes two queries.
+func MyInteractionRefs(login string) ([]PRRef, error) {
+	if login == "" {
+		return nil, fmt.Errorf("cannot search for interactions without a GitHub login")
+	}
+	return cachedRefSearch("my_interactions:"+strings.ToLower(login), func() []string {
+		return []string{
+			fmt.Sprintf("is:pr is:open reviewed-by:%s", login),
+			fmt.Sprintf("is:pr is:open commenter:%s", login),
+		}
+	})
+}
+
+// ReviewRequestedQueries builds the searches behind ReviewRequestedRefs.
+// archived:false matches what github.com's review-request list shows: a PR in
+// an archived repo can't be reviewed. Teams beyond maxTeamSearches are dropped
+// rather than spending the search rate limit on them.
+func ReviewRequestedQueries(login string, teams []string) []string {
+	queries := []string{fmt.Sprintf("is:pr is:open archived:false review-requested:%s", login)}
+	if len(teams) > maxTeamSearches {
+		slog.Warn("You belong to more teams than one cycle searches; team review requests from the rest will be missed",
+			"teams", len(teams), "searched", maxTeamSearches)
+		teams = teams[:maxTeamSearches]
+	}
+	for _, team := range teams {
+		if strings.TrimSpace(team) == "" {
+			continue
+		}
+		queries = append(queries, fmt.Sprintf("is:pr is:open archived:false team-review-requested:%s", team))
+	}
+	return queries
+}
+
+// cachedRefSearch runs queries (built lazily, so team lookups are skipped on a
+// cache hit) and caches the union. Failures are not cached: unlike the
+// interaction prefilter, which fails open into a slower-but-correct path, a
+// failed search here means the workflow has no candidates at all, and caching
+// that would extend one bad minute across several cycles.
+func cachedRefSearch(cacheKey string, buildQueries func() []string) ([]PRRef, error) {
+	if val, found := GlobalCache.Get(cacheKey); found {
+		return val.([]PRRef), nil
+	}
+	var refs []PRRef
+	for _, query := range buildQueries() {
+		found, err := searchPRRefs(query)
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, found...)
+	}
+	refs = DedupeRefs(refs)
+	GlobalCache.Set(cacheKey, refs, candidateRefsTTL)
+	return refs, nil
+}
+
+// DedupeRefs removes duplicates, keeping first-seen order. Searches overlap by
+// design — a PR can be both directly requested and requested from a team.
+func DedupeRefs(refs []PRRef) []PRRef {
+	seen := make(map[PRRef]struct{}, len(refs))
+	out := make([]PRRef, 0, len(refs))
+	for _, ref := range refs {
+		if _, dup := seen[ref]; dup {
+			continue
+		}
+		seen[ref] = struct{}{}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func searchPRRefsFromGithub(query string) ([]PRRef, error) {
+	client := GetGithubClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	refs := []PRRef{}
+	opts := &github.SearchOptions{ListOptions: github.ListOptions{PerPage: searchRefsPageSize, Page: 1}}
+	for page := 0; ; page++ {
+		if page == searchRefsMaxPages {
+			return nil, fmt.Errorf("search %q did not terminate within %d pages", query, searchRefsMaxPages)
+		}
+		result, resp, err := client.Search.Issues(ctx, query, opts)
+		if err != nil {
+			return nil, fmt.Errorf("search %q: %w", query, err)
+		}
+		if result.GetIncompleteResults() {
+			return nil, fmt.Errorf("search %q returned incomplete results", query)
+		}
+		for _, issue := range result.Issues {
+			owner, repo, ok := splitRepositoryAPIURL(issue.GetRepositoryURL())
+			if !ok || issue.Number == nil {
+				continue
+			}
+			refs = append(refs, PRRef{Owner: owner, Repo: repo, Number: *issue.Number})
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return refs, nil
+}
+
+// GetPRsForRefs fetches the full pull request behind each ref, concurrently.
+//
+// A ref GitHub answers with 404/410 is skipped with a warning rather than
+// failing the batch: the search index lags repository transfers and deletions,
+// and one dead ref must not be able to hold a section hostage every cycle. Any
+// other error fails the whole call, so a rate-limited or broken cycle leaves
+// the caller's section alone instead of emptying it.
+func GetPRsForRefs(client *github.Client, refs []PRRef) ([]*github.PullRequest, error) {
+	if len(refs) > maxCandidateRefs {
+		slog.Warn("Candidate PR list is longer than one cycle fetches; ignoring the excess",
+			"candidates", len(refs), "fetching", maxCandidateRefs)
+		refs = refs[:maxCandidateRefs]
+	}
+
+	prs := make([]*github.PullRequest, len(refs))
+	errs := make([]error, len(refs))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, prFetchConcurrency)
+	for i, ref := range refs {
+		wg.Add(1)
+		go func(i int, ref PRRef) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			pr, resp, err := client.PullRequests.Get(context.Background(), ref.Owner, ref.Repo, ref.Number)
+			if err != nil {
+				if resp != nil && (resp.StatusCode == 404 || resp.StatusCode == 410) {
+					slog.Warn("Skipping search result the API no longer serves", "pr", ref.String(), "status", resp.StatusCode)
+					return
+				}
+				errs[i] = fmt.Errorf("fetching %s: %w", ref.String(), err)
+				return
+			}
+			prs[i] = pr
+		}(i, ref)
+	}
+	wg.Wait()
+
+	found := make([]*github.PullRequest, 0, len(refs))
+	for i := range refs {
+		if errs[i] != nil {
+			return nil, errs[i]
+		}
+		if prs[i] != nil {
+			found = append(found, prs[i])
+		}
+	}
+	return found, nil
+}

--- a/git_tools/pr_search_test.go
+++ b/git_tools/pr_search_test.go
@@ -1,0 +1,189 @@
+package git_tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// stubSearch swaps in a fake search (and an empty team list, so no test ever
+// reaches the real API) for the duration of a test, and records the queries it
+// was asked for.
+func stubSearch(t *testing.T, results map[string][]PRRef, err error) *[]string {
+	t.Helper()
+	oldSearch, oldTeams := searchPRRefs, myTeamRefs
+	t.Cleanup(func() { searchPRRefs, myTeamRefs = oldSearch, oldTeams })
+	myTeamRefs = func() []string { return nil }
+
+	queries := []string{}
+	searchPRRefs = func(query string) ([]PRRef, error) {
+		queries = append(queries, query)
+		if err != nil {
+			return nil, err
+		}
+		return results[query], nil
+	}
+	return &queries
+}
+
+// Each test needs its own login, since the ref searches are cached globally by
+// login for a couple of minutes.
+func testLogin(t *testing.T) string {
+	t.Helper()
+	return "user-" + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+func TestReviewRequestedQueriesCoverDirectAndTeamRequests(t *testing.T) {
+	queries := ReviewRequestedQueries("octocat", []string{"acme/reviewers", "acme/platform"})
+
+	if len(queries) != 3 {
+		t.Fatalf("expected one direct query plus one per team, got %v", queries)
+	}
+	if !strings.Contains(queries[0], "review-requested:octocat") {
+		t.Errorf("first query should be the direct request search, got %q", queries[0])
+	}
+	if !strings.Contains(queries[1], "team-review-requested:acme/reviewers") ||
+		!strings.Contains(queries[2], "team-review-requested:acme/platform") {
+		t.Errorf("team queries missing: %v", queries)
+	}
+	for _, q := range queries {
+		for _, qualifier := range []string{"is:pr", "is:open", "archived:false"} {
+			if !strings.Contains(q, qualifier) {
+				t.Errorf("query %q is missing %q", q, qualifier)
+			}
+		}
+	}
+}
+
+func TestReviewRequestedQueriesWithoutTeams(t *testing.T) {
+	queries := ReviewRequestedQueries("octocat", nil)
+	if len(queries) != 1 {
+		t.Fatalf("expected just the direct request search, got %v", queries)
+	}
+}
+
+// Someone in dozens of teams would otherwise spend the whole search rate limit
+// on this one workflow.
+func TestReviewRequestedQueriesCapTeamSearches(t *testing.T) {
+	teams := make([]string, 25)
+	for i := range teams {
+		teams[i] = fmt.Sprintf("acme/team-%d", i)
+	}
+	queries := ReviewRequestedQueries("octocat", teams)
+	if len(queries) != maxTeamSearches+1 {
+		t.Errorf("expected %d queries (direct + capped teams), got %d", maxTeamSearches+1, len(queries))
+	}
+}
+
+func TestReviewRequestedRefsUnionsAndDedupes(t *testing.T) {
+	login := testLogin(t)
+	shared := PRRef{Owner: "acme", Repo: "api", Number: 7}
+	direct := fmt.Sprintf("is:pr is:open archived:false review-requested:%s", login)
+	stubSearch(t, map[string][]PRRef{
+		direct: {shared, {Owner: "acme", Repo: "web", Number: 3}},
+	}, nil)
+
+	refs, err := ReviewRequestedRefs(login)
+	if err != nil {
+		t.Fatalf("ReviewRequestedRefs: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs, got %v", refs)
+	}
+	if refs[0] != shared {
+		t.Errorf("expected search order to be preserved, got %v", refs)
+	}
+}
+
+func TestReviewRequestedRefsFailsLoudly(t *testing.T) {
+	login := testLogin(t)
+	stubSearch(t, nil, errors.New("rate limited"))
+
+	if _, err := ReviewRequestedRefs(login); err == nil {
+		t.Fatal("a failed search must be an error: an empty candidate list would empty the section")
+	}
+
+	// The failure must not be cached, or one bad minute would silence the
+	// section for several cycles.
+	stubSearch(t, map[string][]PRRef{
+		fmt.Sprintf("is:pr is:open archived:false review-requested:%s", login): {{Owner: "a", Repo: "b", Number: 1}},
+	}, nil)
+	refs, err := ReviewRequestedRefs(login)
+	if err != nil {
+		t.Fatalf("retry after a failure: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Errorf("expected the retry to return results, got %v", refs)
+	}
+}
+
+func TestRefSearchesAreCachedPerLogin(t *testing.T) {
+	login := testLogin(t)
+	queries := stubSearch(t, map[string][]PRRef{
+		fmt.Sprintf("is:pr is:open archived:false review-requested:%s", login): {{Owner: "a", Repo: "b", Number: 1}},
+	}, nil)
+
+	for i := 0; i < 3; i++ {
+		if _, err := ReviewRequestedRefs(login); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if len(*queries) != 1 {
+		t.Errorf("expected the searches to be shared between calls in a cycle, ran %d", len(*queries))
+	}
+}
+
+func TestMyInteractionRefsSearchesReviewsAndComments(t *testing.T) {
+	login := testLogin(t)
+	reviewed := fmt.Sprintf("is:pr is:open reviewed-by:%s", login)
+	commented := fmt.Sprintf("is:pr is:open commenter:%s", login)
+	queries := stubSearch(t, map[string][]PRRef{
+		reviewed:  {{Owner: "acme", Repo: "api", Number: 1}},
+		commented: {{Owner: "acme", Repo: "api", Number: 1}, {Owner: "acme", Repo: "api", Number: 2}},
+	}, nil)
+
+	refs, err := MyInteractionRefs(login)
+	if err != nil {
+		t.Fatalf("MyInteractionRefs: %v", err)
+	}
+	if len(*queries) != 2 {
+		t.Errorf("expected both interaction searches, got %v", *queries)
+	}
+	if len(refs) != 2 {
+		t.Errorf("expected the overlap to be deduped, got %v", refs)
+	}
+}
+
+func TestRefSearchesRequireALogin(t *testing.T) {
+	if _, err := ReviewRequestedRefs(""); err == nil {
+		t.Error("expected an error without a login")
+	}
+	if _, err := MyInteractionRefs(""); err == nil {
+		t.Error("expected an error without a login")
+	}
+}
+
+func TestDedupeRefsKeepsFirstSeenOrder(t *testing.T) {
+	a := PRRef{Owner: "acme", Repo: "api", Number: 1}
+	b := PRRef{Owner: "acme", Repo: "api", Number: 2}
+	c := PRRef{Owner: "other", Repo: "api", Number: 1}
+
+	got := DedupeRefs([]PRRef{a, b, a, c, b})
+	want := []PRRef{a, b, c}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPRRefString(t *testing.T) {
+	ref := PRRef{Owner: "acme", Repo: "api", Number: 42}
+	if ref.String() != "acme/api#42" {
+		t.Errorf("String() = %q", ref.String())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crs/config"
+	"crs/git_tools"
 	"crs/logger"
 	"crs/server"
 	"crs/workflows"
@@ -21,20 +22,32 @@ func main() {
 	slog.SetDefault(log)
 	slog.Info("starting")
 
-	// Initialize configuration
-	if err := config.Initialize(); err != nil {
-		slog.Error("Failed to initialize configuration", "error", err)
-		os.Exit(1)
-	}
-	defer config.C().DB.Close()
-
 	oneOff := flag.Bool("oneoff", false, "Pass oneoff to only run once")
 	serverFlag := flag.Bool("server", false, "Run as an RPC server")
 	testFlag := flag.Bool("test", false, "Run in test mode")
 	listPRs := flag.Bool("list-prs", false, "List all PRs from the database")
 	listSections := flag.Bool("list-sections", false, "List all sections from the database")
 	getPRFlag := flag.String("pr", "", "Get cached details for a specific PR (format: owner/repo/number)")
+	printDefaultConfig := flag.Bool("print-default-config", false, "Print the built-in default configuration and exit")
 	flag.Parse()
+
+	// Printing the defaults is what someone does before they have a config, a
+	// database, or a token, so it happens before anything is initialized.
+	if *printDefaultConfig {
+		fmt.Print(config.DefaultConfigTOML)
+		return
+	}
+
+	// Lets a config that never names a GithubUsername still know who "me" is.
+	// Set before Initialize so the very first parse can use it.
+	config.LoginResolver = git_tools.GetAuthenticatedLogin
+
+	// Initialize configuration
+	if err := config.Initialize(); err != nil {
+		slog.Error("Failed to initialize configuration", "error", err)
+		os.Exit(1)
+	}
+	defer config.C().DB.Close()
 
 	if *testFlag {
 		content, err := server.GetFullPRResponse("C-Hipple", "gtdbot", 9, false, nil)

--- a/server/server.go
+++ b/server/server.go
@@ -786,10 +786,14 @@ func newConfigView(cfg config.Config) ConfigView {
 // ConfigPayload is the shared body of the config replies, so GetConfig and
 // UpdateConfig hand back the same shape and a client can render either one.
 type ConfigPayload struct {
-	Okay          bool                         `json:"okay"`
-	Message       string                       `json:"message"`
-	Path          string                       `json:"path"`
-	Config        ConfigView                   `json:"config"`
+	Okay    bool       `json:"okay"`
+	Message string     `json:"message"`
+	Path    string     `json:"path"`
+	Config  ConfigView `json:"config"`
+	// UsingDefaults is true when no file exists at Path and the server is
+	// running the built-in defaults. Saving any change writes the file, at
+	// which point what a client shows becomes what is on disk.
+	UsingDefaults bool                         `json:"using_defaults"`
 	WorkflowTypes []workflows.WorkflowTypeInfo `json:"workflow_types"`
 	Filters       []workflows.FilterInfo       `json:"filters"`
 }
@@ -797,6 +801,7 @@ type ConfigPayload struct {
 func (p *ConfigPayload) populate(cfg config.Config) {
 	p.Okay = true
 	p.Config = newConfigView(cfg)
+	p.UsingDefaults = cfg.UsingDefaults
 	p.WorkflowTypes = workflows.WorkflowTypes()
 	p.Filters = workflows.FilterTypes()
 

--- a/workflows/builders.go
+++ b/workflows/builders.go
@@ -24,6 +24,10 @@ func MatchWorkflows(workflow_maps []config.RawWorkflow, repos *[]string, jiraDom
 			wf, err = BuildListMyPRsWorkflow(&raw_workflow, repos)
 		case "ProjectListWorkflow":
 			wf, err = BuildProjectListWorkflow(&raw_workflow, repos, jiraDomain)
+		case "WaitingOnMeWorkflow":
+			wf, err = BuildSearchWorkflow(&raw_workflow, ModeWaitingOnMe)
+		case "MyReviewRequestsWorkflow":
+			wf, err = BuildSearchWorkflow(&raw_workflow, ModeReviewRequested)
 		default:
 			slog.Warn("Skipping workflow with unknown WorkflowType", "name", raw_workflow.Name, "type", raw_workflow.WorkflowType)
 			continue
@@ -110,6 +114,37 @@ func BuildListMyPRsWorkflow(raw *config.RawWorkflow, repos *[]string) (Workflow,
 		IncludeDiff:          raw.IncludeDiff,
 		AuxDataReq:           computeAuxRequirements(raw.Filters, raw.IncludeDiff),
 		PostFilterAux:        postFilterAuxRequirements(raw.Filters),
+		DesktopNotifications: raw.DesktopNotifications,
+	}
+	return wf, nil
+}
+
+// BuildSearchWorkflow builds the workflows that find their PRs through GitHub
+// search instead of a repository list. They need no Repos, and their identity
+// falls back to the API token's user (config.parseConfig fills GithubUsername
+// in when the file leaves it out), so both work with an empty configuration.
+func BuildSearchWorkflow(raw *config.RawWorkflow, mode SearchMode) (Workflow, error) {
+	filters, err := BuildFiltersList(raw)
+	if err != nil {
+		return nil, err
+	}
+	wf := SearchWorkflow{
+		Name:         raw.Name,
+		SectionTitle: raw.SectionTitle,
+		Mode:         mode,
+		Login:        strings.TrimSpace(raw.GithubUsername),
+		Filters:      filters,
+		IncludeDiff:  raw.IncludeDiff,
+		AuxDataReq:   computeAuxRequirements(raw.Filters, false),
+		// The candidate set here is already a review queue rather than every
+		// open PR in a repo, but the display data is still only worth fetching
+		// for the PRs that make it into the section.
+		PostFilterAux: AuxDataRequirement{
+			Comments: true,
+			Reviews:  true,
+			Commits:  true,
+			Diff:     raw.IncludeDiff,
+		},
 		DesktopNotifications: raw.DesktopNotifications,
 	}
 	return wf, nil

--- a/workflows/search_workflow.go
+++ b/workflows/search_workflow.go
@@ -1,0 +1,161 @@
+package workflows
+
+import (
+	"crs/config"
+	"crs/git_tools"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// SearchMode selects which GitHub searches a SearchWorkflow gets its candidate
+// PRs from.
+type SearchMode string
+
+const (
+	// ModeReviewRequested mirrors github.com's own "Review requests" list:
+	// every open PR whose review was requested from you, or from a team you
+	// belong to.
+	ModeReviewRequested SearchMode = "review_requested"
+
+	// ModeWaitingOnMe narrows the same candidates — plus the PRs you have
+	// already reviewed or commented on — down to the ones actually in your
+	// court, via FilterWaitingOnMe.
+	ModeWaitingOnMe SearchMode = "waiting_on_me"
+)
+
+// SearchWorkflow builds its section from GitHub search rather than from a
+// configured repository list, which is what lets the server run with no
+// configuration at all (see config.DefaultConfigTOML). The identity it searches
+// for comes from the config's GithubUsername, which the server fills in from the
+// API token when it isn't set.
+type SearchWorkflow struct {
+	Name         string
+	SectionTitle string
+	Mode         SearchMode
+	// Login is the GitHub user the searches are about.
+	Login       string
+	Filters     []git_tools.PRFilter
+	IncludeDiff bool
+
+	// AuxDataReq is data this workflow's own filters read out of the
+	// AuxDataStore, so it has to be fetched before filtering.
+	AuxDataReq AuxDataRequirement
+	// PostFilterAux is the display data fetched for the PRs that survive the
+	// filters — the section's reviewer summary and GetPRDetails' caches.
+	PostFilterAux AuxDataRequirement
+
+	// DesktopNotifications overrides the global setting for this workflow.
+	// nil means inherit the global config.
+	DesktopNotifications *bool
+}
+
+func (w SearchWorkflow) GetName() string {
+	return w.Name
+}
+
+func (w SearchWorkflow) GetOrgSectionName() string {
+	return w.SectionTitle
+}
+
+// GetPRRequirements returns nothing: this workflow's PRs aren't known until its
+// searches run, so the manager's collection phase has nothing to pre-fetch and
+// Run does its own fetching — the same arrangement ProjectListWorkflow uses.
+func (w SearchWorkflow) GetPRRequirements() []PRRequirement {
+	return nil
+}
+
+// ShouldNotify resolves the effective desktop-notification setting for this
+// workflow: the per-workflow override if set, otherwise the global config.
+func (w SearchWorkflow) ShouldNotify() bool {
+	if w.DesktopNotifications != nil {
+		return *w.DesktopNotifications
+	}
+	return config.C().DesktopNotifications
+}
+
+func (w SearchWorkflow) Run(_ []*github.PullRequest, c chan FileChanges, file_change_wg *sync.WaitGroup) (RunResult, error) {
+	login := strings.TrimSpace(w.Login)
+	if login == "" {
+		return RunResult{}, fmt.Errorf("%s needs a GitHub login: set GithubUsername in the config, or give the server a token whose user it can look up", w.Name)
+	}
+
+	refs, err := w.candidateRefs(login)
+	if err != nil {
+		// Every early return in here leaves the section as it is. Falling
+		// through to ProcessPRsDB with an empty list would read as "none of
+		// these PRs are mine any more" and delete the whole section.
+		return RunResult{}, fmt.Errorf("finding candidate PRs for %s: %w", w.Name, err)
+	}
+	slog.Info("Search workflow candidates", "workflow", w.Name, "mode", w.Mode, "candidates", len(refs))
+
+	prs, err := git_tools.GetPRsForRefs(git_tools.GetGithubClient(), refs)
+	if err != nil {
+		return RunResult{}, fmt.Errorf("fetching candidate PRs for %s: %w", w.Name, err)
+	}
+
+	// Pre-filter fetch: only what this workflow's filters read from the store.
+	if w.AuxDataReq != (AuxDataRequirement{}) {
+		prefetchAuxForFilteredPRs(w.Name, prs, w.AuxDataReq)
+	}
+
+	prs = git_tools.ApplyPRFilters(prs, w.filters(login))
+
+	// Post-filter fetch: display data, for the survivors only.
+	if w.PostFilterAux != (AuxDataRequirement{}) {
+		prefetchAuxForFilteredPRs(w.Name, prs, w.PostFilterAux)
+	}
+
+	db := config.C().DB
+	section, err := db.GetOrCreateSection(w.SectionTitle, config.C().SectionPriority[w.SectionTitle])
+	if err != nil {
+		slog.Error("Error getting section", "error", err, "section", w.SectionTitle)
+		return RunResult{}, errors.New("Section Not Found")
+	}
+
+	beforeCount, _ := db.GetItemCount()
+	slog.Info("Starting workflow", "items_before", beforeCount)
+	result := ProcessPRsDB(w.Name, prs, c, db, section, file_change_wg, w.IncludeDiff, w.ShouldNotify())
+	afterCount, _ := db.GetItemCount()
+	slog.Info("Finished workflow", "items_after", afterCount)
+	return result, nil
+}
+
+// filters returns the mode's own filter followed by the configured ones.
+func (w SearchWorkflow) filters(login string) []git_tools.PRFilter {
+	if w.Mode != ModeWaitingOnMe {
+		return w.Filters
+	}
+	return append([]git_tools.PRFilter{git_tools.MakeWaitingOnMeFilter(login)}, w.Filters...)
+}
+
+// candidateRefs runs the searches this mode draws its PRs from.
+func (w SearchWorkflow) candidateRefs(login string) ([]git_tools.PRRef, error) {
+	switch w.Mode {
+	case ModeReviewRequested:
+		return git_tools.ReviewRequestedRefs(login)
+
+	case ModeWaitingOnMe:
+		// A PR is waiting on me either because I have an open review request
+		// — including one I was asked for through a team — or because
+		// something I already did on it needs following up: a dismissed
+		// approval, or a thread of mine awaiting my reply. The second group
+		// only exists among PRs I have reviewed or commented on, so the union
+		// of the two searches is the complete candidate set. See
+		// git_tools/interaction_prefilter.go for the full argument.
+		requested, err := git_tools.ReviewRequestedRefs(login)
+		if err != nil {
+			return nil, err
+		}
+		interacted, err := git_tools.MyInteractionRefs(login)
+		if err != nil {
+			return nil, err
+		}
+		return git_tools.DedupeRefs(append(requested, interacted...)), nil
+	}
+	return nil, fmt.Errorf("unknown search mode %q", w.Mode)
+}

--- a/workflows/search_workflow_test.go
+++ b/workflows/search_workflow_test.go
@@ -1,0 +1,118 @@
+package workflows
+
+import (
+	"crs/config"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestDefaultConfigWorkflowsAreBuildable is the guard on the promise that the
+// server runs with no config file: the built-in defaults must survive both
+// validation registries and actually build into workflows.
+func TestDefaultConfigWorkflowsAreBuildable(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("config.DefaultConfig: %v", err)
+	}
+
+	if problems := ValidateWorkflows(cfg.RawWorkflows, cfg.Repos); len(problems) > 0 {
+		t.Errorf("the default workflows must validate cleanly, got %v", problems)
+	}
+
+	built := MatchWorkflows(cfg.RawWorkflows, &cfg.Repos, cfg.JiraDomain)
+	if len(built) != 2 {
+		t.Fatalf("expected both default workflows to build, got %d", len(built))
+	}
+
+	modes := map[SearchMode]string{}
+	for _, wf := range built {
+		search, ok := wf.(SearchWorkflow)
+		if !ok {
+			t.Fatalf("workflow %q is a %T, want a SearchWorkflow", wf.GetName(), wf)
+		}
+		// Search-driven workflows do their own fetching, so the manager must
+		// not try to collect PRs for them.
+		if reqs := search.GetPRRequirements(); reqs != nil {
+			t.Errorf("workflow %q should declare no PR requirements, got %v", search.Name, reqs)
+		}
+		modes[search.Mode] = search.SectionTitle
+	}
+	if modes[ModeWaitingOnMe] != "Waiting On Me" {
+		t.Errorf("waiting-on-me section = %q", modes[ModeWaitingOnMe])
+	}
+	if modes[ModeReviewRequested] != "Review Requested" {
+		t.Errorf("review-requested section = %q", modes[ModeReviewRequested])
+	}
+}
+
+func TestBuildSearchWorkflow(t *testing.T) {
+	raw := config.RawWorkflow{
+		Name:           "waiting",
+		SectionTitle:   "Waiting On Me",
+		GithubUsername: "  octocat  ",
+		Filters:        []string{"FilterNotDraft"},
+		IncludeDiff:    true,
+	}
+
+	built, err := BuildSearchWorkflow(&raw, ModeWaitingOnMe)
+	if err != nil {
+		t.Fatalf("BuildSearchWorkflow: %v", err)
+	}
+	wf := built.(SearchWorkflow)
+
+	if wf.Login != "octocat" {
+		t.Errorf("Login = %q, want the trimmed configured login", wf.Login)
+	}
+	if wf.Mode != ModeWaitingOnMe {
+		t.Errorf("Mode = %q", wf.Mode)
+	}
+	if len(wf.Filters) != 1 {
+		t.Errorf("expected the configured filter to be built, got %d", len(wf.Filters))
+	}
+	// The section display needs this data for the PRs that survive filtering.
+	want := AuxDataRequirement{Comments: true, Reviews: true, Commits: true, Diff: true}
+	if wf.PostFilterAux != want {
+		t.Errorf("PostFilterAux = %+v, want %+v", wf.PostFilterAux, want)
+	}
+}
+
+// A workflow with no identity can't search for anything. It must say so rather
+// than run: an empty result would read as "the section is empty now" and delete
+// everything in it.
+func TestSearchWorkflowRunRequiresALogin(t *testing.T) {
+	wf := SearchWorkflow{Name: "waiting", SectionTitle: "Waiting On Me", Mode: ModeWaitingOnMe}
+
+	var wg sync.WaitGroup
+	_, err := wf.Run(nil, make(chan FileChanges, 1), &wg)
+	if err == nil {
+		t.Fatal("expected an error when no login is available")
+	}
+	if !strings.Contains(err.Error(), "GithubUsername") {
+		t.Errorf("the error should point at how to fix it, got %q", err)
+	}
+}
+
+func TestSearchWorkflowRunRejectsUnknownMode(t *testing.T) {
+	wf := SearchWorkflow{Name: "odd", SectionTitle: "Odd", Mode: "nonsense", Login: "octocat"}
+
+	var wg sync.WaitGroup
+	_, err := wf.Run(nil, make(chan FileChanges, 1), &wg)
+	if err == nil || !strings.Contains(err.Error(), "unknown search mode") {
+		t.Errorf("expected an unknown-mode error, got %v", err)
+	}
+}
+
+// The waiting-on-me mode owns its filter: it is applied first, ahead of
+// whatever the config asked for.
+func TestSearchWorkflowFiltersPrependTheModeFilter(t *testing.T) {
+	waiting := SearchWorkflow{Mode: ModeWaitingOnMe}
+	if got := len(waiting.filters("octocat")); got != 1 {
+		t.Errorf("waiting-on-me should contribute its own filter, got %d filters", got)
+	}
+
+	requested := SearchWorkflow{Mode: ModeReviewRequested}
+	if got := len(requested.filters("octocat")); got != 0 {
+		t.Errorf("review-requested is already the search; it should add no filter, got %d", got)
+	}
+}

--- a/workflows/validate.go
+++ b/workflows/validate.go
@@ -47,6 +47,18 @@ var workflowTypes = []WorkflowTypeInfo{
 		OptionalFields: []string{"Repos", "Filters", "PRState", "IncludeDiff", "DesktopNotifications"},
 	},
 	{
+		Name:           "WaitingOnMeWorkflow",
+		Description:    "PRs that are in your court right now — an open review request (yours or your team's), a dismissed approval, or a thread waiting on your reply. Found through GitHub search, so it needs no Repos; identity comes from GithubUsername or, failing that, the API token's own user.",
+		RequiredFields: []string{},
+		OptionalFields: []string{"Filters", "IncludeDiff", "GithubUsername", "DesktopNotifications"},
+	},
+	{
+		Name:           "MyReviewRequestsWorkflow",
+		Description:    "Every open PR whose review was requested from you or from a team you belong to — the same list as github.com's \"Review requests\". Found through GitHub search, so it needs no Repos; identity comes from GithubUsername or, failing that, the API token's own user.",
+		RequiredFields: []string{},
+		OptionalFields: []string{"Filters", "IncludeDiff", "GithubUsername", "DesktopNotifications"},
+	},
+	{
 		Name:           "ProjectListWorkflow",
 		Description:    "Sync the pull requests linked to the children of a Jira epic. Repos takes a list, so one workflow can cover a project spanning several repositories. Requires JiraDomain plus the JIRA_API_TOKEN and JIRA_API_EMAIL environment variables.",
 		RequiredFields: []string{"JiraEpic"},


### PR DESCRIPTION
Two changes that ship together: the review list gets a denser, GitHub-style layout, and the server stops requiring a config file to be useful.

## Review list (`116092c`)

Replaces the stacked cards with a two-column layout:

- **State sidebar** — Open / Draft / Merged / Closed / Everything with live counts. Lifecycle state isn't a field the backend sends, so it's derived from `status` + `tags` exactly the way `prStatusOrder` does server-side. Opens on **Open**, remembers your choice.
- **Repo and author facets** — checkable lists ordered by open-PR count, ten rows before they scroll. Checks OR within a field and AND across fields. The existing dropdowns become single-value shortcuts into the *same* selection, so the two controls can't disagree about what's filtered.
- **Dense rows** — state pill, title, `repo · #number · author · relative time`. Row actions appear on hover or keyboard focus instead of taking permanent space.
- Sticky toolbar with an "N of M" counter, refresh, and collapse-all.

The derivations (state, relative time, query matching, facet counts, section grouping) live in `pr_list_utils.ts` behind unit tests rather than inside the component.

Incidental fix: `App.css` was never imported — nothing had imported it since some earlier refactor, so `.hover-line` and the `.plugin-output` markdown styles had been dead in the built client. `main.tsx` now imports it, which also revives those styles in the review and plugin views.

## Zero-config startup (`dd85cfd`)

A valid `CRS_GITHUB_TOKEN` is now the only setup step. With no `~/.config/codereviewserver.toml`, the server warns (naming the path it looked at) and runs built-in defaults filling two sections: **Waiting On Me** and **Review Requested**. A config file that exists but doesn't parse is still an error — the defaults are a fallback for "no file", never a silent replacement for one that was meant to work.

Neither default names a repository or a user. They're two new workflow types, usable in any config, that find candidates through GitHub search:

- `MyReviewRequestsWorkflow` runs `review-requested:<me>` plus `team-review-requested:<org>/<team>` for each of my teams — the direct qualifier doesn't expand to team membership, and github.com's own list shows both.
- `WaitingOnMeWorkflow` takes those candidates plus `reviewed-by:<me>` and `commenter:<me>` — the only PRs that can be waiting on me for a reason other than an open request — then applies the existing `FilterWaitingOnMe`.

A failed search is an error, so a rate-limited cycle leaves the section alone instead of emptying it.

**Identity** resolves as workflow `GithubUsername` → root `GithubUsername` → the user the token belongs to. The looked-up login is never written to the config file, and it fixes identity for every "me" filter, not just the defaults.

Also:

- `-print-default-config` writes the defaults out, touching neither config nor database so it works before either exists.
- `Update.Render` seeds the document with the defaults when no file exists, so a client's first save materializes the workflows the user has been looking at instead of dropping them.
- `GetConfig` reports `using_defaults`; the web config editor says so.
- `debug_waiting_on_me` resolves identity the same way, recognizes the new workflow type, and explains the search candidates when no repos are configured — it was useless in exactly the new default setup.

## Tradeoffs

- Search costs **one core API call per candidate PR** (capped at 250/cycle). An explicit `Repos` list with `SyncReviewRequestsWorkflow` is still cheaper once you know which repos you care about; documented as such.
- Teams past the first ten are skipped, to stay inside the search API's 30-requests-per-minute budget.

## Verification

- `go build ./...` and `go test ./...` pass; 20 new Go tests across `config`, `workflows`, `git_tools`, including that the defaults validate cleanly and build, and that a failed search doesn't empty a section.
- Frontend: type-check, lint, format, and 153 tests pass.
- Ran `-oneoff` live against GitHub with an isolated config dir and database: warned, resolved the login, created both sections, and its candidate counts matched direct API queries exactly (`review-requested` = 0, `reviewed-by` = 2, `commenter` = 2).
- `-print-default-config > config.toml` round-trips into a clean load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)