### PR TITLE
bun_client: render images embedded in comments and reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ RPC handlers serve data to clients (web UI, Emacs).
 - `database/` — SQLite with WAL mode. Sections, items, PR caches, local comments, plugin results, workflow action log (`workflow_action_log.go`)
 - `config/` — TOML config from `~/.config/codereviewserver.toml`, accessed via `config.C()` (global singleton with RWMutex)
 - `git_tools/` — GitHub API wrapper using go-github. Mostly REST; `review_threads.go` is the one GraphQL call, because review-thread resolution (`isResolved`) has no REST equivalent
+- `images/` — downloads and caches the images embedded in PR bodies, reviews and comments to `$CRS_HOME/images`, content-addressed by URL. Only `github.com` / `*.githubusercontent.com` are fetched, since bodies are attacker-supplied text. Clients render from the cached file rather than from GitHub: a private repo's attachments are served only to a request carrying the server's token
 - `llm/` — non-plugin LLM calls (experimental diff file ordering + review-ease rating) behind a `Client` interface; Gemini is the only backend today. Appends every call to `~/.crs/llm_calls.log`
 - `org/` — org-mode serialization for the Emacs client
 - `utils/` — diff parsing utilities
@@ -56,8 +57,9 @@ RPC handlers serve data to clients (web UI, Emacs).
 1. **Workflow fetch**: GitHub API → filter PRs → `ProcessPRsDB` upserts into `sections`/`items` tables
 2. **Aux data fetch**: `fetchAuxDataForPR` (manager.go) fetches reviews/commits/CI/review-threads and persists to DB caches, recording each write in `WorkflowActionLog` (workflow name, head SHA, fields written). What gets fetched is the union of what the workflows' filters asked for and what `applyCacheWarmRequirements` adds for a PR that is new or has a new head SHA — the warm covers every field `GetPRDetails` reads, so opening a review is a pure cache hit
 3. **Post-update hooks**: for each PR the cycle added or re-fetched after a push, `notifyPRsUpdated` (manager.go) calls the hook registered via `workflows.SetPRUpdatedHook` — `server.WarmPRAnalysis` in server mode — which runs the plugins and the LLM diff analysis in the background so they're cached before anyone opens the review
-4. **Client request**: RPC `GetPR` → `GetPRDetails` (renderer.go) → checks DB caches → falls back to GitHub API
-5. **Rendering**: `OrgRenderer` reads sections/items from DB, sorts by priority, returns org-mode or JSON
+4. **Image prefetch**: `ensurePostUpdateHooks` also hands every image URL found in the description, reviews and comments to `images.Store.Prefetch`, ahead of the head-SHA debounce — a new comment carrying a screenshot doesn't change the SHA. `PRPayload.images` then reports where each one landed, and `GetImage` fetches on demand anything the prefetch hasn't reached
+5. **Client request**: RPC `GetPR` → `GetPRDetails` (renderer.go) → checks DB caches → falls back to GitHub API
+6. **Rendering**: `OrgRenderer` reads sections/items from DB, sorts by priority, returns org-mode or JSON
 
 Nothing on the read path waits for a plugin or an LLM call: `ensurePostUpdateHooks` dispatches them in goroutines, and `orderDiffFiles` uses the cached LLM ordering or falls back to `sortFilesTestsLast`. The workflow layer cannot import `server` (`server` imports `workflows`), which is why step 3 goes through a registered callback wired up in `main.go`.
 

--- a/bun_client/README.md
+++ b/bun_client/README.md
@@ -36,5 +36,8 @@
 
 - **List PRs**: View list of reviews (from `GetAllReviews`).
 - **Review PR**: View PR details, diffs, and comments (from `GetPR`).
+- **Embedded images**: Screenshots in descriptions, reviews and comments render
+  inline. Attachments on a private repo are fetched with `CRS_GITHUB_TOKEN` through
+  `GET /api/github-image`, since the browser can't authenticate to GitHub itself.
 - **Add Comments**: Add inline comments by specifying filename and position.
 - **Submit Review**: Approve, Comment, or Request Changes.

--- a/bun_client/README.md
+++ b/bun_client/README.md
@@ -37,7 +37,7 @@
 - **List PRs**: View list of reviews (from `GetAllReviews`).
 - **Review PR**: View PR details, diffs, and comments (from `GetPR`).
 - **Embedded images**: Screenshots in descriptions, reviews and comments render
-  inline. Attachments on a private repo are fetched with `CRS_GITHUB_TOKEN` through
-  `GET /api/github-image`, since the browser can't authenticate to GitHub itself.
+  inline. The browser can't authenticate to GitHub, so `GET /api/github-image` asks
+  the Go server (which holds `CRS_GITHUB_TOKEN`) for the copy it downloaded.
 - **Add Comments**: Add inline comments by specifying filename and position.
 - **Submit Review**: Approve, Comment, or Request Changes.

--- a/bun_client/bun.lock
+++ b/bun_client/bun.lock
@@ -21,6 +21,8 @@
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -347,6 +349,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.278", "", {}, "sha512-dQ0tM1svDRQOwxnXxm+twlGTjr9Upvt8UFWAgmLsxEzFQxhbti4VwxmMjsDxVC51Zo84swW7FVCXEV+VAkhuPw=="],
 
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -409,9 +413,17 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
     "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
 
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
@@ -426,6 +438,8 @@
     "highlightjs-vue": ["highlightjs-vue@1.0.0", "", {}, "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -557,6 +571,8 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -588,6 +604,10 @@
     "react-syntax-highlighter": ["react-syntax-highlighter@16.1.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "highlight.js": "^10.4.1", "highlightjs-vue": "^1.0.0", "lowlight": "^1.17.0", "prismjs": "^1.30.0", "refractor": "^5.0.0" }, "peerDependencies": { "react": ">= 0.14.0" } }, "sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg=="],
 
     "refractor": ["refractor@5.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/prismjs": "^1.0.0", "hastscript": "^9.0.0", "parse-entities": "^4.0.0" } }, "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
@@ -649,9 +669,13 @@
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/bun_client/frontend/package.json
+++ b/bun_client/frontend/package.json
@@ -17,7 +17,9 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
-        "react-syntax-highlighter": "^16.1.0"
+        "react-syntax-highlighter": "^16.1.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/bun_client/frontend/src/components/GitHubMarkdown.tsx
+++ b/bun_client/frontend/src/components/GitHubMarkdown.tsx
@@ -1,0 +1,113 @@
+import { type ComponentProps, useState } from 'react';
+import Markdown, { type Components, type ExtraProps } from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
+import { proxyImageUrl, proxySrcSet } from '../github_images';
+
+// Order matters: `rehype-raw` parses the raw HTML in the body, and
+// `rehype-sanitize` then runs over the parsed result. Sanitizing has to happen
+// on the tree, not on the markdown string.
+const REHYPE_PLUGINS = [rehypeRaw, rehypeSanitize];
+
+function MarkdownImage({ node: _node, src, srcSet, ...props }: ComponentProps<'img'> & ExtraProps) {
+    // The original URL is what a new tab should open: a top-level navigation to
+    // github.com carries the user's session, so even a private attachment
+    // renders full size there.
+    const original = typeof src === 'string' ? src : '';
+    const proxied = original ? proxyImageUrl(original) : '';
+    // Remembering the URL that failed rather than a bare flag means a body that
+    // re-renders with a different image tries the proxy again.
+    const [failedSrc, setFailedSrc] = useState('');
+    // A bridge running without CRS_GITHUB_TOKEN, or not running at all, still
+    // shouldn't lose a screenshot that GitHub serves publicly.
+    const useOriginal = proxied !== original && failedSrc === proxied;
+
+    return (
+        <img
+            {...props}
+            alt={props.alt ?? ''}
+            src={useOriginal ? original : proxied || src}
+            srcSet={srcSet ? proxySrcSet(srcSet) : undefined}
+            onError={() => {
+                if (proxied && proxied !== original) setFailedSrc(proxied);
+            }}
+            loading="lazy"
+            title={props.title ?? (original ? 'Click to open the full-size image' : undefined)}
+            style={{
+                // GitHub stamps the screenshot's natural size onto the tag,
+                // routinely 1900px wide — several times the card it lands in.
+                maxWidth: '100%',
+                height: 'auto',
+                borderRadius: '4px',
+                verticalAlign: 'middle',
+                cursor: original ? 'zoom-in' : 'default',
+            }}
+            onClick={e => {
+                if (!original) return;
+                // A bare click on a comment card means "reply to this thread";
+                // opening the screenshot shouldn't also open the reply box.
+                e.stopPropagation();
+                window.open(original, '_blank', 'noopener,noreferrer');
+            }}
+        />
+    );
+}
+
+// <picture> pairs, which GitHub emits for light/dark screenshots.
+function MarkdownSource({
+    node: _node,
+    src,
+    srcSet,
+    ...props
+}: ComponentProps<'source'> & ExtraProps) {
+    return (
+        <source
+            {...props}
+            src={src ? proxyImageUrl(src) : undefined}
+            srcSet={srcSet ? proxySrcSet(srcSet) : undefined}
+        />
+    );
+}
+
+function MarkdownLink({ node: _node, ...props }: ComponentProps<'a'> & ExtraProps) {
+    // Links in a comment point at GitHub, issues, or docs — none of which
+    // should replace the review you are in the middle of.
+    return <a {...props} target="_blank" rel="noopener noreferrer" onClick={stopPropagation} />;
+}
+
+function stopPropagation(e: { stopPropagation: () => void }) {
+    e.stopPropagation();
+}
+
+const COMPONENTS: Components = {
+    a: MarkdownLink,
+    img: MarkdownImage,
+    source: MarkdownSource,
+};
+
+/**
+ * Markdown rendered the way GitHub renders it, for text written by people on
+ * the PR: descriptions, review bodies and comments.
+ *
+ * Two things it does that plain react-markdown does not:
+ *
+ * 1. **Raw HTML is parsed.** GitHub's upload widget writes a pasted screenshot
+ *    into the body as an `<img>` tag, and people hand-write `<details>` blocks.
+ *    react-markdown drops raw HTML, so all of that used to disappear from a
+ *    thread — most visibly, the screenshot someone attached to explain a bug.
+ * 2. **Images load through the bridge.** See `github_images.ts`: an attachment
+ *    on a private repository needs the server's token, which the browser has no
+ *    way to supply.
+ *
+ * These bodies are written by whoever commented on the PR, so the raw HTML is
+ * untrusted. `rehype-sanitize`'s default schema is GitHub's own: `img`,
+ * `details`, `picture`, tables and their sizing attributes survive; `script`,
+ * event handlers, inline styles and non-http(s) URLs do not.
+ */
+export default function GitHubMarkdown({ children }: { children: string }) {
+    return (
+        <Markdown rehypePlugins={REHYPE_PLUGINS} components={COMPONENTS}>
+            {children}
+        </Markdown>
+    );
+}

--- a/bun_client/frontend/src/components/review/CommentThread.tsx
+++ b/bun_client/frontend/src/components/review/CommentThread.tsx
@@ -1,6 +1,6 @@
-import Markdown from 'react-markdown';
 import { colors } from '../../design';
 import { buildReplyTree, flattenReplyTree, summarizeThread } from '../../discussion_utils';
+import GitHubMarkdown from '../GitHubMarkdown';
 import ThreadStateBadges from './ThreadStateBadges';
 import type { Comment } from './types';
 
@@ -165,7 +165,7 @@ export default function CommentThread({
                             }}
                         >
                             <div className="markdown-content" style={{ flex: 1, minWidth: 0 }}>
-                                <Markdown>{c.body}</Markdown>
+                                <GitHubMarkdown>{c.body}</GitHubMarkdown>
                             </div>
                             {c.author === 'local' && (
                                 <button

--- a/bun_client/frontend/src/components/review/OutdatedCommentsPanel.tsx
+++ b/bun_client/frontend/src/components/review/OutdatedCommentsPanel.tsx
@@ -1,6 +1,6 @@
-import Markdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { Button, colors, shadows } from '../../design';
+import GitHubMarkdown from '../GitHubMarkdown';
 import type { DiffTheme } from './diff_theme';
 import type { Comment } from './types';
 
@@ -172,7 +172,7 @@ export default function OutdatedCommentsPanel({
                                             color: 'var(--text-primary)',
                                         }}
                                     >
-                                        <Markdown>{c.body}</Markdown>
+                                        <GitHubMarkdown>{c.body}</GitHubMarkdown>
                                     </div>
                                 </div>
                             ))}

--- a/bun_client/frontend/src/components/review/PRDiscussion.tsx
+++ b/bun_client/frontend/src/components/review/PRDiscussion.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react';
-import Markdown from 'react-markdown';
 import { colors } from '../../design';
 import {
     buildDiscussionTimeline,
@@ -10,6 +9,7 @@ import {
     type ThreadSummary,
     type TimelineEntry,
 } from '../../discussion_utils';
+import GitHubMarkdown from '../GitHubMarkdown';
 import ThreadStateBadges from './ThreadStateBadges';
 import { type Comment, type ReviewData, stripHtmlComments } from './types';
 
@@ -211,7 +211,7 @@ function TimelineThread({
                             className="markdown-content"
                             style={{ fontSize: '13px', lineHeight: 1.55 }}
                         >
-                            <Markdown>{stripHtmlComments(c.body)}</Markdown>
+                            <GitHubMarkdown>{stripHtmlComments(c.body)}</GitHubMarkdown>
                         </div>
                     </div>
                 ))}
@@ -280,7 +280,7 @@ function TimelineRow({
                     className="pr-description"
                     style={{ fontSize: '14px', lineHeight: 1.6, color: 'var(--text-primary)' }}
                 >
-                    <Markdown>{stripHtmlComments(entry.body)}</Markdown>
+                    <GitHubMarkdown>{stripHtmlComments(entry.body)}</GitHubMarkdown>
                 </div>
             )}
             {entry.threads.length > 0 && (

--- a/bun_client/frontend/src/components/review/PRHeader.tsx
+++ b/bun_client/frontend/src/components/review/PRHeader.tsx
@@ -1,5 +1,5 @@
-import Markdown from 'react-markdown';
 import { colors } from '../../design';
+import GitHubMarkdown from '../GitHubMarkdown';
 import CopyUrlButton from './CopyUrlButton';
 import { type PRMetadata, stripHtmlComments } from './types';
 
@@ -539,7 +539,7 @@ export default function PRHeader({
                                 padding: '0 20px 16px',
                             }}
                         >
-                            <Markdown>{stripHtmlComments(metadata.body)}</Markdown>
+                            <GitHubMarkdown>{stripHtmlComments(metadata.body)}</GitHubMarkdown>
                         </div>
                     )}
                 </div>

