### PR TITLE
Add crs-add-annotation-as-comment to promote plugin annotations to review feedback

### DIFF
--- a/client.el/crs-client.el
+++ b/client.el/crs-client.el
@@ -45,6 +45,7 @@
   "TAB" #'crs-toggle-section
   "<tab>" #'crs-toggle-section
   "<backtab>" #'crs-collapse-all-sections
+  "a" #'crs-add-annotation-as-comment
   "c" #'crs-add-or-edit-comment
   "d" #'crs-delete-local-comment
   "C-c C-c" #'crs-submit-review
@@ -108,6 +109,7 @@
     (kbd "TAB") #'crs-toggle-section
     (kbd "<tab>") #'crs-toggle-section
     (kbd "<backtab>") #'crs-collapse-all-sections
+    "a" #'crs-add-annotation-as-comment
     "c" #'crs-add-or-edit-comment
     "d" #'crs-delete-local-comment
     (kbd "C-c C-c") #'crs-submit-review
@@ -135,6 +137,7 @@
     (kbd "TAB") #'crs-toggle-section
     (kbd "<tab>") #'crs-toggle-section
     (kbd "<backtab>") #'crs-collapse-all-sections
+    "a" #'crs-add-annotation-as-comment
     "c" #'crs-add-or-edit-comment
     "d" #'crs-delete-local-comment
     (kbd "C-c C-c") #'crs-submit-review

--- a/client.el/crs-comments.el
+++ b/client.el/crs-comments.el
@@ -15,6 +15,7 @@
 (declare-function crs--render-and-update "crs-render")
 (declare-function crs--review-buffer-name "crs-review")
 (declare-function crs--diff-line-marker "crs-render")