--- a/bun_client/frontend/src/github_images.test.ts
+++ b/bun_client/frontend/src/github_images.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import { isGitHubImageHost, proxyImageUrl, proxySrcSet } from './github_images';
+
+// API_BASE is '' outside a browser, so the proxied URLs below are same-origin.
+const proxied = (href: string) => `/api/github-image?url=${encodeURIComponent(href)}`;
+
+describe('proxyImageUrl', () => {
+    test('routes a pasted screenshot through the bridge', () => {
+        const href = 'https://github.com/user-attachments/assets/9b506449-0b9b-4c14-90f7';
+        expect(proxyImageUrl(href)).toBe(proxied(href));
+    });
+
+    test('routes the githubusercontent CDN hosts too', () => {
+        for (const href of [
+            'https://user-images.githubusercontent.com/1/x.png',
+            'https://private-user-images.githubusercontent.com/1/x.png?jwt=abc',
+            'https://raw.githubusercontent.com/o/r/main/docs/x.png',
+        ]) {
+            expect(proxyImageUrl(href)).toBe(proxied(href));
+        }
+    });
+
+    test('preserves the query string through the round trip', () => {
+        const href = 'https://private-user-images.githubusercontent.com/1/x.png?jwt=a.b&v=2';
+        const decoded = decodeURIComponent(proxyImageUrl(href).split('url=')[1]);
+        expect(decoded).toBe(href);
+    });
+
+    test('leaves images hosted elsewhere alone', () => {
+        const href = 'https://img.shields.io/badge/build-passing-green.svg';
+        expect(proxyImageUrl(href)).toBe(href);
+    });
+
+    test('leaves relative, empty and non-http sources alone', () => {
+        // No repository context here to resolve a relative path against.
+        expect(proxyImageUrl('docs/img/diagram.png')).toBe('docs/img/diagram.png');
+        expect(proxyImageUrl('')).toBe('');
+        expect(proxyImageUrl('data:image/png;base64,AAAA')).toBe('data:image/png;base64,AAAA');
+    });
+});
+
+describe('proxySrcSet', () => {
+    test('rewrites every candidate and keeps its descriptor', () => {
+        const one = 'https://github.com/user-attachments/assets/one';
+        const two = 'https://github.com/user-attachments/assets/two';
+        expect(proxySrcSet(`${one} 1x, ${two} 2x`)).toBe(`${proxied(one)} 1x, ${proxied(two)} 2x`);
+    });
+
+    test('handles a single candidate with no descriptor', () => {
+        const one = 'https://user-images.githubusercontent.com/1/x.png';
+        expect(proxySrcSet(one)).toBe(proxied(one));
+    });
+
+    test('drops empty candidates from a trailing comma', () => {
+        expect(proxySrcSet('https://example.com/a.png 1x, ')).toBe('https://example.com/a.png 1x');
+    });
+});
+
+describe('isGitHubImageHost', () => {
+    test('only matches on a dot boundary', () => {
+        expect(isGitHubImageHost('user-images.githubusercontent.com')).toBe(true);
+        expect(isGitHubImageHost('githubusercontent.com.evil.test')).toBe(false);
+        expect(isGitHubImageHost('notgithub.com')).toBe(false);
+    });
+});

--- a/bun_client/frontend/src/github_images.ts
+++ b/bun_client/frontend/src/github_images.ts
@@ -1,0 +1,67 @@
+import { API_BASE } from './api';
+
+/**
+ * Rewrites GitHub-hosted image URLs to run through the bridge's image proxy.
+ *
+ * A screenshot pasted into a comment lands in the body as
+ * `https://github.com/user-attachments/assets/<uuid>`, which redirects to a
+ * signed CDN URL. On a private repository GitHub only issues that redirect to
+ * an authenticated request, and the browser's github.com session cookie is not
+ * sent on a cross-site image load — so the image renders broken no matter who
+ * is looking at it. The bridge holds `CRS_GITHUB_TOKEN`, so it fetches the
+ * bytes instead (see `bun_client/github_images.ts`, which re-checks every URL
+ * this module hands it).
+ *
+ * Anything not on a GitHub host is left alone and loaded directly.
+ */
+
+const PROXY_PATH = '/api/github-image';
+
+/**
+ * True for the hosts GitHub serves attachments and repository content from.
+ * Kept in sync with the bridge's copy in `bun_client/github_images.ts`, which
+ * is the one that actually enforces it.
+ */
+export function isGitHubImageHost(host: string): boolean {
+    const h = host.toLowerCase();
+    return (
+        h === 'github.com' ||
+        h === 'www.github.com' ||
+        h === 'githubusercontent.com' ||
+        h.endsWith('.githubusercontent.com')
+    );
+}
+
+/**
+ * The URL an `<img>` in a GitHub body should actually load: the proxy for
+ * GitHub-hosted images, the original for everything else (including relative
+ * and malformed URLs, which we have no repository context to resolve).
+ */
+export function proxyImageUrl(src: string): string {
+    if (!src) return src;
+    let url: URL;
+    try {
+        url = new URL(src);
+    } catch {
+        return src;
+    }
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return src;
+    if (!isGitHubImageHost(url.hostname)) return src;
+    return `${API_BASE}${PROXY_PATH}?url=${encodeURIComponent(url.href)}`;
+}
+
+/**
+ * Same rewrite across a `srcset`, for the `<picture>` markup GitHub emits for
+ * light/dark image pairs. Each candidate is `<url> [descriptor]`.
+ */
+export function proxySrcSet(srcSet: string): string {
+    return srcSet
+        .split(',')
+        .map(candidate => candidate.trim())
+        .filter(candidate => candidate.length > 0)
+        .map(candidate => {
+            const [url, ...descriptor] = candidate.split(/\s+/);
+            return [proxyImageUrl(url), ...descriptor].join(' ');
+        })
+        .join(', ');
+}

--- a/bun_client/frontend/src/github_images.ts
+++ b/bun_client/frontend/src/github_images.ts
@@ -8,9 +8,9 @@ import { API_BASE } from './api';
  * signed CDN URL. On a private repository GitHub only issues that redirect to
  * an authenticated request, and the browser's github.com session cookie is not
  * sent on a cross-site image load — so the image renders broken no matter who
- * is looking at it. The bridge holds `CRS_GITHUB_TOKEN`, so it fetches the
- * bytes instead (see `bun_client/github_images.ts`, which re-checks every URL
- * this module hands it).
+ * is looking at it. The Go server holds `CRS_GITHUB_TOKEN` and downloads them
+ * (which is also what lets the Emacs client show the same screenshots); the
+ * bridge route serves whatever it cached.
  *
  * Anything not on a GitHub host is left alone and loaded directly.
  */