+(declare-function crs--annotations-on-current-line "crs-render")
 
 (defun crs-submit-comment ()
   "Submit the comment in the current buffer."
@@ -292,6 +293,103 @@ If called interactively, attempts to guess parameters from context."
 
 ;; Alias for backwards compatibility
 (defalias 'crs-add-comment 'crs-add-or-edit-comment)
+
+;;; Plugin annotations as local comments
+;;
+;; A plugin annotation is client-side only: it is redrawn from the GetPR reply
+;; on every render and never becomes review feedback.  Promoting one to a local
+;; comment turns it into feedback `crs-submit-review' will post, anchored to the
+;; diff position the annotation is already drawn on.
+
+(defun crs--annotation-comment-body (annotation)
+  "Format ANNOTATION as the body of a local comment."
+  (format "Automated comment by %s\n\n%s"
+          (or (cdr (assq 'plugin annotation)) "plugin")
+          (or (cdr (assq 'content annotation)) "")))
+
+(defun crs--annotation-choice-label (index annotation)
+  "Label ANNOTATION as choice INDEX (0-based) for `completing-read'.
+The number keeps labels distinct when one line carries two annotations
+that open with the same text."
+  (let* ((plugin (or (cdr (assq 'plugin annotation)) "plugin"))
+         (severity (or (cdr (assq 'severity annotation)) ""))
+         (content (or (cdr (assq 'content annotation)) ""))
+         (first-line (car (split-string content "\n"))))
+    (format "%d. [%s%s] %s"
+            (1+ index)
+            plugin
+            (if (string-empty-p severity) "" (concat "/" severity))
+            (if (> (length first-line) 60)
+                (concat (substring first-line 0 57) "...")
+              first-line))))
+
+(defun crs--select-annotation (annotations)
+  "Return the one annotation of ANNOTATIONS to turn into a comment.
+Prompts when the line carries more than one."
+  (if (= (length annotations) 1)
+      (car annotations)
+    (let ((choices nil)
+          (index 0))
+      (dolist (annotation annotations)
+        (push (cons (crs--annotation-choice-label index annotation) annotation) choices)
+        (setq index (1+ index)))
+      (setq choices (nreverse choices))
+      (cdr (assoc (completing-read "Annotation to add as a comment: "
+                                   (mapcar #'car choices) nil t)
+                  choices)))))
+
+(defun crs-add-annotation-as-comment ()
+  "Add the plugin annotation at point as a local comment on the same line.
+Point can be on a collapsed <A: plugin> indicator or anywhere inside an
+expanded annotation block; when the line carries several annotations, this
+prompts for which one to add.  The comment is created directly, without
+opening a comment buffer, with the body
+
+  Automated comment by PLUGIN
+
+  ANNOTATION CONTENT"
+  (interactive)
+  (let ((annotations (crs--annotations-on-current-line)))
+    (unless annotations
+      (user-error "No plugin annotation on this line"))
+    (let* ((ctx (crs--get-comment-context))
+           (owner (nth 0 ctx))
+           (repo (nth 1 ctx))
+           (number (nth 2 ctx))
+           (filename (nth 3 ctx))
+           (position (nth 4 ctx))
+           (file-line (nth 8 ctx)))
+      (unless (and owner repo number filename)
+        (user-error "Could not determine the review context for this line"))
+      ;; Position 0 means the annotation hangs off a hunk header because the
+      ;; line it names is not shown in the diff.  GitHub has no such position,
+      ;; and a comment left there would not render back onto any line.
+      (unless (and (integerp position) (> position 0))
+        (user-error "Annotation is not anchored to a line of the diff"))
+      (let* ((annotation (crs--select-annotation annotations))
+             (plugin (or (cdr (assq 'plugin annotation)) "plugin"))
+             (body (crs--annotation-comment-body annotation))
+             (original-line (line-number-at-pos))
+             (original-context (list filename position file-line)))
+        (crs--send-request
+         "RPCHandler.AddComment"
+         (vector (list (cons 'Owner owner)
+                       (cons 'Repo repo)
+                       (cons 'Number number)
+                       (cons 'Filename filename)
+                       (cons 'Position position)
+                       (cons 'ReplyToID nil)
+                       (cons 'Body body)))
+         (lambda (result)
+           (let ((err (cdr (assq 'error result))))
+             (if err
+                 (message "Error adding comment: %s"
+                          (if (stringp err) err (cdr (assq 'message err))))
+               (let ((review-buffer (get-buffer (crs--review-buffer-name owner repo number))))
+                 (when review-buffer
+                   (crs--render-and-update review-buffer result original-line original-context))
+                 (message "Added %s annotation as a local comment on %s:%d"
+                          plugin filename position))))))))))
 
 (defun crs--get-local-comment-at-point ()
   "Get the local comment ID at point, or nil if not on a local comment.

--- a/client.el/crs-render.el
+++ b/client.el/crs-render.el
@@ -311,11 +311,13 @@ instead; annotations for files not in the diff are dropped (they remain
 visible in the plugin output buffers).
 
 SHOW-FULL non-nil inserts full annotation blocks beneath each annotated
-line; otherwise a compact <A: plugin> indicator is appended to the line,
-carrying the annotation list in a `crs-annotations' text property so the
-echo-area preview can find it.  Must run after `delta-wash' and after
-`crs--insert-comments-into-buffer' so line positions are final and the
-washer's painting is untouched."
+line; otherwise a compact <A: plugin> indicator is appended to the line.
+Either way the annotation list is stored in a `crs-annotations' text
+property — on the indicator when collapsed, and on both the block and its
+anchor line when expanded — so the echo-area preview and
+`crs-add-annotation-as-comment' can find it from either spot.  Must run
+after `delta-wash' and after `crs--insert-comments-into-buffer' so line
+positions are final and the washer's painting is untouched."
   (when (> (length (or annotations [])) 0)
     (let ((annotation-map (crs--index-annotations annotations))
           (anchored (make-hash-table :test 'equal))
@@ -367,8 +369,10 @@ washer's painting is untouched."
                     (puthash key t anchored)
                     (push (cons line-end
                                 (if show-full
-                                    (concat "\n" (string-trim-right
-                                                  (crs--render-annotation-block line-annotations)))
+                                    (list 'block
+                                          (concat "\n" (string-trim-right
+                                                        (crs--render-annotation-block line-annotations)))
+                                          line-annotations line-start line-end)
                                   (list 'indicator line-annotations)))
                           insertions)))
                 (setq head-line (1+ head-line))))))
@@ -393,28 +397,45 @@ washer's painting is untouched."
                                     (or (cdr (assq 'line b)) 0)))))
                  (hunk-pos (gethash file first-hunks)))
              (push (if show-full
-                       (cons (car hunk-pos) (crs--render-annotation-block sorted t))
+                       (cons (car hunk-pos)
+                             (list 'block (crs--render-annotation-block sorted t)
+                                   sorted (car hunk-pos) (cdr hunk-pos)))
                      (cons (cdr hunk-pos) (list 'indicator sorted)))
                    insertions)))
          leftovers))
 
-      ;; Execute insertions (sorted by point descending).  Indicators are
-      ;; inserted at line end without touching the line itself, so text
-      ;; properties applied by the washer survive.
+      ;; Execute insertions (sorted by point descending).  Nothing rewrites an
+      ;; existing line: indicators are inserted at line end and blocks around
+      ;; it, so text properties applied by the washer survive.  The only
+      ;; property added to a diff line is `crs-annotations', which marks the
+      ;; anchor of an expanded block.
       (setq insertions (sort insertions (lambda (a b) (> (car a) (car b)))))
       (save-excursion
         (dolist (ins insertions)
           (goto-char (car ins))
           (let ((content (cdr ins)))
-            (if (and (listp content) (eq (car content) 'indicator))
-                (let* ((line-annotations (cadr content))
-                       (indicator (propertize
-                                   (crs--format-compact-annotation-indicator line-annotations)
-                                   'crs-annotations line-annotations))
-                       (line-length (- (point) (line-beginning-position)))
-                       (padding (max (- 120 line-length) 1)))
-                  (insert (make-string padding ?\s) indicator))
-              (insert content))))))))
+            (cond
+             ((eq (car content) 'indicator)
+              (let* ((line-annotations (nth 1 content))
+                     (indicator (propertize
+                                 (crs--format-compact-annotation-indicator line-annotations)
+                                 'crs-annotations line-annotations))
+                     (line-length (- (point) (line-beginning-position)))
+                     (padding (max (- 120 line-length) 1)))
+                (insert (make-string padding ?\s) indicator)))
+             ((eq (car content) 'block)
+              (let* ((text (nth 1 content))
+                     (line-annotations (nth 2 content))
+                     (anchor-beg (nth 3 content))
+                     (anchor-end (nth 4 content))
+                     (start (point)))
+                (insert (propertize text 'crs-annotations line-annotations))
+                ;; A block anchored to a diff line is inserted after it, so the
+                ;; line keeps its positions; an unanchored block is inserted
+                ;; above its hunk header, which shifts by the block's length.
+                (let ((shift (if (>= anchor-beg start) (- (point) start) 0)))
+                  (put-text-property (+ anchor-beg shift) (+ anchor-end shift)
+                                     'crs-annotations line-annotations)))))))))))
 
 (defun crs--annotations-on-current-line ()
   "Return the plugin annotations attached to the current line, or nil.

--- a/client.el/crs-tests.el
+++ b/client.el/crs-tests.el
@@ -36,7 +36,7 @@
                 crs-submit-review crs-approve-review crs-comment-review
                 crs-request-changes-review crs-set-review-feedback
                 crs-expand-hunk-before crs-expand-hunk-after
-                crs-toggle-annotations
+                crs-toggle-annotations crs-add-annotation-as-comment
                 crs-sync-pr crs-checkout-current-project
                 crs-get-plugin-output crs-rerun-plugin crs-run-on-demand-plugin
                 crs-get-rate-limit-status))
@@ -55,6 +55,8 @@
                 crs--format-compact-annotation-indicator
                 crs--annotations-on-current-line
                 crs--annotations-minibuffer-summary
+                crs--annotation-comment-body crs--annotation-choice-label
+                crs--select-annotation
                 crs--insert-plugin-output-entry))
     (should (fboundp fn))))
 
@@ -229,6 +231,117 @@ line the diff does not show, and one for a file outside the diff.")
                   '(((plugin . "Sec") (severity . "warning")
                      (content . "bad line\nsecond line"))))
                  "1 annotation: [Sec/warning]: bad line")))
+
+(ert-deftest crs-test-expanded-annotations-are-findable-at-point ()
+  "An expanded block and the line it annotates both carry the annotations."
+  (with-temp-buffer
+    (insert crs-test--annotation-diff)
+    (crs--insert-annotations-into-buffer crs-test--annotations t)
+    ;; The annotated diff line itself...
+    (goto-char (point-min))
+    (search-forward "+line two")
+    (should (equal (cdr (assq 'content (car (crs--annotations-on-current-line))))
+                   "this line looks wrong"))
+    ;; ...and the block rendered beneath it.
+    (forward-line 2)
+    (should (string-match-p "Security Check"
+                            (buffer-substring-no-properties
+                             (line-beginning-position) (line-end-position))))
+    (should (equal (cdr (assq 'content (car (crs--annotations-on-current-line))))
+                   "this line looks wrong"))
+    ;; The unanchored block hangs above its hunk header, which is marked too.
+    (goto-char (point-min))
+    (search-forward "@@ -1,3 +1,4 @@")
+    (should (equal (cdr (assq 'content (car (crs--annotations-on-current-line))))
+                   "outside the hunk"))))
+
+;;; --- Annotations promoted to local comments ---
+
+(defconst crs-test--washed-annotation-diff
+  (concat "modified test.py\n"
+          "@@ -1,3 +1,4 @@\n"
+          " line one\n"
+          "+line two\n"
+          " line three\n"
+          " line four\n")
+  "`crs-test--annotation-diff' after `crs--simplify-diff-headers'.
+This is the shape a review buffer holds, and the one the comment-context
+parser reads file names from.")
+
+(ert-deftest crs-test-annotation-comment-body ()
+  "The comment body names the plugin, then carries the annotation content."
+  (should (equal (crs--annotation-comment-body
+                  '((plugin . "Security Check") (content . "this line looks wrong")))
+                 "Automated comment by Security Check\n\nthis line looks wrong"))
+  ;; An annotation carrying no plugin name still yields a well-formed body.
+  (should (equal (crs--annotation-comment-body '((content . "hm")))
+                 "Automated comment by plugin\n\nhm")))
+
+(ert-deftest crs-test-select-annotation ()
+  "A lone annotation is taken directly; several are chosen by numbered label."
+  (let ((only '((plugin . "Sec") (content . "x"))))
+    (should (eq (crs--select-annotation (list only)) only)))
+  (should (equal (crs--annotation-choice-label
+                  0 '((plugin . "Sec") (severity . "warning") (content . "bad\nmore")))
+                 "1. [Sec/warning] bad"))
+  (should (equal (crs--annotation-choice-label 1 '((plugin . "Sec") (content . "bad")))
+                 "2. [Sec] bad"))
+  (let* ((a '((plugin . "A") (content . "first")))
+         (b '((plugin . "B") (content . "second")))
+         (offered nil))
+    (cl-letf (((symbol-function 'completing-read)
+               (lambda (_prompt choices &rest _)
+                 (setq offered choices)
+                 (nth 1 choices))))
+      (should (equal (crs--select-annotation (list a b)) b))
+      (should (equal offered '("1. [A] first" "2. [B] second"))))))
+
+(ert-deftest crs-test-add-annotation-as-comment ()
+  "The annotation at point is sent as a local comment at the same position."
+  (with-temp-buffer
+    (insert crs-test--washed-annotation-diff)
+    (crs--insert-annotations-into-buffer crs-test--annotations nil)
+    (goto-char (point-min))
+    (search-forward "+line two")
+    (let ((sent nil))
+      (cl-letf (((symbol-function 'crs--get-current-review-info)
+                 (lambda () (list "C-Hipple" "code-review-server" 83)))
+                ((symbol-function 'crs--send-request)
+                 (lambda (method params &optional _callback)
+                   (setq sent (list method params)))))
+        (crs-add-annotation-as-comment))
+      (should sent)
+      (should (equal (nth 0 sent) "RPCHandler.AddComment"))
+      (let ((args (aref (nth 1 sent) 0)))
+        (should (equal (cdr (assq 'Owner args)) "C-Hipple"))
+        (should (equal (cdr (assq 'Repo args)) "code-review-server"))
+        (should (equal (cdr (assq 'Number args)) 83))
+        (should (equal (cdr (assq 'Filename args)) "test.py"))
+        ;; " line one" is diff position 1, so the annotated "+line two" is 2.
+        (should (equal (cdr (assq 'Position args)) 2))
+        (should-not (cdr (assq 'ReplyToID args)))
+        (should (equal (cdr (assq 'Body args))
+                       "Automated comment by Security Check\n\nthis line looks wrong"))))))
+
+(ert-deftest crs-test-add-annotation-as-comment-needs-an-anchored-annotation ()
+  "Lines with no annotation, and unanchored annotations, send nothing."
+  (with-temp-buffer
+    (insert crs-test--washed-annotation-diff)
+    (crs--insert-annotations-into-buffer crs-test--annotations nil)
+    (cl-letf (((symbol-function 'crs--get-current-review-info)
+               (lambda () (list "C-Hipple" "code-review-server" 83)))
+              ((symbol-function 'crs--send-request)
+               (lambda (&rest _) (ert-fail "should not send a request"))))
+      ;; A plain diff line carries no annotation.
+      (goto-char (point-min))
+      (search-forward "line three")
+      (should-error (crs-add-annotation-as-comment) :type 'user-error)
+      ;; The out-of-hunk annotation sits on a hunk header, which has no diff
+      ;; position for a comment to anchor to.
+      (goto-char (point-min))
+      (search-forward "@@ -1,3 +1,4 @@")
+      (should (crs--annotations-on-current-line))
+      (should-error (crs-add-annotation-as-comment) :type 'user-error))))
 
 (ert-deftest crs-test-insert-plugin-output-entry ()
   "Plugin output entries prefer the parsed body and list annotations sorted."

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -169,6 +169,16 @@ Annotations also render inline in the review buffer's diff, from the `annotation
 
 As in the web client, an annotation anchors to the line matching its `line` on the PR's head side, landing on an added or unchanged line of the diff. Annotations the diff can't show a row for attach to their file's first hunk header, labelled with the line they point at. Annotations naming a file that isn't in the diff at all appear only in the plugin output buffers.
 
+An annotation can also be promoted to review feedback. With the cursor on an annotated line — on the collapsed `<A: plugin>` indicator, or anywhere inside an expanded annotation block — `a` (`crs-add-annotation-as-comment`) files that annotation as a local comment at the same diff position, without opening a comment buffer. The body is:
+
+```
+Automated comment by <plugin name>
+
+<annotation content>
+```
+
+A line carrying several annotations prompts for which one to file. Annotations that collapsed onto a file's hunk header are refused: the line they name is not in the diff, so there is no position for a comment to anchor to. The comment is an ordinary local comment from there on — editable with `c`, deletable with `d`, and posted by `crs-submit-review` like any other.
+
 ## On-Demand Plugins
 
 By default, all configured plugins automatically run when a PR is fetched or when its commit changes (once per SHA). However, some plugins can be expensive to run (e.g., those making API calls to third-party services like Gemini or Claude).


### PR DESCRIPTION
## Summary

Adds a new command `crs-add-annotation-as-comment` that allows users to promote plugin annotations directly to local comments in the review buffer. This enables annotations from automated checks to become part of the review feedback without manually copying their content.

### Changes

- **New command `crs-add-annotation-as-comment`** (`crs-comments.el`): Converts a plugin annotation at point into a local comment at the same diff position. When a line carries multiple annotations, prompts the user to select which one to file. The comment body is formatted as:
  ```
  Automated comment by <plugin name>
  
  <annotation content>
  ```

- **Helper functions** (`crs-comments.el`):
  - `crs--annotation-comment-body`: Formats an annotation as a comment body
  - `crs--annotation-choice-label`: Generates numbered choice labels for `completing-read` when selecting among multiple annotations
  - `crs--select-annotation`: Handles single vs. multiple annotation selection

- **Enhanced annotation rendering** (`crs-render.el`): Modified `crs--insert-annotations-into-buffer` to attach `crs-annotations` text properties to both expanded annotation blocks and their anchor lines, enabling `crs--annotations-on-current-line` to find annotations from either location (collapsed indicator or expanded block).

- **Keybinding** (`crs-client.el`): Bound `a` to `crs-add-annotation-as-comment` in both the review buffer and diff view.

- **Documentation** (`docs/plugins.md`): Added section explaining the new feature, including usage and limitations (e.g., annotations on hunk headers cannot be filed as comments since they lack a diff position).

- **Comprehensive test coverage** (`crs-tests.el`): Added tests for annotation selection, comment body formatting, and the full workflow including error cases (unannotated lines, unanchored annotations).

## Test Plan

- [x] Added unit tests covering annotation selection, comment body formatting, and the full `crs-add-annotation-as-comment` workflow
- [x] Tests verify error handling for lines without annotations and unanchored annotations
- [x] Existing tests pass; new tests validate the feature end-to-end

https://claude.ai/code/session_01JquPxXQxasJD7ixaZt4vwT