--- a/bun_client/frontend/src/github_markdown.test.tsx
+++ b/bun_client/frontend/src/github_markdown.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import GitHubMarkdown from './components/GitHubMarkdown';
+
+const render = (body: string) => renderToStaticMarkup(<GitHubMarkdown>{body}</GitHubMarkdown>);
+
+// Verbatim shape of a GitHub comment with two screenshots attached, which is
+// what the upload widget writes into the body.
+const COMMENT_WITH_SCREENSHOTS = `So I've done some quick debugging.
+
+Mid race: <img width="1905" height="1189" alt="Screenshot 2025-12-01 at 13 04 37" src="https://github.com/user-attachments/assets/9b506449-0b9b-4c14-90f7-775beb9e68af" />
+
+End of race: <img width="1910" height="1190" alt="Screenshot 2025-12-01 at 13 05 28" src="https://github.com/user-attachments/assets/016b4b0e-57d4-4b22-8ae9-34d730246647" />`;
+
+describe('GitHubMarkdown', () => {
+    test('renders the raw <img> tags GitHub embeds in a comment', () => {
+        const html = render(COMMENT_WITH_SCREENSHOTS);
+        const images = html.match(/<img\b/g) ?? [];
+        expect(images).toHaveLength(2);
+        expect(html).toContain(
+            'src="/api/github-image?url=https%3A%2F%2Fgithub.com%2Fuser-attachments%2Fassets%2F9b506449-0b9b-4c14-90f7-775beb9e68af"'
+        );
+        expect(html).toContain('alt="Screenshot 2025-12-01 at 13 04 37"');
+        // The surrounding prose still renders as markdown.
+        expect(html).toContain('<p>So I&#x27;ve done some quick debugging.</p>');
+    });
+
+    test("clamps the screenshot's stamped-on natural size to the card", () => {
+        const html = render(COMMENT_WITH_SCREENSHOTS);
+        expect(html).toContain('width="1905"');
+        expect(html).toContain('max-width:100%');
+        expect(html).toContain('height:auto');
+    });
+
+    test('proxies markdown image syntax as well as raw tags', () => {
+        const html = render('![shot](https://user-images.githubusercontent.com/1/x.png)');
+        expect(html).toContain(
+            'src="/api/github-image?url=https%3A%2F%2Fuser-images.githubusercontent.com%2F1%2Fx.png"'
+        );
+    });
+
+    test('loads non-GitHub images directly', () => {
+        const html = render('![badge](https://img.shields.io/badge/ci-green.svg)');
+        expect(html).toContain('src="https://img.shields.io/badge/ci-green.svg"');
+        expect(html).not.toContain('/api/github-image');
+    });
+
+    test('rewrites both halves of a light/dark <picture>', () => {
+        const html = render(
+            '<picture>' +
+                '<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/dark">' +
+                '<img src="https://github.com/user-attachments/assets/light" />' +
+                '</picture>'
+        );
+        // React keeps the JSX spelling in static markup; HTML attribute
+        // names are case-insensitive, so the browser reads it as `srcset`.
+        expect(html).toMatch(/srcset="\/api\/github-image\?url=/i);
+        expect(html).toContain('assets%2Fdark');
+        expect(html).toContain('assets%2Flight');
+    });
+
+    test('keeps the other raw HTML people write in review comments', () => {
+        const html = render('<details><summary>Traceback</summary>\n\nboom\n\n</details>');
+        expect(html).toContain('<details>');
+        expect(html).toContain('<summary>Traceback</summary>');
+        expect(html).toContain('boom');
+    });
+
+    test('strips scripts and event handlers from an untrusted body', () => {
+        const html = render(
+            '<img src="https://github.com/user-attachments/assets/x" onerror="alert(1)">' +
+                '<script>alert(2)</script>' +
+                '<a href="javascript:alert(3)">click</a>' +
+                '<p style="position:fixed;top:0">overlay</p>'
+        );
+        expect(html).toContain('<img');
+        expect(html).not.toContain('onerror');
+        expect(html).not.toContain('alert(2)');
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('position:fixed');
+    });
+
+    test('opens links in a new tab so the review stays put', () => {
+        const html = render('see [the issue](https://github.com/o/r/issues/1)');
+        expect(html).toContain('href="https://github.com/o/r/issues/1"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+    });
+});

--- a/bun_client/github_images.test.ts
+++ b/bun_client/github_images.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { fetchGitHubImage, MAX_REDIRECTS, parseGitHubImageUrl } from './github_images';
+import { isGitHubImageHost, parseGitHubImageUrl } from './github_images';
 
 describe('parseGitHubImageUrl', () => {
     test('accepts the hosts GitHub serves attachments from', () => {
@@ -42,90 +42,10 @@ describe('parseGitHubImageUrl', () => {
     });
 });
 
-interface Call {
-    url: string;
-    authorization: string | undefined;
-}
-
-// A fetch stand-in that replays a scripted sequence of responses and records
-// what it was called with.
-function scriptedFetch(responses: Response[]): {
-    calls: Call[];
-    impl: (input: string, init?: RequestInit) => Promise<Response>;
-} {
-    const calls: Call[] = [];
-    let i = 0;
-    return {
-        calls,
-        impl: async (input, init) => {
-            const headers = new Headers(init?.headers);
-            calls.push({ url: input, authorization: headers.get('authorization') ?? undefined });
-            const response = responses[i++];
-            if (!response) throw new Error(`unexpected fetch of ${input}`);
-            return response;
-        },
-    };
-}
-
-const redirectTo = (location: string) => new Response(null, { status: 302, headers: { location } });
-
-const imageResponse = () =>
-    new Response('png-bytes', { status: 200, headers: { 'content-type': 'image/png' } });
-
-describe('fetchGitHubImage', () => {
-    const attachment = new URL('https://github.com/user-attachments/assets/abc');
-
-    test('sends the token on the first request', async () => {
-        const { calls, impl } = scriptedFetch([imageResponse()]);
-        const response = await fetchGitHubImage(attachment, 'ghp_token', impl);
-        expect(response.status).toBe(200);
-        expect(calls).toEqual([{ url: attachment.href, authorization: 'Bearer ghp_token' }]);
-    });
-
-    test('omits the header entirely when no token is configured', async () => {
-        const { calls, impl } = scriptedFetch([imageResponse()]);
-        await fetchGitHubImage(attachment, '', impl);
-        expect(calls[0].authorization).toBeUndefined();
-    });
-
-    test('drops the token on the redirect to the signed CDN url', async () => {
-        // GitHub rejects a request that carries both its own query signature
-        // and an Authorization header, so following this hop with the token
-        // attached fails where an anonymous request succeeds.
-        const signed = 'https://private-user-images.githubusercontent.com/1/x.png?jwt=abc';
-        const { calls, impl } = scriptedFetch([redirectTo(signed), imageResponse()]);
-        const response = await fetchGitHubImage(attachment, 'ghp_token', impl);
-        expect(response.status).toBe(200);
-        expect(calls).toEqual([
-            { url: attachment.href, authorization: 'Bearer ghp_token' },
-            { url: signed, authorization: undefined },
-        ]);
-    });
-
-    test('resolves a relative redirect against the current url', async () => {
-        const { calls, impl } = scriptedFetch([redirectTo('/other/asset.png'), imageResponse()]);
-        await fetchGitHubImage(attachment, '', impl);
-        expect(calls[1].url).toBe('https://github.com/other/asset.png');
-    });
-
-    test('refuses to follow a redirect off GitHub', async () => {
-        const { impl } = scriptedFetch([redirectTo('https://evil.test/pixel.png')]);
-        await expect(fetchGitHubImage(attachment, 'ghp_token', impl)).rejects.toThrow(
-            'redirect off GitHub to evil.test'
-        );
-    });
-
-    test('gives up on a redirect loop', async () => {
-        const loop = Array.from({ length: MAX_REDIRECTS + 1 }, () =>
-            redirectTo('https://github.com/user-attachments/assets/abc')
-        );
-        const { impl } = scriptedFetch(loop);
-        await expect(fetchGitHubImage(attachment, '', impl)).rejects.toThrow('too many redirects');
-    });
-
-    test('returns an error response rather than following it', async () => {
-        const { impl } = scriptedFetch([new Response('nope', { status: 404 })]);
-        const response = await fetchGitHubImage(attachment, '', impl);
-        expect(response.status).toBe(404);
+describe('isGitHubImageHost', () => {
+    test('only matches on a dot boundary', () => {
+        expect(isGitHubImageHost('user-images.githubusercontent.com')).toBe(true);
+        expect(isGitHubImageHost('githubusercontent.com.evil.test')).toBe(false);
+        expect(isGitHubImageHost('notgithub.com')).toBe(false);
     });
 });

--- a/bun_client/github_images.test.ts
+++ b/bun_client/github_images.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test';
+import { fetchGitHubImage, MAX_REDIRECTS, parseGitHubImageUrl } from './github_images';
+
+describe('parseGitHubImageUrl', () => {
+    test('accepts the hosts GitHub serves attachments from', () => {
+        const accepted = [
+            'https://github.com/user-attachments/assets/9b506449-0b9b-4c14-90f7-775beb9e68af',
+            'https://www.github.com/user-attachments/assets/abc',
+            'https://user-images.githubusercontent.com/1234/screenshot.png',
+            'https://private-user-images.githubusercontent.com/1234/x.png?jwt=token',
+            'https://raw.githubusercontent.com/owner/repo/main/docs/img/diagram.png',
+            'https://githubusercontent.com/x.png',
+        ];
+        for (const href of accepted) {
+            expect(parseGitHubImageUrl(href)?.href).toBe(href);
+        }
+    });
+
+    test('rejects anything not on a GitHub host', () => {
+        const rejected = [
+            'https://example.com/pixel.png',
+            // Suffix matching has to be on a dot boundary, or this passes.
+            'https://githubusercontent.com.evil.test/x.png',
+            'https://evil.test/?q=githubusercontent.com',
+            'https://github.com.evil.test/x.png',
+        ];
+        for (const href of rejected) {
+            expect(parseGitHubImageUrl(href)).toBeNull();
+        }
+    });
+
+    test('rejects non-http protocols and unparseable input', () => {
+        expect(parseGitHubImageUrl('file:///etc/passwd')).toBeNull();
+        expect(parseGitHubImageUrl('data:image/png;base64,AAAA')).toBeNull();
+        expect(parseGitHubImageUrl('/user-attachments/assets/abc')).toBeNull();
+        expect(parseGitHubImageUrl('')).toBeNull();
+        expect(parseGitHubImageUrl(null)).toBeNull();
+    });
+
+    test('matches hosts case-insensitively', () => {
+        expect(parseGitHubImageUrl('https://GitHub.com/user-attachments/assets/a')).not.toBeNull();
+    });
+});
+
+interface Call {
+    url: string;
+    authorization: string | undefined;
+}
+
+// A fetch stand-in that replays a scripted sequence of responses and records
+// what it was called with.
+function scriptedFetch(responses: Response[]): {
+    calls: Call[];
+    impl: (input: string, init?: RequestInit) => Promise<Response>;
+} {
+    const calls: Call[] = [];
+    let i = 0;
+    return {
+        calls,
+        impl: async (input, init) => {
+            const headers = new Headers(init?.headers);
+            calls.push({ url: input, authorization: headers.get('authorization') ?? undefined });
+            const response = responses[i++];
+            if (!response) throw new Error(`unexpected fetch of ${input}`);
+            return response;
+        },
+    };
+}
+
+const redirectTo = (location: string) => new Response(null, { status: 302, headers: { location } });
+
+const imageResponse = () =>
+    new Response('png-bytes', { status: 200, headers: { 'content-type': 'image/png' } });
+
+describe('fetchGitHubImage', () => {
+    const attachment = new URL('https://github.com/user-attachments/assets/abc');
+
+    test('sends the token on the first request', async () => {
+        const { calls, impl } = scriptedFetch([imageResponse()]);
+        const response = await fetchGitHubImage(attachment, 'ghp_token', impl);
+        expect(response.status).toBe(200);
+        expect(calls).toEqual([{ url: attachment.href, authorization: 'Bearer ghp_token' }]);
+    });
+
+    test('omits the header entirely when no token is configured', async () => {
+        const { calls, impl } = scriptedFetch([imageResponse()]);
+        await fetchGitHubImage(attachment, '', impl);
+        expect(calls[0].authorization).toBeUndefined();
+    });
+
+    test('drops the token on the redirect to the signed CDN url', async () => {
+        // GitHub rejects a request that carries both its own query signature
+        // and an Authorization header, so following this hop with the token
+        // attached fails where an anonymous request succeeds.
+        const signed = 'https://private-user-images.githubusercontent.com/1/x.png?jwt=abc';
+        const { calls, impl } = scriptedFetch([redirectTo(signed), imageResponse()]);
+        const response = await fetchGitHubImage(attachment, 'ghp_token', impl);
+        expect(response.status).toBe(200);
+        expect(calls).toEqual([
+            { url: attachment.href, authorization: 'Bearer ghp_token' },
+            { url: signed, authorization: undefined },
+        ]);
+    });
+
+    test('resolves a relative redirect against the current url', async () => {
+        const { calls, impl } = scriptedFetch([redirectTo('/other/asset.png'), imageResponse()]);
+        await fetchGitHubImage(attachment, '', impl);
+        expect(calls[1].url).toBe('https://github.com/other/asset.png');
+    });
+
+    test('refuses to follow a redirect off GitHub', async () => {
+        const { impl } = scriptedFetch([redirectTo('https://evil.test/pixel.png')]);
+        await expect(fetchGitHubImage(attachment, 'ghp_token', impl)).rejects.toThrow(
+            'redirect off GitHub to evil.test'
+        );
+    });
+
+    test('gives up on a redirect loop', async () => {
+        const loop = Array.from({ length: MAX_REDIRECTS + 1 }, () =>
+            redirectTo('https://github.com/user-attachments/assets/abc')
+        );
+        const { impl } = scriptedFetch(loop);
+        await expect(fetchGitHubImage(attachment, '', impl)).rejects.toThrow('too many redirects');
+    });
+
+    test('returns an error response rather than following it', async () => {
+        const { impl } = scriptedFetch([new Response('nope', { status: 404 })]);
+        const response = await fetchGitHubImage(attachment, '', impl);
+        expect(response.status).toBe(404);
+    });
+});

--- a/bun_client/github_images.ts
+++ b/bun_client/github_images.ts
@@ -1,0 +1,94 @@
+/**
+ * The bridge half of the GitHub image proxy.
+ *
+ * Comments and reviews embed screenshots as `<img>` tags pointing at
+ * github.com/user-attachments or *.githubusercontent.com. Those URLs redirect
+ * to a signed CDN URL, and on a private repository the redirect is only issued
+ * to an authenticated request — which a browser loading the image cross-site
+ * cannot make, since its github.com cookie is not sent. The bridge already has
+ * `CRS_GITHUB_TOKEN`, so it fetches the bytes and hands them to the page.
+ *
+ * `frontend/src/github_images.ts` decides which URLs to send here; this module
+ * is the trust boundary. It re-checks the requested URL and every redirect
+ * target, so the endpoint can't be turned into an open proxy by a crafted
+ * comment body.
+ */
+
+/** How many redirects to follow before giving up. */
+export const MAX_REDIRECTS = 5;
+
+/** True for the hosts GitHub serves attachments and repository content from. */
+export function isGitHubImageHost(host: string): boolean {
+    const h = host.toLowerCase();
+    return (
+        h === 'github.com' ||
+        h === 'www.github.com' ||
+        h === 'githubusercontent.com' ||
+        h.endsWith('.githubusercontent.com')
+    );
+}
+
+/**
+ * Validate the `?url=` parameter. Returns the parsed URL, or null when it is
+ * missing, unparseable, not http(s), or not on a GitHub host.
+ */
+export function parseGitHubImageUrl(raw: string | null | undefined): URL | null {
+    if (!raw) return null;
+    let url: URL;
+    try {
+        url = new URL(raw);
+    } catch {
+        return null;
+    }
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    if (!isGitHubImageHost(url.hostname)) return null;
+    return url;
+}
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Fetch a GitHub-hosted image, following redirects by hand.
+ *
+ * Two reasons not to let `fetch` follow them: every hop has to be re-checked
+ * against the host allowlist, and the token must be dropped after the first
+ * one. GitHub's redirect target carries its own signature in the query string,
+ * and rejects the request outright if an `Authorization` header rides along
+ * with it.
+ */
+export async function fetchGitHubImage(
+    target: URL,
+    token: string,
+    fetchImpl: FetchLike = fetch
+): Promise<Response> {
+    let current = target;
+    let authorization = token ? `Bearer ${token}` : '';
+
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+        const headers: Record<string, string> = {
+            Accept: 'image/*',
+            'User-Agent': 'code-review-server',
+        };
+        if (authorization) headers.Authorization = authorization;
+
+        const response = await fetchImpl(current.href, { redirect: 'manual', headers });
+        if (response.status < 300 || response.status >= 400) return response;
+
+        const location = response.headers.get('location');
+        if (!location) return response;
+
+        let next: URL;
+        try {
+            next = new URL(location, current);
+        } catch {
+            throw new Error(`unparseable redirect from ${current.hostname}`);
+        }
+        if (!isGitHubImageHost(next.hostname)) {
+            throw new Error(`redirect off GitHub to ${next.hostname}`);
+        }
+        current = next;
+        authorization = '';
+    }
+
+    throw new Error(`too many redirects fetching ${target.href}`);
+}

--- a/bun_client/github_images.ts
+++ b/bun_client/github_images.ts
@@ -1,21 +1,27 @@
 /**
- * The bridge half of the GitHub image proxy.
+ * URL checking for the bridge's image route.
  *
- * Comments and reviews embed screenshots as `<img>` tags pointing at
- * github.com/user-attachments or *.githubusercontent.com. Those URLs redirect
- * to a signed CDN URL, and on a private repository the redirect is only issued
- * to an authenticated request — which a browser loading the image cross-site
- * cannot make, since its github.com cookie is not sent. The bridge already has
- * `CRS_GITHUB_TOKEN`, so it fetches the bytes and hands them to the page.
+ * The downloading itself belongs to the Go server: it holds `CRS_GITHUB_TOKEN`,
+ * which a private repository's attachments require, and caching there means the
+ * Emacs client and anything else render the same images rather than each client
+ * reimplementing the fetch. The bridge asks for one over `RPCHandler.GetImage`
+ * and serves the file that comes back.
  *
- * `frontend/src/github_images.ts` decides which URLs to send here; this module
- * is the trust boundary. It re-checks the requested URL and every redirect
- * target, so the endpoint can't be turned into an open proxy by a crafted
- * comment body.
+ * This check is only a fast rejection so an obviously wrong URL doesn't cost a
+ * round trip; the Go server validates again, and it is the one that matters.
+ * `frontend/src/github_images.ts` decides which URLs get routed here at all.
  */
 
-/** How many redirects to follow before giving up. */
-export const MAX_REDIRECTS = 5;
+/** The reply shape of the Go server's RPCHandler.GetImage. */
+export interface GetImageReply {
+    okay: boolean;
+    url: string;
+    path: string;
+    content_type: string;
+    size: number;
+    cached: boolean;
+    error: string;
+}
 
 /** True for the hosts GitHub serves attachments and repository content from. */
 export function isGitHubImageHost(host: string): boolean {
@@ -43,52 +49,4 @@ export function parseGitHubImageUrl(raw: string | null | undefined): URL | null 
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
     if (!isGitHubImageHost(url.hostname)) return null;
     return url;
-}
-
-type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
-
-/**
- * Fetch a GitHub-hosted image, following redirects by hand.
- *
- * Two reasons not to let `fetch` follow them: every hop has to be re-checked
- * against the host allowlist, and the token must be dropped after the first
- * one. GitHub's redirect target carries its own signature in the query string,
- * and rejects the request outright if an `Authorization` header rides along
- * with it.
- */
-export async function fetchGitHubImage(
-    target: URL,
-    token: string,
-    fetchImpl: FetchLike = fetch
-): Promise<Response> {
-    let current = target;
-    let authorization = token ? `Bearer ${token}` : '';
-
-    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-        const headers: Record<string, string> = {
-            Accept: 'image/*',
-            'User-Agent': 'code-review-server',
-        };
-        if (authorization) headers.Authorization = authorization;
-
-        const response = await fetchImpl(current.href, { redirect: 'manual', headers });
-        if (response.status < 300 || response.status >= 400) return response;
-
-        const location = response.headers.get('location');
-        if (!location) return response;
-
-        let next: URL;
-        try {
-            next = new URL(location, current);
-        } catch {
-            throw new Error(`unparseable redirect from ${current.hostname}`);
-        }
-        if (!isGitHubImageHost(next.hostname)) {
-            throw new Error(`redirect off GitHub to ${next.hostname}`);
-        }
-        current = next;
-        authorization = '';
-    }
-
-    throw new Error(`too many redirects fetching ${target.href}`);
 }

--- a/bun_client/server.ts
+++ b/bun_client/server.ts
@@ -1,7 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import { type Subprocess, spawn } from 'bun';
-import { fetchGitHubImage, parseGitHubImageUrl } from './github_images';
+import { type GetImageReply, parseGitHubImageUrl } from './github_images';
 import { JsonRpcLineParser } from './rpc_framing';
 
 let assets: Record<string, string> = {};
@@ -322,9 +322,10 @@ Bun.serve<{
             );
         }
 
-        // Fetch a GitHub-hosted image on the page's behalf, so screenshots
-        // embedded in comments and reviews load. Attachments on a private repo
-        // need the review server's token, which the browser cannot send.
+        // Serve a GitHub-hosted image embedded in a comment or review. The Go
+        // server owns the download — it holds the token a private repo's
+        // attachments require, and caching there means every client gets the
+        // same images — so this hands back the file it cached.
         if (url.pathname === '/api/github-image' && req.method === 'GET') {
             const target = parseGitHubImageUrl(url.searchParams.get('url'));
             if (!target) {
@@ -334,37 +335,36 @@ Bun.serve<{
                 });
             }
             try {
-                const upstream = await fetchGitHubImage(target, process.env.CRS_GITHUB_TOKEN || '');
-                if (!upstream.ok) {
-                    console.error(`[Image] ${upstream.status} fetching ${target.href}`);
-                    return new Response(`Upstream returned ${upstream.status}`, {
+                const image = (await bridge.call('RPCHandler.GetImage', [
+                    { URL: target.href },
+                ])) as GetImageReply;
+                if (!image?.okay || !image.path) {
+                    console.error(`[Image] ${image?.error || 'no path'} for ${target.href}`);
+                    return new Response('Image unavailable', {
                         status: 502,
                         headers: CORS_HEADERS,
                     });
                 }
-                // An HTML sign-in page is a failure dressed as a 200, and
-                // passing non-image bytes through would make this a general
-                // purpose fetcher.
-                const contentType = upstream.headers.get('content-type') || '';
-                if (!contentType.startsWith('image/')) {
-                    console.error(`[Image] non-image ${contentType} from ${target.href}`);
-                    return new Response('Upstream did not return an image', {
+                const file = Bun.file(image.path);
+                if (!(await file.exists())) {
+                    console.error(`[Image] cached file is gone: ${image.path}`);
+                    return new Response('Image unavailable', {
                         status: 502,
                         headers: CORS_HEADERS,
                     });
                 }
-                return new Response(upstream.body, {
+                return new Response(file, {
                     headers: {
                         ...CORS_HEADERS,
-                        'Content-Type': contentType,
+                        'Content-Type': image.content_type || 'application/octet-stream',
                         // The same screenshot re-renders on every keystroke in
                         // a reply box.
                         'Cache-Control': 'private, max-age=600',
                     },
                 });
             } catch (err) {
-                console.error(`[Image] proxy failed for ${target.href}:`, err);
-                return new Response('Image proxy failed', { status: 502, headers: CORS_HEADERS });
+                console.error(`[Image] could not load ${target.href}:`, err);
+                return new Response('Image unavailable', { status: 502, headers: CORS_HEADERS });
             }
         }
 

--- a/bun_client/server.ts
+++ b/bun_client/server.ts
@@ -1,6 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import { type Subprocess, spawn } from 'bun';
+import { fetchGitHubImage, parseGitHubImageUrl } from './github_images';
 import { JsonRpcLineParser } from './rpc_framing';
 
 let assets: Record<string, string> = {};
@@ -319,6 +320,52 @@ Bun.serve<{
                     headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
                 }
             );
+        }
+
+        // Fetch a GitHub-hosted image on the page's behalf, so screenshots
+        // embedded in comments and reviews load. Attachments on a private repo
+        // need the review server's token, which the browser cannot send.
+        if (url.pathname === '/api/github-image' && req.method === 'GET') {
+            const target = parseGitHubImageUrl(url.searchParams.get('url'));
+            if (!target) {
+                return new Response('Not a GitHub image URL', {
+                    status: 400,
+                    headers: CORS_HEADERS,
+                });
+            }
+            try {
+                const upstream = await fetchGitHubImage(target, process.env.CRS_GITHUB_TOKEN || '');
+                if (!upstream.ok) {
+                    console.error(`[Image] ${upstream.status} fetching ${target.href}`);
+                    return new Response(`Upstream returned ${upstream.status}`, {
+                        status: 502,
+                        headers: CORS_HEADERS,
+                    });
+                }
+                // An HTML sign-in page is a failure dressed as a 200, and
+                // passing non-image bytes through would make this a general
+                // purpose fetcher.
+                const contentType = upstream.headers.get('content-type') || '';
+                if (!contentType.startsWith('image/')) {
+                    console.error(`[Image] non-image ${contentType} from ${target.href}`);
+                    return new Response('Upstream did not return an image', {
+                        status: 502,
+                        headers: CORS_HEADERS,
+                    });
+                }
+                return new Response(upstream.body, {
+                    headers: {
+                        ...CORS_HEADERS,
+                        'Content-Type': contentType,
+                        // The same screenshot re-renders on every keystroke in
+                        // a reply box.
+                        'Cache-Control': 'private, max-age=600',
+                    },
+                });
+            } catch (err) {
+                console.error(`[Image] proxy failed for ${target.href}:`, err);
+                return new Response('Image proxy failed', { status: 502, headers: CORS_HEADERS });
+            }
         }
 
         // Read file contents from repository

--- a/client.el/crs-html.el
+++ b/client.el/crs-html.el
@@ -6,23 +6,84 @@
 
 ;;; Code:
 
+(require 'seq)
 (require 'shr)
 (require 'crs-vars)
+
+(defconst crs--image-tag-regexp "<\\(?:img\\|source\\)\\b[^>]*>"
+  "Matches the image tags GitHub embeds in a body.
+A pasted screenshot arrives as a raw <img> tag — that is what GitHub's
+upload widget writes — rather than as Markdown image syntax.")
+
+(defconst crs--img-src-regexp "\\(<img[^>]*\\bsrc=\\)\\([\"']\\)\\([^\"']*\\)\\2"
+  "Matches the src attribute of an <img> tag, capturing the URL in group 3.")
+
+(defun crs--image-cache-path (url)
+  "Return the local file the server cached URL at, or nil if there isn't one.
+Reads `crs--buffer-images', which the review buffer fills from the
+GetPR reply."
+  (let ((wanted (replace-regexp-in-string "&amp;" "&" url t t)))
+    (seq-some (lambda (image)
+                (let ((image-url (cdr (assq 'url image)))
+                      (path (cdr (assq 'path image))))
+                  (when (and (stringp image-url) (stringp path)
+                             (string= image-url wanted)
+                             (not (string-empty-p path))
+                             (file-readable-p path))
+                    path)))
+              (or crs--buffer-images []))))
+
+(defun crs--localize-image-srcs (html)
+  "Point each <img> in HTML at the copy of the image the server cached.
+An attachment on a private repository is served only to a request
+carrying a GitHub token, which shr has no way to send — so without this
+the screenshot in a review comment cannot render at all.  Images the
+server did not cache are left alone for shr to fetch itself."
+  (if (seq-empty-p (or crs--buffer-images []))
+      html
+    (replace-regexp-in-string
+     crs--img-src-regexp
+     (lambda (match)
+       (let ((path (crs--image-cache-path (match-string 3 match))))
+         (if path
+             (concat (match-string 1 match) (match-string 2 match)
+                     "file://" path (match-string 2 match))
+           match)))
+     html t t)))
 
 (defun crs--ensure-html (text)
   "Return TEXT as HTML suitable for shr rendering.
 If TEXT already looks like HTML (starts with a tag), bare newlines are
 replaced with <br> elements so shr preserves the visual line structure.
 Otherwise convert plain text/Markdown line breaks to HTML paragraphs and
-br elements so that shr preserves the visual line structure."
-  (if (string-match-p "\\`[[:space:]]*<" text)
-      (replace-regexp-in-string "\n" "<br>" text)
-    (let* ((escaped (replace-regexp-in-string "&" "&amp;" text))
-           (escaped (replace-regexp-in-string "<" "&lt;" escaped))
-           (escaped (replace-regexp-in-string ">" "&gt;" escaped))
-           (with-paras (replace-regexp-in-string "\n\n+" "</p><p>" escaped))
-           (with-brs (replace-regexp-in-string "\n" "<br>" with-paras)))
-      (concat "<p>" with-brs "</p>"))))
+br elements so that shr preserves the visual line structure.
+
+Image tags survive that escaping.  A body is mostly prose, so it takes
+the escaping branch, and escaping a screenshot's <img> tag would render
+the tag itself as text instead of the picture."
+  (crs--localize-image-srcs
+   (if (string-match-p "\\`[[:space:]]*<" text)
+       (replace-regexp-in-string "\n" "<br>" text)
+     (let* ((tags nil)
+            (protected (replace-regexp-in-string
+                        crs--image-tag-regexp
+                        (lambda (tag)
+                          (push tag tags)
+                          (format "\0crs-image-%d\0" (1- (length tags))))
+                        text t t))
+            (escaped (replace-regexp-in-string "&" "&amp;" protected))
+            (escaped (replace-regexp-in-string "<" "&lt;" escaped))
+            (escaped (replace-regexp-in-string ">" "&gt;" escaped))
+            (with-paras (replace-regexp-in-string "\n\n+" "</p><p>" escaped))
+            (with-brs (replace-regexp-in-string "\n" "<br>" with-paras))
+            (restored (replace-regexp-in-string
+                       "\0crs-image-\\([0-9]+\\)\0"
+                       (lambda (marker)
+                         (nth (- (length tags) 1
+                                 (string-to-number (match-string 1 marker)))
+                              tags))
+                       with-brs t t)))
+       (concat "<p>" restored "</p>")))))
 
 (defun crs--shr-render (html-string start)
   "Render HTML-STRING with shr, starting from buffer position START.

--- a/client.el/crs-render.el
+++ b/client.el/crs-render.el
@@ -943,6 +943,7 @@ for more robust position restoration."
           (new-reviews nil)
           (new-commits nil)
           (new-preamble nil)
+          (new-images nil)
           (new-annotations nil)
           (new-show-comments (if (local-variable-p 'crs--buffer-show-comments)
                                  crs--buffer-show-comments
@@ -961,7 +962,8 @@ for more robust position restoration."
           (existing-reviews crs--buffer-reviews)
           (existing-preamble crs--buffer-preamble)
           (existing-review-feedback crs--buffer-review-feedback)
-          (existing-commits crs--buffer-commits))
+          (existing-commits crs--buffer-commits)
+          (existing-images crs--buffer-images))
 
       ;; If content is a JSON result (alist), extract the components
       (when (and content (listp content) (not (stringp content)))
@@ -974,6 +976,7 @@ for more robust position restoration."
                (metadata (cdr (assq 'metadata content)))
                (reviews (cdr (assq 'reviews content)))
                (commits (cdr (assq 'commits content)))
+               (images (cdr (assq 'images content)))
                (raw-content (cdr (assq 'content content)))
                (preamble (if raw-content
                              (if (string-match "Files changed (.*)\n\n" raw-content)
@@ -993,6 +996,7 @@ for more robust position restoration."
           (setq new-metadata metadata)
           (setq new-reviews reviews)
           (setq new-commits commits)
+          (setq new-images images)
           (setq new-preamble preamble)
           (setq new-annotations (cdr (assq 'annotations content)))))
 
@@ -1003,6 +1007,7 @@ for more robust position restoration."
       (setq crs--buffer-metadata (or new-metadata existing-metadata))
       (setq crs--buffer-reviews (or new-reviews existing-reviews))
       (setq crs--buffer-commits (or new-commits existing-commits))
+      (setq crs--buffer-images (or new-images existing-images))
       (setq crs--buffer-preamble (or new-preamble existing-preamble))
       (setq crs--buffer-show-comments new-show-comments)
       (setq crs--buffer-annotations (or new-annotations existing-annotations))
@@ -1074,6 +1079,9 @@ for more robust position restoration."
 
         (my-code-review-mode)))
 
+      ;; The major-mode change above wiped the buffer-locals, and rendering a
+      ;; body needs the cached image paths, so put those back first.
+      (setq crs--buffer-images (or new-images existing-images))
       (crs--process-html-placeholders)
 
       ;; Re-set the buffer-local variables AFTER mode change
@@ -1083,6 +1091,7 @@ for more robust position restoration."
       (setq crs--buffer-metadata (or new-metadata existing-metadata))
       (setq crs--buffer-reviews (or new-reviews existing-reviews))
       (setq crs--buffer-commits (or new-commits existing-commits))
+      (setq crs--buffer-images (or new-images existing-images))
       (setq crs--buffer-preamble (or new-preamble existing-preamble))
       (setq crs--buffer-show-comments new-show-comments)
       (setq crs--buffer-annotations (or new-annotations existing-annotations))

--- a/client.el/crs-tests.el
+++ b/client.el/crs-tests.el
@@ -49,6 +49,7 @@
                 crs--get-comment-context crs--get-current-review-info
                 crs--review-buffer-name crs--parse-hunk-header
                 crs--ensure-html crs--make-html-placeholder
+                crs--localize-image-srcs crs--image-cache-path
                 crs--process-html-placeholders crs--strip-comments-tree
                 crs--index-annotations crs--render-annotation-block
                 crs--insert-annotations-into-buffer
@@ -64,6 +65,7 @@
                  crs--buffer-owner crs--buffer-diff crs--buffer-comments
                  crs--buffer-metadata crs--buffer-show-comments
                  crs--buffer-annotations crs--buffer-show-annotations
+                 crs--buffer-images
                  crs--comment-owner crs--comment-filename crs--comment-position
                  crs--plugin-owner crs--plugin-name crs--plugin-output-map))
     (should (boundp var))))
@@ -108,6 +110,43 @@
     (should (string-prefix-p "<p>" out)))
   ;; Content that already looks like HTML is left structurally intact.
   (should (equal (crs--ensure-html "<div>hi</div>") "<div>hi</div>")))
+
+(ert-deftest crs-test-ensure-html-keeps-embedded-images ()
+  "A screenshot in an otherwise-prose body survives as a tag, not as text."
+  (let* ((body "Mid race: <img width=\"1905\" src=\"https://github.com/user-attachments/assets/one\" />\n\nEnd: <img src=\"https://github.com/user-attachments/assets/two\">")
+         (out (crs--ensure-html body)))
+    (should (string-match-p "<img width=\"1905\" src=\"https://github.com/user-attachments/assets/one\" />" out))
+    (should (string-match-p "<img src=\"https://github.com/user-attachments/assets/two\">" out))
+    ;; The prose around them is still escaped and paragraphed.
+    (should (string-prefix-p "<p>" out))
+    (should-not (string-match-p "&lt;img" out)))
+  ;; Prose that merely mentions a tag is still escaped.
+  (should (string-match-p "&lt;div&gt;" (crs--ensure-html "use <div> here"))))
+
+(ert-deftest crs-test-localize-image-srcs ()
+  "Images the server cached are rendered from disk; the rest are left alone."
+  (let* ((cached (make-temp-file "crs-image" nil ".png"))
+         (crs--buffer-images
+          (vector `((url . "https://github.com/user-attachments/assets/one")
+                    (path . ,cached)
+                    (cached . t))
+                  ;; Not downloaded yet: no path to point at.
+                  `((url . "https://github.com/user-attachments/assets/two")
+                    (path . "")
+                    (cached . :json-false)))))
+    (unwind-protect
+        (let ((out (crs--localize-image-srcs
+                    (concat "<img src=\"https://github.com/user-attachments/assets/one\">"
+                            "<img src=\"https://github.com/user-attachments/assets/two\">"
+                            "<img src=\"https://img.shields.io/badge.svg\">"))))
+          (should (string-match-p (concat "src=\"file://" (regexp-quote cached) "\"") out))
+          (should (string-match-p "src=\"https://github.com/user-attachments/assets/two\"" out))
+          (should (string-match-p "src=\"https://img.shields.io/badge.svg\"" out)))
+      (delete-file cached)))
+  ;; With nothing cached the body comes back untouched.
+  (let ((crs--buffer-images nil))
+    (should (equal (crs--localize-image-srcs "<img src=\"https://github.com/x\">")
+                   "<img src=\"https://github.com/x\">"))))
 
 (ert-deftest crs-test-html-placeholder-roundtrip ()
   ;; Empty content yields the no-content sentinel, not a placeholder.

--- a/client.el/crs-vars.el
+++ b/client.el/crs-vars.el
@@ -117,6 +117,12 @@ with `crs-toggle-comments' also uncollapses annotations, and
   "The review feedback for the current PR.")
 (defvar-local crs--buffer-commits nil
   "The commits list for the current PR.")
+(defvar-local crs--buffer-images nil
+  "Images embedded in the current PR, from the GetPR reply's `images'.
+Each entry carries the URL as it appears in a body and the path of the
+copy the server downloaded, which is what makes a screenshot on a private
+repository renderable here: GitHub serves it only to an authenticated
+request, and the server holds the token.")
 
 ;; Buffer-local state for plugin-output buffers.
 (defvar-local crs--plugin-owner nil

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -137,6 +137,17 @@ several modules; `crs-client.el` is the entry point that loads them all
 
 Starting a review will then load a new code-review buffer which you can read the review, make comments, and submit your review.
 
+### Embedded screenshots
+
+Descriptions, reviews and comments are rendered with `shr`, and screenshots in
+them display inline in graphical Emacs. The client does not fetch those images
+itself: an attachment on a private repository is served only to a request
+carrying a GitHub token, which `shr` has no way to send. The server downloads
+them instead and the reply's `images` field says where each one landed, so the
+client points the `<img>` tag at that local file. An image the server did not
+cache — anything hosted off GitHub, or one that has not been downloaded yet — is
+left for `shr` to fetch as before.
+
 ### Configuration
 
 The following customizable variables control client behavior. Set them in your Emacs init file or via `M-x customize-group RET crs RET`.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -101,8 +101,32 @@ the reply wholesale instead of patching local state.
 | `commits`           | []CommitJSON   | Commits on the PR                                                           |
 | `feedback`          | string         | The locally saved review feedback draft for this PR (see `SetFeedback`); empty when none has been saved |
 | `annotations`       | []PRAnnotation | Diff annotations aggregated from every plugin that has already executed successfully for this PR (see [Plugins](plugins.md#plugin-response-contract)) |
+| `images`            | []ImageJSON    | Every GitHub-hosted image embedded in the description, reviews and comments, with the local file the server downloaded it to |
 
 Slice fields are normalized before sending: a client always sees `[]`, never `null`.
+
+#### Image Object (`ImageJSON`)
+
+Screenshots are how reviewers explain a bug, and they arrive in a body as raw
+`<img>` tags — that is what GitHub's upload widget writes. A client cannot fetch
+one itself on a private repository: the attachment URL redirects to a signed URL
+that GitHub issues only to an authenticated request. The server downloads them
+with its own token instead, so every client renders the same images from disk.
+
+| Field          | Type   | Description                                                                 |
+|----------------|--------|-----------------------------------------------------------------------------|
+| `url`          | string | The image URL as it appears in the body — match on this to rewrite the tag  |
+| `path`         | string | Absolute path of the downloaded file, or `""` when it isn't cached yet      |
+| `content_type` | string | MIME type of the cached file; empty alongside an empty `path`               |
+| `size`         | int64  | Size of the cached file in bytes                                            |
+| `cached`       | bool   | `true` when `path` points at a file that exists                             |
+
+The download is asynchronous, so a body can be served before its images have
+landed — `path` is empty until they do. A client that meets an empty `path` asks
+for that one image with [`GetImage`](#rpchandlergetimage), which downloads it on
+the spot. Images hosted anywhere other than `github.com` or
+`*.githubusercontent.com` are absent from this list entirely: they need no
+credentials, so clients load them directly.
 
 #### PRAnnotation Object
 
@@ -387,6 +411,68 @@ The four range fields and `HunkHeader` describe the hunk as it currently stands;
     "HunkHeader": "func (h *RPCHandler) GetPR("
   }],
   "id": 9
+}
+```
+
+---
+
+### `RPCHandler.GetImage`
+
+Returns the local file holding an image embedded in a PR's description, reviews
+or comments, downloading it first if it isn't cached yet.
+
+This is the fallback behind the payload's [`images`](#image-object-imagejson)
+list. Most images are already on disk by the time a client asks — the server
+downloads them whenever it loads a PR's discussion — so this normally costs a
+`stat`. A comment posted since the last fetch is the case that goes to GitHub,
+and this call blocks for it, unlike the rest of the read path.
+
+**Args** (`GetImageArgs`):
+| Field | Type   | Required | Description                                        |
+|-------|--------|----------|----------------------------------------------------|
+| `URL` | string | Yes      | The image URL exactly as it appears in the body    |
+
+**Reply** (`GetImageReply`):
+| Field          | Type   | Description                                                        |
+|----------------|--------|--------------------------------------------------------------------|
+| `okay`         | bool   | `true` when the image is on disk                                   |
+| `url`          | string | The URL that was resolved                                          |
+| `path`         | string | Absolute path of the cached file                                   |
+| `content_type` | string | MIME type of the cached file                                       |
+| `size`         | int64  | Size of the cached file in bytes                                   |
+| `cached`       | bool   | `false` when this call had to download the image                   |
+| `error`        | string | Why it could not be served, when `okay` is `false`                 |
+
+A URL that isn't on `github.com` or `*.githubusercontent.com` comes back with
+`okay: false` rather than as an RPC error — the client should load it directly,
+since images elsewhere need no credentials. The server only fetches GitHub hosts
+on purpose: bodies are written by whoever commented on the PR, and following
+every URL in one would make the review server issue requests wherever a
+commenter pointed it. Redirects are re-checked against the same allowlist,
+responses that aren't images are refused, and downloads are capped at 25 MB.
+
+Cached files live in `$CRS_HOME/images`, named by the SHA-256 of their URL, and
+are safe to delete — they are re-downloaded on demand.
+
+**Example Request**:
+```json
+{
+  "method": "RPCHandler.GetImage",
+  "params": [{ "URL": "https://github.com/user-attachments/assets/9b506449-0b9b-4c14-90f7-775beb9e68af" }],
+  "id": 11
+}
+```
+
+**Example Reply**:
+```json
+{
+  "okay": true,
+  "url": "https://github.com/user-attachments/assets/9b506449-0b9b-4c14-90f7-775beb9e68af",
+  "path": "/home/you/.crs/images/c33e7f4874...458b.png",
+  "content_type": "image/png",
+  "size": 26186,
+  "cached": true,
+  "error": ""
 }
 ```
 

--- a/docs/web_client_features.md
+++ b/docs/web_client_features.md
@@ -111,7 +111,7 @@ browser cannot. Reproduce them if you want the corresponding features.
 
 | Endpoint | Purpose |
 |---|---|
-| `GET /api/github-image?url=` | Fetches a GitHub-hosted image with the server's token and streams it back, so screenshots embedded in comments load. Only `github.com` and `*.githubusercontent.com` are accepted, redirects are re-checked against the same list, and a non-image response is refused. |
+| `GET /api/github-image?url=` | Serves a GitHub-hosted image embedded in a comment or review. The bridge does not fetch it: it calls `GetImage`, which downloads with the server's token and caches, and streams back the file that comes out. Only `github.com` and `*.githubusercontent.com` are accepted. |
 | `POST /api/read-file` | Read a file from disk. Accepts an absolute `filePath`, or `repoPath` + relative `filePath` (rejects paths that escape `repoPath`). Powers the code viewer. |
 | `POST /api/list-files` | Recursive file listing under `repoPath`, skipping `node_modules`, `.git`, `.next`, `dist`. Powers the code viewer's file tree. |
 | `GET /api/check-lsp` | Whether the `diff-lsp` binary is on `PATH`. |
@@ -335,12 +335,14 @@ markdown is not just markdown:
   from anyone who can comment, so `rehype-sanitize` runs *after* `rehype-raw` (that
   order matters) with its default GitHub-derived schema: `script`, event handlers,
   inline styles and non-http(s) URLs are stripped.
-- **Images load through the bridge**, via `/api/github-image`. Attachment URLs
-  redirect to a signed CDN URL that GitHub only issues to an authenticated request
-  on a private repo, and a browser's github.com cookie is not sent on a cross-site
-  image load — so a direct `<img src>` renders broken for everyone on the team. If
-  the proxy fails the client retries the original URL, which still works for public
-  repositories.
+- **Images come from the server**, via `/api/github-image` → `GetImage`. Attachment
+  URLs redirect to a signed CDN URL that GitHub only issues to an authenticated
+  request on a private repo, and a browser's github.com cookie is not sent on a
+  cross-site image load — so a direct `<img src>` renders broken for everyone on
+  the team. The Go server downloads them with its token and caches them under
+  `$CRS_HOME/images`, which is also what lets the Emacs client render the same
+  screenshots; the bridge just serves the cached file. If that fails the page
+  retries the original URL, which still works for public repositories.
 - **Sizing and clicks**: GitHub stamps the screenshot's natural size (often ~1900px)
   onto the tag, so images are clamped to the card width; clicking one opens the
   original on github.com rather than the thread's reply box.
@@ -587,9 +589,9 @@ Ordered roughly by how much time they'll cost you if missed.
 14. **Comment bodies contain raw HTML, and their images need your token.** A markdown
     renderer that ignores HTML throws away every pasted screenshot; one that renders
     it without sanitizing is an XSS hole, since the body is written by whoever
-    commented. And on a private repo the image bytes are only served to an
-    authenticated request, which the browser cannot make cross-site — fetch them
-    server-side. See the body-rendering notes in [3.6](#36-comments).
+    commented. The image bytes you can get for free: the payload's `images` list
+    maps each URL to a file the server already downloaded, and `GetImage` fetches
+    one on demand. See the body-rendering notes in [3.6](#36-comments).
 
 ---
 

--- a/docs/web_client_features.md
+++ b/docs/web_client_features.md
@@ -111,6 +111,7 @@ browser cannot. Reproduce them if you want the corresponding features.
 
 | Endpoint | Purpose |
 |---|---|
+| `GET /api/github-image?url=` | Fetches a GitHub-hosted image with the server's token and streams it back, so screenshots embedded in comments load. Only `github.com` and `*.githubusercontent.com` are accepted, redirects are re-checked against the same list, and a non-image response is refused. |
 | `POST /api/read-file` | Read a file from disk. Accepts an absolute `filePath`, or `repoPath` + relative `filePath` (rejects paths that escape `repoPath`). Powers the code viewer. |
 | `POST /api/list-files` | Recursive file listing under `repoPath`, skipping `node_modules`, `.git`, `.next`, `dist`. Powers the code viewer's file tree. |
 | `GET /api/check-lsp` | Whether the `diff-lsp` binary is on `PATH`. |
@@ -203,7 +204,8 @@ Rendered from `GetPR`'s `metadata`:
   approved-by, changes-requested-by, commented-by.
 - Labels, assignees, milestone row.
 - Collapsible markdown description, with HTML comments stripped (PR templates are
-  full of them). Expanded by default.
+  full of them) and embedded images rendered — see
+  [3.6](#36-comments). Expanded by default.
 - CI failure list when `ci_failures` is non-empty.
 - Links out: GitHub button and Copy URL button.
 
@@ -322,6 +324,26 @@ client treats `author === 'local'` as "mine, still editable".
 Calls used: `AddComment`, `EditComment`, `DeleteComment`, `SetFeedback`. Each returns
 a full refreshed PR payload, which the client applies wholesale rather than patching
 local state.
+
+**Body rendering (`GitHubMarkdown.tsx`)** — every body written by a person on the PR
+(description, review body, comment) goes through one component, because GitHub
+markdown is not just markdown:
+
+- **Raw HTML is parsed** (`rehype-raw`). A pasted screenshot arrives in the body as
+  an `<img>` tag, not as `![](…)`, and plain react-markdown drops raw HTML — so
+  screenshots, `<details>` blocks and `<picture>` pairs silently vanish. Bodies come
+  from anyone who can comment, so `rehype-sanitize` runs *after* `rehype-raw` (that
+  order matters) with its default GitHub-derived schema: `script`, event handlers,
+  inline styles and non-http(s) URLs are stripped.
+- **Images load through the bridge**, via `/api/github-image`. Attachment URLs
+  redirect to a signed CDN URL that GitHub only issues to an authenticated request
+  on a private repo, and a browser's github.com cookie is not sent on a cross-site
+  image load — so a direct `<img src>` renders broken for everyone on the team. If
+  the proxy fails the client retries the original URL, which still works for public
+  repositories.
+- **Sizing and clicks**: GitHub stamps the screenshot's natural size (often ~1900px)
+  onto the tag, so images are clamped to the card width; clicking one opens the
+  original on github.com rather than the thread's reply box.
 
 ### 3.7 Submitting a review
 
@@ -562,6 +584,12 @@ Ordered roughly by how much time they'll cost you if missed.
     `body_type` is missing or unrecognized.
 13. **Annotations anchor to head-side line numbers**, and need a fallback bucket for
     lines the diff doesn't render.
+14. **Comment bodies contain raw HTML, and their images need your token.** A markdown
+    renderer that ignores HTML throws away every pasted screenshot; one that renders
+    it without sanitizing is an XSS hole, since the body is written by whoever
+    commented. And on a private repo the image bytes are only served to an
+    authenticated request, which the browser cannot make cross-site — fetch them
+    server-side. See the body-rendering notes in [3.6](#36-comments).
 
 ---
 

--- a/images/cache.go
+++ b/images/cache.go
@@ -1,0 +1,425 @@
+package images
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"crs/config"
+)
+
+const (
+	// MaxImageBytes caps a single download. GitHub's own attachment limit is
+	// well under this; the cap exists so a comment linking something enormous
+	// can't fill the disk.
+	MaxImageBytes = 25 << 20
+
+	fetchTimeout    = 30 * time.Second
+	maxRedirects    = 5
+	prefetchWorkers = 4
+
+	// How long a failed fetch is remembered, so a broken URL in an old comment
+	// isn't retried on every pass over the pull request.
+	failureTTL = 10 * time.Minute
+)
+
+// The extension is how a client learns an image's type: Emacs hands the cached
+// file to shr, which types it by extension, and the web bridge serves it back
+// with the matching content type. Ordered so lookups are deterministic.
+var imageTypes = []struct {
+	contentType string
+	ext         string
+}{
+	{"image/png", ".png"},
+	{"image/jpeg", ".jpg"},
+	{"image/gif", ".gif"},
+	{"image/webp", ".webp"},
+	{"image/svg+xml", ".svg"},
+	{"image/avif", ".avif"},
+	{"image/apng", ".apng"},
+	{"image/bmp", ".bmp"},
+	{"image/x-icon", ".ico"},
+	{"image/vnd.microsoft.icon", ".ico"},
+	{"image/tiff", ".tiff"},
+}
+
+// Entry is a cached image on disk.
+type Entry struct {
+	// URL is the normalized source URL the bytes came from.
+	URL string
+	// Path is the absolute path of the cached file.
+	Path string
+	// ContentType is the image's MIME type, as recorded by its extension.
+	ContentType string
+	// Size is the file size in bytes.
+	Size int64
+}
+
+type failure struct {
+	err   error
+	until time.Time
+}
+
+type pendingFetch struct {
+	done  chan struct{}
+	entry Entry
+	err   error
+}
+
+// Store is a content-addressed cache of downloaded images. The zero value is
+// not usable; construct one with NewStore or take the shared one from
+// DefaultStore.
+type Store struct {
+	dir        string
+	httpClient *http.Client
+	// token is read per request so a token exported after startup still works.
+	token func() string
+	// allowHost gates which hosts may be fetched. Overridden in tests, which
+	// serve from a local address the real allowlist rejects.
+	allowHost func(string) bool
+
+	mu       sync.Mutex
+	inflight map[string]*pendingFetch
+	failures map[string]failure
+}
+
+// NewStore returns a store that caches images under dir.
+func NewStore(dir string) *Store {
+	return &Store{
+		dir: dir,
+		httpClient: &http.Client{
+			Timeout: fetchTimeout,
+			// Redirects are followed by hand: every hop has to be re-checked
+			// against the host allowlist, and the token has to be dropped
+			// after the first one.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		token:     func() string { return os.Getenv("CRS_GITHUB_TOKEN") },
+		allowHost: IsGitHubImageHost,
+		inflight:  make(map[string]*pendingFetch),
+		failures:  make(map[string]failure),
+	}
+}
+
+var (
+	storesMu sync.Mutex
+	stores   = map[string]*Store{}
+)
+
+// DefaultStore returns the shared store under $CRS_HOME/images. One store per
+// directory, so the in-flight and failure bookkeeping is shared by everything
+// that asks for the same cache — and so a test that repoints CRS_HOME gets its
+// own store rather than a stale one.
+func DefaultStore() *Store {
+	dir := defaultDir()
+	storesMu.Lock()
+	defer storesMu.Unlock()
+	if s, ok := stores[dir]; ok {
+		return s
+	}
+	s := NewStore(dir)
+	stores[dir] = s
+	return s
+}
+
+func defaultDir() string {
+	home, err := config.GetCRSHome()
+	if err != nil || home == "" {
+		slog.Warn("Could not resolve CRS home for the image cache; using a temp directory", "error", err)
+		return filepath.Join(os.TempDir(), "crs-images")
+	}
+	return filepath.Join(home, "images")
+}
+
+// Dir is the directory cached images are written to.
+func (s *Store) Dir() string { return s.dir }
+
+// Lookup reports whether an image is already on disk, without touching the
+// network. Callers on the read path use this: serving a pull request must
+// never wait on a download.
+func (s *Store) Lookup(rawURL string) (Entry, bool) {
+	key, err := s.normalize(rawURL)
+	if err != nil {
+		return Entry{}, false
+	}
+	return s.lookupKey(key)
+}
+
+func (s *Store) lookupKey(key string) (Entry, bool) {
+	base := s.pathBase(key)
+	for _, t := range imageTypes {
+		path := base + t.ext
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		return Entry{URL: key, Path: path, ContentType: t.contentType, Size: info.Size()}, true
+	}
+	return Entry{}, false
+}
+
+// Resolve returns a cached image, downloading it first if it isn't cached yet.
+// The bool reports whether the entry was already on disk, which is what the
+// prefetch is trying to make true for everything a reviewer is about to see.
+func (s *Store) Resolve(rawURL string) (Entry, bool, error) {
+	key, err := s.normalize(rawURL)
+	if err != nil {
+		return Entry{}, false, err
+	}
+	if entry, ok := s.lookupKey(key); ok {
+		return entry, true, nil
+	}
+	entry, err := s.fetch(key)
+	return entry, false, err
+}
+
+// Put stores bytes the caller already has under an image's URL, as though they
+// had been downloaded. Returns an error for a URL the store would not fetch,
+// or a content type it has no extension for.
+func (s *Store) Put(rawURL, contentType string, body []byte) (Entry, error) {
+	key, err := s.normalize(rawURL)
+	if err != nil {
+		return Entry{}, err
+	}
+	normalized := normalizeContentType(contentType)
+	ext, ok := extensionFor(normalized)
+	if !ok {
+		return Entry{}, fmt.Errorf("unsupported content type %q", contentType)
+	}
+	path := s.pathBase(key) + ext
+	if err := s.write(path, body); err != nil {
+		return Entry{}, err
+	}
+	return Entry{URL: key, Path: path, ContentType: normalized, Size: int64(len(body))}, nil
+}
+
+// Prefetch downloads any of these images that aren't cached yet. It blocks
+// until they are all done, so callers run it in a goroutine; failures are
+// logged rather than returned, since one broken image should not stop the
+// rest.
+func (s *Store) Prefetch(urls []string) {
+	if len(urls) == 0 {
+		return
+	}
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, prefetchWorkers)
+	fetched := 0
+	for _, raw := range urls {
+		key, err := s.normalize(raw)
+		if err != nil {
+			continue
+		}
+		if _, ok := s.lookupKey(key); ok {
+			continue
+		}
+		fetched++
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(key string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if _, err := s.fetch(key); err != nil {
+				slog.Warn("Failed to cache an image embedded in a PR", "url", key, "error", err)
+			}
+		}(key)
+	}
+	wg.Wait()
+	if fetched > 0 {
+		slog.Info("Cached images embedded in a PR", "attempted", fetched, "referenced", len(urls))
+	}
+}
+
+// fetch downloads one image, collapsing concurrent requests for the same URL
+// into a single download.
+func (s *Store) fetch(key string) (Entry, error) {
+	s.mu.Lock()
+	if f, ok := s.failures[key]; ok {
+		if time.Now().Before(f.until) {
+			s.mu.Unlock()
+			return Entry{}, f.err
+		}
+		delete(s.failures, key)
+	}
+	if pending, ok := s.inflight[key]; ok {
+		s.mu.Unlock()
+		<-pending.done
+		return pending.entry, pending.err
+	}
+	pending := &pendingFetch{done: make(chan struct{})}
+	s.inflight[key] = pending
+	s.mu.Unlock()
+
+	pending.entry, pending.err = s.download(key)
+
+	s.mu.Lock()
+	delete(s.inflight, key)
+	if pending.err != nil {
+		s.failures[key] = failure{err: pending.err, until: time.Now().Add(failureTTL)}
+	}
+	s.mu.Unlock()
+	close(pending.done)
+
+	return pending.entry, pending.err
+}
+
+func (s *Store) download(key string) (Entry, error) {
+	resp, err := s.get(key)
+	if err != nil {
+		return Entry{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Entry{}, fmt.Errorf("github returned %d for %s", resp.StatusCode, key)
+	}
+
+	// A sign-in page is a failure dressed as a 200, and writing non-image bytes
+	// into the cache would hand every client something it can't render.
+	contentType := normalizeContentType(resp.Header.Get("Content-Type"))
+	ext, ok := extensionFor(contentType)
+	if !ok {
+		return Entry{}, fmt.Errorf("unsupported content type %q for %s", contentType, key)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, MaxImageBytes+1))
+	if err != nil {
+		return Entry{}, fmt.Errorf("reading %s: %w", key, err)
+	}
+	if len(body) > MaxImageBytes {
+		return Entry{}, fmt.Errorf("image at %s is larger than %d bytes", key, MaxImageBytes)
+	}
+
+	path := s.pathBase(key) + ext
+	if err := s.write(path, body); err != nil {
+		return Entry{}, err
+	}
+	return Entry{URL: key, Path: path, ContentType: contentType, Size: int64(len(body))}, nil
+}
+
+// get issues the request, following redirects by hand.
+func (s *Store) get(key string) (*http.Response, error) {
+	current := key
+	token := s.token()
+
+	for hop := 0; hop <= maxRedirects; hop++ {
+		req, err := http.NewRequest(http.MethodGet, current, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "image/*")
+		req.Header.Set("User-Agent", "code-review-server")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+			return resp, nil
+		}
+
+		location := resp.Header.Get("Location")
+		resp.Body.Close()
+		if location == "" {
+			return nil, fmt.Errorf("redirect without a location from %s", current)
+		}
+		base, err := url.Parse(current)
+		if err != nil {
+			return nil, err
+		}
+		next, err := base.Parse(location)
+		if err != nil {
+			return nil, fmt.Errorf("unparseable redirect from %s: %w", current, err)
+		}
+		if !s.allowHost(next.Hostname()) {
+			return nil, fmt.Errorf("refusing to follow a redirect off GitHub to %s", next.Hostname())
+		}
+		current = next.String()
+		// The signed URL GitHub redirects to carries its own credentials in the
+		// query string, and the request is rejected outright if an
+		// Authorization header rides along with it.
+		token = ""
+	}
+	return nil, fmt.Errorf("too many redirects fetching %s", key)
+}
+
+// write puts the bytes in place atomically, so a download interrupted halfway
+// never leaves a truncated image that later looks like a cache hit.
+func (s *Store) write(path string, body []byte) error {
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return fmt.Errorf("creating the image cache directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(s.dir, ".partial-*")
+	if err != nil {
+		return fmt.Errorf("creating a temp file for %s: %w", path, err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", path, err)
+	}
+	// CreateTemp makes the file private to the owner; images are read by
+	// whatever client is rendering the review, so give them the usual mode.
+	if err := os.Chmod(tmp.Name(), 0o644); err != nil {
+		return fmt.Errorf("setting the mode on %s: %w", path, err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("moving the image into place at %s: %w", path, err)
+	}
+	return nil
+}
+
+// normalize validates a URL and returns the canonical string used as its cache
+// key.
+func (s *Store) normalize(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("unparseable image url %q", raw)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("image url %q is not http(s)", raw)
+	}
+	if !s.allowHost(parsed.Hostname()) {
+		return "", fmt.Errorf("image url %q is not on a GitHub host", raw)
+	}
+	return parsed.String(), nil
+}
+
+// pathBase is the cached file's path without its extension. Content-addressing
+// by URL keeps names stable across restarts and free of anything a commenter
+// could use to escape the cache directory.
+func (s *Store) pathBase(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return filepath.Join(s.dir, hex.EncodeToString(sum[:]))
+}
+
+func normalizeContentType(header string) string {
+	value, _, _ := strings.Cut(header, ";")
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func extensionFor(contentType string) (string, bool) {
+	for _, t := range imageTypes {
+		if t.contentType == contentType {
+			return t.ext, true
+		}
+	}
+	return "", false
+}

--- a/images/cache_test.go
+++ b/images/cache_test.go
@@ -1,0 +1,302 @@
+package images
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// newTestStore returns a store pointed at a temp directory that will fetch from
+// the local test servers below, which the real GitHub allowlist rejects.
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	s := NewStore(t.TempDir())
+	s.allowHost = func(string) bool { return true }
+	s.token = func() string { return "" }
+	return s
+}
+
+func servePNG(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "image/png")
+	fmt.Fprint(w, body)
+}
+
+func TestResolveDownloadsThenServesFromDisk(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		servePNG(w, "png-bytes")
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	entry, cached, err := store.Resolve(server.URL + "/assets/abc")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if cached {
+		t.Error("first Resolve() reported a cache hit")
+	}
+	if entry.ContentType != "image/png" {
+		t.Errorf("ContentType = %q, want image/png", entry.ContentType)
+	}
+	if entry.Size != int64(len("png-bytes")) {
+		t.Errorf("Size = %d, want %d", entry.Size, len("png-bytes"))
+	}
+	if !strings.HasSuffix(entry.Path, ".png") {
+		t.Errorf("Path = %q, want a .png extension so clients can type it", entry.Path)
+	}
+	body, err := os.ReadFile(entry.Path)
+	if err != nil {
+		t.Fatalf("reading the cached file: %v", err)
+	}
+	if string(body) != "png-bytes" {
+		t.Errorf("cached bytes = %q, want %q", body, "png-bytes")
+	}
+
+	again, cached, err := store.Resolve(server.URL + "/assets/abc")
+	if err != nil {
+		t.Fatalf("second Resolve() error = %v", err)
+	}
+	if !cached {
+		t.Error("second Resolve() went back to the network")
+	}
+	if again.Path != entry.Path {
+		t.Errorf("second Resolve() path = %q, want %q", again.Path, entry.Path)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("made %d requests, want 1", got)
+	}
+}
+
+func TestResolveSendsTheTokenAndDropsItOnTheRedirect(t *testing.T) {
+	// GitHub rejects a request that carries both the signature in its redirect
+	// target's query string and an Authorization header, so the token has to
+	// come off after the first hop.
+	var authHeaders []string
+	var mu sync.Mutex
+	record := func(r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+	}
+
+	signed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		servePNG(w, "png-bytes")
+	}))
+	defer signed.Close()
+
+	attachment := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		http.Redirect(w, r, signed.URL+"/signed?jwt=abc", http.StatusFound)
+	}))
+	defer attachment.Close()
+
+	store := newTestStore(t)
+	store.token = func() string { return "ghp_token" }
+	if _, _, err := store.Resolve(attachment.URL + "/assets/abc"); err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"Bearer ghp_token", ""}
+	if len(authHeaders) != len(want) {
+		t.Fatalf("got %d requests (%v), want %d", len(authHeaders), authHeaders, len(want))
+	}
+	for i, w := range want {
+		if authHeaders[i] != w {
+			t.Errorf("request %d Authorization = %q, want %q", i, authHeaders[i], w)
+		}
+	}
+}
+
+func TestResolveRefusesARedirectOffTheAllowlist(t *testing.T) {
+	attachment := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://evil.test/pixel.png", http.StatusFound)
+	}))
+	defer attachment.Close()
+
+	store := newTestStore(t)
+	// Everything but the redirect target is allowed, so the refusal is the
+	// hop check rather than the initial validation.
+	store.allowHost = func(host string) bool { return host != "evil.test" }
+
+	_, _, err := store.Resolve(attachment.URL + "/assets/abc")
+	if err == nil {
+		t.Fatal("Resolve() followed a redirect off the allowlist")
+	}
+	if !strings.Contains(err.Error(), "refusing to follow a redirect") {
+		t.Errorf("Resolve() error = %v, want a refused-redirect error", err)
+	}
+}
+
+func TestResolveRejectsNonImageResponses(t *testing.T) {
+	// A sign-in page comes back as a 200 with HTML; caching it would hand every
+	// client something it can't render.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, "<html>sign in</html>")
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	if _, _, err := store.Resolve(server.URL + "/assets/abc"); err == nil {
+		t.Fatal("Resolve() accepted an HTML response")
+	}
+	if _, ok := store.Lookup(server.URL + "/assets/abc"); ok {
+		t.Error("a non-image response was written to the cache")
+	}
+}
+
+func TestResolveRejectsAnErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	_, _, err := store.Resolve(server.URL + "/assets/gone")
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("Resolve() error = %v, want a 404 error", err)
+	}
+}
+
+func TestResolveRemembersAFailureBriefly(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	for i := 0; i < 3; i++ {
+		if _, _, err := store.Resolve(server.URL + "/assets/gone"); err == nil {
+			t.Fatal("Resolve() succeeded against a 404")
+		}
+	}
+	// A broken URL in an old comment shouldn't be retried every time the PR is
+	// looked at.
+	if got := requests.Load(); got != 1 {
+		t.Errorf("made %d requests, want 1", got)
+	}
+}
+
+func TestResolveRejectsAnOversizedImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(make([]byte, MaxImageBytes+1))
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	_, _, err := store.Resolve(server.URL + "/assets/huge")
+	if err == nil || !strings.Contains(err.Error(), "larger than") {
+		t.Fatalf("Resolve() error = %v, want a size-limit error", err)
+	}
+	if _, ok := store.Lookup(server.URL + "/assets/huge"); ok {
+		t.Error("an oversized image was written to the cache")
+	}
+}
+
+func TestConcurrentResolvesDownloadOnce(t *testing.T) {
+	var requests atomic.Int32
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		<-release
+		servePNG(w, "png-bytes")
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, _, err := store.Resolve(server.URL + "/assets/abc"); err != nil {
+				t.Errorf("Resolve() error = %v", err)
+			}
+		}()
+	}
+	close(release)
+	wg.Wait()
+
+	if got := requests.Load(); got != 1 {
+		t.Errorf("made %d requests, want 1 — concurrent resolves should collapse", got)
+	}
+}
+
+func TestPrefetchFillsTheCacheAndSkipsWhatIsThere(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		servePNG(w, "png-bytes")
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	urls := []string{
+		server.URL + "/assets/one",
+		server.URL + "/assets/two",
+		// Not fetchable, and must not stop the others.
+		"https://evil.test/pixel.png",
+	}
+	store.allowHost = func(host string) bool { return host != "evil.test" }
+
+	store.Prefetch(urls)
+	if got := requests.Load(); got != 2 {
+		t.Errorf("made %d requests, want 2", got)
+	}
+	for _, u := range urls[:2] {
+		if _, ok := store.Lookup(u); !ok {
+			t.Errorf("Lookup(%q) = false after Prefetch", u)
+		}
+	}
+
+	store.Prefetch(urls)
+	if got := requests.Load(); got != 2 {
+		t.Errorf("made %d requests after a second Prefetch, want 2 — cached images should be skipped", got)
+	}
+}
+
+func TestLookupNeverTouchesTheNetwork(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		servePNG(w, "png-bytes")
+	}))
+	defer server.Close()
+
+	store := newTestStore(t)
+	if _, ok := store.Lookup(server.URL + "/assets/abc"); ok {
+		t.Error("Lookup() reported a hit for an image that was never fetched")
+	}
+	if got := requests.Load(); got != 0 {
+		t.Errorf("Lookup() made %d requests, want 0", got)
+	}
+}
+
+func TestResolveValidatesTheURL(t *testing.T) {
+	// The real allowlist, i.e. what the RPC handler enforces.
+	store := NewStore(t.TempDir())
+	for _, raw := range []string{
+		"https://evil.test/pixel.png",
+		"http://192.168.1.1/admin",
+		"file:///etc/passwd",
+		"not a url at all",
+		"",
+	} {
+		if _, _, err := store.Resolve(raw); err == nil {
+			t.Errorf("Resolve(%q) succeeded, want a validation error", raw)
+		}
+	}
+}

--- a/images/extract.go
+++ b/images/extract.go
@@ -1,0 +1,125 @@
+// Package images downloads and caches the images embedded in a pull request's
+// description, reviews and comments.
+//
+// Screenshots are how reviewers explain a bug, and every one of them is a
+// problem for a client on its own: an attachment URL redirects to a signed CDN
+// URL that GitHub only issues to an authenticated request, so on a private
+// repository the bytes are unreachable without the server's token. Doing the
+// fetch here means the token stays in one place and every client — web, Emacs,
+// anything else — renders the same images from local disk.
+package images
+
+import (
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Bodies arrive as GitHub-flavored markdown, where an attached screenshot is
+// usually a raw <img> tag (that is what the upload widget writes) but can also
+// be markdown image syntax, or a <picture>/<source> pair for a light/dark
+// screenshot.
+var (
+	imageTagPattern  = regexp.MustCompile(`(?is)<(?:img|source)\b[^>]*>`)
+	srcAttrPattern   = regexp.MustCompile(`(?is)\b(src|srcset)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))`)
+	markdownImgRegex = regexp.MustCompile(`!\[[^\]]*\]\(\s*<?([^)\s>]+)>?[^)]*\)`)
+)
+
+// IsGitHubImageHost reports whether a host is one GitHub serves attachments and
+// repository content from.
+//
+// Only these are cached. A body is written by whoever commented on the pull
+// request, so treating every URL in it as something to fetch would turn the
+// review server into a request generator pointed wherever a commenter likes.
+// Images hosted elsewhere (CI badges, say) are left for the client to load
+// directly, which needs no credentials anyway.
+func IsGitHubImageHost(host string) bool {
+	h := strings.ToLower(host)
+	return h == "github.com" ||
+		h == "www.github.com" ||
+		h == "githubusercontent.com" ||
+		strings.HasSuffix(h, ".githubusercontent.com")
+}
+
+// ParseURL returns the parsed form of an image URL the server is willing to
+// fetch, or nil when it is unparseable, not http(s), or not on a GitHub host.
+func ParseURL(raw string) *url.URL {
+	if raw == "" {
+		return nil
+	}
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil
+	}
+	if !IsGitHubImageHost(parsed.Hostname()) {
+		return nil
+	}
+	return parsed
+}
+
+// ExtractURLs returns the GitHub-hosted image URLs referenced by a body, in the
+// order they appear and without duplicates.
+func ExtractURLs(body string) []string {
+	if body == "" {
+		return nil
+	}
+
+	var found []string
+	seen := make(map[string]bool)
+	add := func(raw string) {
+		// Attribute values are HTML-escaped, so a URL with query parameters
+		// arrives with &amp; where the server needs &.
+		raw = html.UnescapeString(strings.TrimSpace(raw))
+		parsed := ParseURL(raw)
+		if parsed == nil || seen[parsed.String()] {
+			return
+		}
+		seen[parsed.String()] = true
+		found = append(found, parsed.String())
+	}
+
+	for _, tag := range imageTagPattern.FindAllString(body, -1) {
+		for _, attr := range srcAttrPattern.FindAllStringSubmatch(tag, -1) {
+			value := firstNonEmpty(attr[2], attr[3], attr[4])
+			if strings.EqualFold(attr[1], "srcset") {
+				for _, candidate := range splitSrcSet(value) {
+					add(candidate)
+				}
+				continue
+			}
+			add(value)
+		}
+	}
+
+	for _, match := range markdownImgRegex.FindAllStringSubmatch(body, -1) {
+		add(match[1])
+	}
+
+	return found
+}
+
+// splitSrcSet pulls the URLs out of a srcset attribute, whose candidates are
+// "<url> [descriptor]" separated by commas.
+func splitSrcSet(value string) []string {
+	var urls []string
+	for _, candidate := range strings.Split(value, ",") {
+		fields := strings.Fields(candidate)
+		if len(fields) > 0 {
+			urls = append(urls, fields[0])
+		}
+	}
+	return urls
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/images/extract_test.go
+++ b/images/extract_test.go
@@ -1,0 +1,143 @@
+package images
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The shape GitHub's upload widget writes into a comment when someone pastes a
+// screenshot, taken from a real review thread.
+const commentWithScreenshots = `So I've done some quick debugging.
+
+Mid race: <img width="1905" height="1189" alt="Screenshot 2025-12-01 at 13 04 37" src="https://github.com/user-attachments/assets/9b506449-0b9b-4c14-90f7-775beb9e68af" />
+
+End of race: <img width="1910" height="1190" alt="Screenshot 2025-12-01 at 13 05 28" src="https://github.com/user-attachments/assets/016b4b0e-57d4-4b22-8ae9-34d730246647" />`
+
+func TestExtractURLsFindsAttachedScreenshots(t *testing.T) {
+	got := ExtractURLs(commentWithScreenshots)
+	want := []string{
+		"https://github.com/user-attachments/assets/9b506449-0b9b-4c14-90f7-775beb9e68af",
+		"https://github.com/user-attachments/assets/016b4b0e-57d4-4b22-8ae9-34d730246647",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractURLs() = %v, want %v", got, want)
+	}
+}
+
+func TestExtractURLsHandlesTheOtherWaysImagesAppear(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "markdown image syntax",
+			body: "![shot](https://user-images.githubusercontent.com/1/x.png)",
+			want: []string{"https://user-images.githubusercontent.com/1/x.png"},
+		},
+		{
+			name: "markdown image with a title",
+			body: `![shot](https://user-images.githubusercontent.com/1/x.png "a title")`,
+			want: []string{"https://user-images.githubusercontent.com/1/x.png"},
+		},
+		{
+			name: "single-quoted src",
+			body: "<img src='https://github.com/user-attachments/assets/a'>",
+			want: []string{"https://github.com/user-attachments/assets/a"},
+		},
+		{
+			name: "unquoted src",
+			body: "<img src=https://github.com/user-attachments/assets/a>",
+			want: []string{"https://github.com/user-attachments/assets/a"},
+		},
+		{
+			name: "uppercase tag",
+			body: `<IMG SRC="https://github.com/user-attachments/assets/a">`,
+			want: []string{"https://github.com/user-attachments/assets/a"},
+		},
+		{
+			name: "light and dark picture sources",
+			body: `<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/dark 1x, https://github.com/user-attachments/assets/dark2 2x">
+<img src="https://github.com/user-attachments/assets/light">
+</picture>`,
+			want: []string{
+				"https://github.com/user-attachments/assets/dark",
+				"https://github.com/user-attachments/assets/dark2",
+				"https://github.com/user-attachments/assets/light",
+			},
+		},
+		{
+			name: "escaped ampersands in a query string",
+			body: `<img src="https://private-user-images.githubusercontent.com/1/x.png?jwt=abc&amp;v=2">`,
+			want: []string{"https://private-user-images.githubusercontent.com/1/x.png?jwt=abc&v=2"},
+		},
+		{
+			name: "the same image twice",
+			body: `<img src="https://github.com/user-attachments/assets/a"> and again <img src="https://github.com/user-attachments/assets/a">`,
+			want: []string{"https://github.com/user-attachments/assets/a"},
+		},
+		{
+			name: "no images at all",
+			body: "just some prose about a `<img>` tag",
+			want: nil,
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractURLs(tt.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractURLs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractURLsSkipsWhatTheServerWillNotFetch(t *testing.T) {
+	// A body is written by whoever commented on the PR, so anything off
+	// GitHub is left for the client to load directly rather than becoming a
+	// request this server makes.
+	body := `<img src="https://img.shields.io/badge/ci-green.svg">
+<img src="http://192.168.1.1/admin">
+<img src="file:///etc/passwd">
+<img src="data:image/png;base64,AAAA">
+<img src="/relative/path.png">
+<img src="https://github.com.evil.test/x.png">
+<img src="https://githubusercontent.com.evil.test/x.png">
+<img src="https://github.com/user-attachments/assets/keeper">`
+
+	want := []string{"https://github.com/user-attachments/assets/keeper"}
+	if got := ExtractURLs(body); !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractURLs() = %v, want %v", got, want)
+	}
+}
+
+func TestIsGitHubImageHost(t *testing.T) {
+	allowed := []string{
+		"github.com",
+		"GitHub.com",
+		"www.github.com",
+		"githubusercontent.com",
+		"user-images.githubusercontent.com",
+		"private-user-images.githubusercontent.com",
+		"raw.githubusercontent.com",
+	}
+	for _, host := range allowed {
+		if !IsGitHubImageHost(host) {
+			t.Errorf("IsGitHubImageHost(%q) = false, want true", host)
+		}
+	}
+
+	// Suffix matching has to be on a dot boundary.
+	denied := []string{"notgithub.com", "githubusercontent.com.evil.test", "github.com.evil.test", "evil.test", ""}
+	for _, host := range denied {
+		if IsGitHubImageHost(host) {
+			t.Errorf("IsGitHubImageHost(%q) = true, want false", host)
+		}
+	}
+}

--- a/server/images.go
+++ b/server/images.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"log/slog"
+
+	"crs/images"
+)
+
+// ImageJSON is one image embedded in a pull request's description, reviews or
+// comments, together with where the server put it on disk.
+//
+// Clients render bodies themselves, so they need a way to turn the URL in an
+// <img> tag into bytes they can display. On a private repository they cannot
+// fetch it: the attachment redirects to a signed URL that GitHub only issues
+// to an authenticated request. Path is the answer — a local file every client
+// can read, already downloaded with the server's token.
+type ImageJSON struct {
+	// URL is the image as it appears in the body.
+	URL string `json:"url"`
+	// Path is the cached file's absolute path, or "" when it isn't cached yet
+	// — the prefetch is asynchronous, so a body can be served before its
+	// images have landed. Clients that find an empty path can ask for the
+	// image directly with RPCHandler.GetImage.
+	Path string `json:"path"`
+	// ContentType is the image's MIME type; empty alongside an empty Path.
+	ContentType string `json:"content_type"`
+	// Size is the cached file's size in bytes.
+	Size int64 `json:"size"`
+	// Cached is true when Path points at a file that exists right now.
+	Cached bool `json:"cached"`
+}
+
+// collectImageURLs returns every GitHub-hosted image URL referenced anywhere in
+// a PR's text, in the order a reader would meet them: description first, then
+// reviews, then comments.
+func collectImageURLs(details *PRDetails) []string {
+	if details == nil {
+		return nil
+	}
+
+	var urls []string
+	seen := map[string]bool{}
+	add := func(body string) {
+		for _, u := range images.ExtractURLs(body) {
+			if seen[u] {
+				continue
+			}
+			seen[u] = true
+			urls = append(urls, u)
+		}
+	}
+
+	add(details.Metadata.Body)
+	for _, r := range details.Reviews {
+		add(r.Body)
+	}
+	for _, c := range details.Comments {
+		add(c.Body)
+	}
+	for _, c := range details.OutdatedComments {
+		add(c.Body)
+	}
+	return urls
+}
+
+// imagesForPR reports where each of a PR's images currently sits in the cache.
+// It only reads the disk cache: serving a PR must never wait on a download.
+func imagesForPR(details *PRDetails) []ImageJSON {
+	urls := collectImageURLs(details)
+	out := make([]ImageJSON, 0, len(urls))
+	store := images.DefaultStore()
+	for _, u := range urls {
+		image := ImageJSON{URL: u}
+		if entry, ok := store.Lookup(u); ok {
+			image.Path = entry.Path
+			image.ContentType = entry.ContentType
+			image.Size = entry.Size
+			image.Cached = true
+		}
+		out = append(out, image)
+	}
+	return out
+}
+
+type GetImageArgs struct {
+	// URL is the image URL as it appears in a PR body, review or comment.
+	URL string `json:"URL"`
+}
+
+type GetImageReply struct {
+	Okay        bool   `json:"okay"`
+	URL         string `json:"url"`
+	Path        string `json:"path"`
+	ContentType string `json:"content_type"`
+	Size        int64  `json:"size"`
+	// Cached is false when this call had to download the image, which is the
+	// case the prefetch exists to avoid.
+	Cached bool   `json:"cached"`
+	Error  string `json:"error"`
+}
+
+// GetImage returns the local path of an image embedded in a PR, downloading it
+// first if the prefetch hasn't got to it yet.
+//
+// This is the fallback behind the `images` list in the PR payload: a client
+// that meets an image with no path — a comment posted since the last fetch,
+// say — asks for it here and gets a file it can render. A URL that isn't on a
+// GitHub host comes back with okay:false, and the client should load it
+// directly instead; those need no credentials.
+//
+// Unlike the rest of the read path this one can block on the network, because
+// the caller is asking for exactly one image and has nothing to show without
+// it.
+func (h *RPCHandler) GetImage(args *GetImageArgs, reply *GetImageReply) error {
+	reply.URL = args.URL
+	entry, cached, err := images.DefaultStore().Resolve(args.URL)
+	if err != nil {
+		slog.Warn("Could not serve an image embedded in a PR", "url", args.URL, "error", err)
+		reply.Error = err.Error()
+		return nil
+	}
+	reply.Okay = true
+	reply.URL = entry.URL
+	reply.Path = entry.Path
+	reply.ContentType = entry.ContentType
+	reply.Size = entry.Size
+	reply.Cached = cached
+	return nil
+}
+
+// prefetchPRImages downloads the images a PR references, so that by the time
+// anyone opens the review they are already on disk. Runs in its own goroutine
+// and returns immediately; images that are already cached cost a stat each.
+func prefetchPRImages(repo string, number int, details *PRDetails) {
+	urls := collectImageURLs(details)
+	if len(urls) == 0 {
+		return
+	}
+	go func() {
+		slog.Debug("Caching images embedded in a PR", "repo", repo, "pr", number, "count", len(urls))
+		images.DefaultStore().Prefetch(urls)
+	}()
+}

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"crs/images"
+)
+
+// A screenshot as GitHub's upload widget writes it into a comment.
+const screenshotTag = `<img width="1905" height="1189" alt="Screenshot" src="https://github.com/user-attachments/assets/9b506449" />`
+
+func TestCollectImageURLsReadsEveryBodyOnThePR(t *testing.T) {
+	details := &PRDetails{
+		Metadata: PRMetadata{Body: "Here's the before shot: " + screenshotTag},
+		Reviews: []ReviewJSON{
+			{Body: `<img src="https://github.com/user-attachments/assets/review">`},
+		},
+		Comments: []CommentJSON{
+			{Body: "![diagram](https://user-images.githubusercontent.com/1/diagram.png)"},
+			// The same screenshot quoted back in a reply is not a second image.
+			{Body: screenshotTag},
+		},
+		OutdatedComments: []CommentJSON{
+			{Body: `<img src="https://github.com/user-attachments/assets/outdated">`},
+		},
+	}
+
+	got := collectImageURLs(details)
+	want := []string{
+		"https://github.com/user-attachments/assets/9b506449",
+		"https://github.com/user-attachments/assets/review",
+		"https://user-images.githubusercontent.com/1/diagram.png",
+		"https://github.com/user-attachments/assets/outdated",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("collectImageURLs() = %v, want %v", got, want)
+	}
+}
+
+func TestCollectImageURLsOnAPRWithoutImages(t *testing.T) {
+	details := &PRDetails{
+		Metadata: PRMetadata{Body: "no images here"},
+		Comments: []CommentJSON{{Body: "still none"}},
+	}
+	if got := collectImageURLs(details); got != nil {
+		t.Errorf("collectImageURLs() = %v, want nil", got)
+	}
+	if got := collectImageURLs(nil); got != nil {
+		t.Errorf("collectImageURLs(nil) = %v, want nil", got)
+	}
+}
+
+// seedImage caches bytes for a URL, standing in for an image the prefetch
+// already downloaded.
+func seedImage(t *testing.T, url string, body []byte) string {
+	t.Helper()
+	entry, err := images.DefaultStore().Put(url, "image/png", body)
+	if err != nil {
+		t.Fatalf("seeding the image cache: %v", err)
+	}
+	return entry.Path
+}
+
+func TestImagesForPRReportsWhatIsOnDisk(t *testing.T) {
+	t.Setenv("CRS_HOME", t.TempDir())
+
+	cachedURL := "https://github.com/user-attachments/assets/cached"
+	missingURL := "https://github.com/user-attachments/assets/missing"
+	path := seedImage(t, cachedURL, []byte("png-bytes"))
+
+	details := &PRDetails{
+		Metadata: PRMetadata{Body: `<img src="` + cachedURL + `"> and <img src="` + missingURL + `">`},
+	}
+
+	got := imagesForPR(details)
+	if len(got) != 2 {
+		t.Fatalf("imagesForPR() returned %d images, want 2", len(got))
+	}
+
+	if got[0].URL != cachedURL || !got[0].Cached {
+		t.Errorf("cached image = %+v, want a cache hit for %s", got[0], cachedURL)
+	}
+	if got[0].Path != path {
+		t.Errorf("cached image path = %q, want %q", got[0].Path, path)
+	}
+	if got[0].ContentType != "image/png" {
+		t.Errorf("cached image content type = %q, want image/png", got[0].ContentType)
+	}
+	if got[0].Size != int64(len("png-bytes")) {
+		t.Errorf("cached image size = %d, want %d", got[0].Size, len("png-bytes"))
+	}
+
+	// An image the prefetch hasn't reached yet is still listed, with an empty
+	// path — that is the client's cue to ask for it with GetImage.
+	if got[1].URL != missingURL || got[1].Cached || got[1].Path != "" {
+		t.Errorf("uncached image = %+v, want an empty path for %s", got[1], missingURL)
+	}
+}
+
+func TestGetImageServesACachedImageWithoutTheNetwork(t *testing.T) {
+	t.Setenv("CRS_HOME", t.TempDir())
+	t.Setenv("CRS_GITHUB_TOKEN", "")
+
+	url := "https://github.com/user-attachments/assets/cached"
+	path := seedImage(t, url, []byte("png-bytes"))
+
+	handler := &RPCHandler{}
+	reply := &GetImageReply{}
+	done := make(chan error, 1)
+	go func() { done <- handler.GetImage(&GetImageArgs{URL: url}, reply) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("GetImage() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetImage() blocked on a cached image")
+	}
+
+	if !reply.Okay || !reply.Cached {
+		t.Errorf("reply = %+v, want okay and cached", reply)
+	}
+	if reply.Path != path {
+		t.Errorf("reply.Path = %q, want %q", reply.Path, path)
+	}
+	if reply.ContentType != "image/png" {
+		t.Errorf("reply.ContentType = %q, want image/png", reply.ContentType)
+	}
+}
+
+func TestGetImageRefusesAnythingOffGitHub(t *testing.T) {
+	t.Setenv("CRS_HOME", t.TempDir())
+
+	handler := &RPCHandler{}
+	for _, url := range []string{
+		"https://evil.test/pixel.png",
+		"http://192.168.1.1/admin",
+		"file:///etc/passwd",
+	} {
+		reply := &GetImageReply{}
+		// A refusal is a soft failure, not an RPC error: the client just loads
+		// the URL itself.
+		if err := handler.GetImage(&GetImageArgs{URL: url}, reply); err != nil {
+			t.Errorf("GetImage(%q) returned an RPC error: %v", url, err)
+		}
+		if reply.Okay || reply.Error == "" {
+			t.Errorf("GetImage(%q) reply = %+v, want okay:false with a reason", url, reply)
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -167,6 +167,10 @@ type PRPayload struct {
 	Commits          []CommitJSON   `json:"commits"`
 	Feedback         string         `json:"feedback"`
 	Annotations      []PRAnnotation `json:"annotations"`
+	// Images maps every image embedded in the text above to the copy the
+	// server downloaded, so clients can render screenshots without holding a
+	// GitHub token of their own. See ImageJSON.
+	Images []ImageJSON `json:"images"`
 }
 
 // populate fills the payload from fetched PR details, normalizing nil slices
@@ -207,6 +211,8 @@ func (p *PRPayload) populate(details *PRDetails, content string, owner, repo str
 		annotations = []PRAnnotation{}
 	}
 	p.Annotations = annotations
+
+	p.Images = imagesForPR(details)
 }
 
 type GetPRReply struct {
@@ -289,6 +295,11 @@ func shouldDispatchHooks(owner, repo string, number int, sha string) bool {
 // content" call this; local-comment mutations do not, since they never change
 // the PR's head SHA. The workflow layer reaches it through WarmPRAnalysis.
 func ensurePostUpdateHooks(owner, repo string, number int, details *PRDetails) {
+	// Deliberately ahead of the SHA debounce below: a new comment carrying a
+	// screenshot doesn't change the head SHA, and it is exactly the case where
+	// an image is missing from the cache.
+	prefetchPRImages(repo, number, details)
+
 	_, sha, err := config.C().DB.GetPullRequest(number, repo)
 	if err != nil {
 		slog.Warn("Error reading cached PR SHA for hook dispatch", "repo", repo, "pr", number, "error", err)


### PR DESCRIPTION
Screenshots are how people explain a bug in a review thread, and they were
disappearing from the web client entirely. Two separate reasons:

GitHub's upload widget writes a pasted screenshot into the body as a raw
`<img>` tag, not as markdown image syntax, and react-markdown drops raw HTML.
Every body written by a person on the PR — description, review body, comment,
outdated comment — now goes through one `GitHubMarkdown` component that parses
raw HTML with rehype-raw and sanitizes the result with rehype-sanitize. Its
default schema is GitHub's own, so `<img>`, `<details>` and `<picture>` survive
along with their sizing attributes, while scripts, event handlers, inline
styles and non-http(s) URLs do not. That matters here: the body is written by
whoever commented on the PR.

The second reason is authentication. An attachment URL redirects to a signed
CDN URL that GitHub only issues to an authenticated request on a private repo,
and the browser's github.com cookie is not sent on a cross-site image load — so
a direct `<img src>` renders broken for the whole team. The bridge gains
`GET /api/github-image`, which fetches the bytes with CRS_GITHUB_TOKEN and
streams them back. It only accepts github.com and *.githubusercontent.com,
re-checks every redirect target against that list, drops the token after the
first hop (GitHub rejects a signed URL that also carries an Authorization
header), and refuses a non-image response. If the proxy fails, the client
retries the original URL, which still works for public repositories.

Also from the same component: images are clamped to the card width, since
GitHub stamps the screenshot's natural size (often ~1900px) onto the tag;
clicking an image opens the original on github.com instead of the reply box;
and links in a comment open in a new tab rather than replacing the review.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PeXdNzcmB2MKiGrjwPvBz7