### PR TITLE
Show each PR's required teams, color-coded, on the review list

### DIFF
--- a/bun_client/frontend/src/App.css
+++ b/bun_client/frontend/src/App.css
@@ -420,6 +420,42 @@ details[open] > summary.crs-sidebar-label::after {
     font-variant-numeric: tabular-nums;
 }
 
+/* Required teams. The chip's color carries the review's status (green
+   approved, red changes requested, amber still waiting on one of your teams,
+   grey waiting on somebody else's); the weight and the italic carry the
+   relationship, so the requests that are yours read first at a glance. */
+.crs-row-teams {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    min-width: 0;
+}
+
+.crs-row-team {
+    padding: 0 6px;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-size: 11px;
+    line-height: 16px;
+    max-width: 18ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.crs-row-team--mine,
+.crs-row-team--personal {
+    font-weight: 600;
+}
+
+.crs-row-team--personal {
+    font-style: italic;
+}
+
+.crs-row-team--theirs {
+    opacity: 0.75;
+}
+
 /* Row actions stay out of the way until the row is hovered or tabbed into.
    `pointer-events: none` while hidden so an invisible button can't swallow a
    click meant for the row; keyboard focus still reveals them. */

--- a/bun_client/frontend/src/components/PRList.tsx
+++ b/bun_client/frontend/src/components/PRList.tsx
@@ -24,6 +24,7 @@ import {
     uniqueValues,
 } from '../pr_list_utils';
 import type { Facet, PRState, ReviewItem } from '../pr_list_utils';
+import { teamChips } from '../team_utils';
 
 interface PRListProps {
     onOpenReview: (owner: string, repo: string, number: number) => void;
@@ -682,6 +683,7 @@ function PRRow({ item, reviewLocation, onOpenReview, onOpenPluginOutput }: PRRow
     const ease = mapReviewEase(item.review_ease);
     const easeTone = ease ? getStatusTone(ease.variant) : null;
     const relative = formatRelativeTime(item.created_at);
+    const teams = teamChips(item.required_teams);
     // Rows open wherever the preference points; the action buttons cover the
     // other destination so both are always one click away.
     const rowOpensGitHub = reviewLocation === 'github';
@@ -749,6 +751,27 @@ function PRRow({ item, reviewLocation, onOpenReview, onOpenPluginOutput }: PRRow
                                 {relative && (
                                     <span title={formatAbsoluteTime(item.created_at)}>
                                         {relative}
+                                    </span>
+                                )}
+                                {teams.length > 0 && (
+                                    <span className="crs-row-teams">
+                                        {teams.map(team => {
+                                            const tone = getStatusTone(team.variant);
+                                            return (
+                                                <span
+                                                    key={team.key}
+                                                    className={`crs-row-team crs-row-team--${team.relationship}`}
+                                                    style={{
+                                                        color: tone.fg,
+                                                        background: tone.bg,
+                                                        borderColor: tone.border,
+                                                    }}
+                                                    title={team.title}
+                                                >
+                                                    {team.label}
+                                                </span>
+                                            );
+                                        })}
                                     </span>
                                 )}
                             </>

--- a/bun_client/frontend/src/pr_list_utils.test.ts
+++ b/bun_client/frontend/src/pr_list_utils.test.ts
@@ -28,6 +28,30 @@ function item(overrides: Partial<ReviewItem> = {}): ReviewItem {
     };
 }
 
+describe('itemMatchesQuery with required teams', () => {
+    const withTeams = item({
+        required_teams: [
+            {
+                name: 'Platform Eng',
+                slug: 'platform-eng',
+                org: 'acme',
+                status: 'pending',
+                mine: true,
+                personal: false,
+            },
+        ],
+    });
+
+    test('matches a required team by name or slug', () => {
+        expect(itemMatchesQuery(withTeams, 'platform eng')).toBe(true);
+        expect(itemMatchesQuery(withTeams, 'platform-eng')).toBe(true);
+    });
+
+    test('still rejects what no field carries', () => {
+        expect(itemMatchesQuery(withTeams, 'security')).toBe(false);
+    });
+});
+
 describe('parseTags', () => {
     test('splits and normalizes the comma-joined tag string', () => {
         expect(parseTags('code-review-server, Merged ')).toEqual(['code-review-server', 'merged']);

--- a/bun_client/frontend/src/pr_list_utils.ts
+++ b/bun_client/frontend/src/pr_list_utils.ts
@@ -8,6 +8,8 @@
  * derivations can be unit tested without rendering.
  */
 
+import { teamSearchTerms, type RequiredTeam } from './team_utils';
+
 /** Matches the ReviewItem struct from the Go backend. */
 export interface ReviewItem {
     section: string;
@@ -24,6 +26,11 @@ export interface ReviewItem {
     review_ease?: string;
     /** RFC3339 time the item was first recorded by a workflow. */
     created_at?: string;
+    /**
+     * Teams this PR needs a review from, each with its status and its relation
+     * to the current user. Absent until a workflow cycle has resolved them.
+     */
+    required_teams?: RequiredTeam[];
 }
 
 /** The lifecycle states the sidebar buckets PRs into. */
@@ -121,14 +128,20 @@ export function formatAbsoluteTime(iso: string | undefined): string {
 
 /**
  * Free-text match across the fields shown in a row: title, repo, owner, author,
- * and PR number. A numeric query (with or without a leading `#`) matches the
- * number by prefix, so the list narrows as the number is typed.
+ * required teams, and PR number. A numeric query (with or without a leading
+ * `#`) matches the number by prefix, so the list narrows as the number is typed.
  */
 export function itemMatchesQuery(item: ReviewItem, query: string): boolean {
     const needle = query.trim().toLowerCase();
     if (!needle) return true;
 
-    const fields = [item.title, item.repo, item.owner, item.author];
+    const fields = [
+        item.title,
+        item.repo,
+        item.owner,
+        item.author,
+        ...teamSearchTerms(item.required_teams),
+    ];
     if (fields.some(field => (field || '').toLowerCase().includes(needle))) {
         return true;
     }

--- a/bun_client/frontend/src/team_utils.test.ts
+++ b/bun_client/frontend/src/team_utils.test.ts
@@ -1,0 +1,92 @@
+import { expect, test, describe } from 'bun:test';
+import { teamChips, teamRelationship, teamSearchTerms, teamVariant } from './team_utils';
+import type { RequiredTeam } from './team_utils';
+
+function team(overrides: Partial<RequiredTeam> = {}): RequiredTeam {
+    return {
+        name: 'Platform',
+        slug: 'platform',
+        org: 'acme',
+        status: 'pending',
+        mine: false,
+        personal: false,
+        ...overrides,
+    };
+}
+
+describe('teamRelationship', () => {
+    test('separates a direct request from a team one', () => {
+        expect(teamRelationship(team({ personal: true, mine: true }))).toBe('personal');
+        expect(teamRelationship(team({ mine: true }))).toBe('mine');
+        expect(teamRelationship(team())).toBe('theirs');
+    });
+});
+
+describe('teamVariant', () => {
+    test('a decision colors the same whoever made it', () => {
+        for (const mine of [true, false]) {
+            expect(teamVariant(team({ status: 'approved', mine }))).toBe('success');
+            expect(teamVariant(team({ status: 'changes_requested', mine }))).toBe('danger');
+            expect(teamVariant(team({ status: 'reviewed', mine }))).toBe('info');
+        }
+    });
+
+    test('only a pending review distinguishes your teams from the rest', () => {
+        expect(teamVariant(team({ status: 'pending', mine: true }))).toBe('warning');
+        expect(teamVariant(team({ status: 'pending', personal: true }))).toBe('warning');
+        expect(teamVariant(team({ status: 'pending' }))).toBe('neutral');
+    });
+
+    test('an unrecognized status stays neutral rather than mis-coloring', () => {
+        expect(teamVariant(team({ status: 'something_new', mine: true }))).toBe('neutral');
+    });
+});
+
+describe('teamChips', () => {
+    test('returns nothing when the backend has not resolved teams yet', () => {
+        expect(teamChips(undefined)).toEqual([]);
+        expect(teamChips([])).toEqual([]);
+    });
+
+    test('labels a personal request with the handle', () => {
+        const [chip] = teamChips([
+            team({ name: 'erin', slug: '', org: '', personal: true, mine: true }),
+        ]);
+        expect(chip.label).toBe('@erin');
+        expect(chip.relationship).toBe('personal');
+        expect(chip.title).toBe('Requested from you directly — awaiting review');
+    });
+
+    test('spells out both dimensions in the tooltip', () => {
+        const [mine, theirs] = teamChips([
+            team({ mine: true, status: 'changes_requested' }),
+            team({ name: 'Security', slug: 'security', status: 'approved' }),
+        ]);
+        expect(mine.title).toBe('Platform (your team) — changes requested');
+        expect(theirs.title).toBe('Security — approved');
+    });
+
+    test('preserves the backend order and keys chips by org/slug', () => {
+        const chips = teamChips([
+            team({ name: 'erin', slug: '', org: '', personal: true, mine: true }),
+            team({ name: 'Security', slug: 'security' }),
+            team(),
+        ]);
+        expect(chips.map(c => c.label)).toEqual(['@erin', 'Security', 'Platform']);
+        expect(chips.map(c => c.key)).toEqual(['@erin', 'acme/security', 'acme/platform']);
+    });
+
+    test('drops entries with no name instead of rendering a blank chip', () => {
+        expect(teamChips([team({ name: '' })])).toEqual([]);
+    });
+});
+
+describe('teamSearchTerms', () => {
+    test('offers both the display name and the slug to the filter box', () => {
+        expect(teamSearchTerms([team({ name: 'Platform Eng', slug: 'platform-eng' })])).toEqual([
+            'Platform Eng',
+            'platform-eng',
+        ]);
+        expect(teamSearchTerms(undefined)).toEqual([]);
+    });
+});

--- a/bun_client/frontend/src/team_utils.ts
+++ b/bun_client/frontend/src/team_utils.ts
@@ -1,0 +1,114 @@
+/**
+ * Display rules for the required-team chips on a review row.
+ *
+ * The backend resolves which teams a PR needs a review from — including the
+ * ones GitHub has already cleared, which is why a team that approved is still
+ * listed — and hands each one a status plus whether it is one of the current
+ * user's teams. This module turns that into what a chip actually shows, so the
+ * two dimensions the colors encode (where the review stands, and whether it is
+ * on you) stay in one testable place.
+ */
+
+import type { StatusVariant } from './design';
+
+/** Matches the TeamReviewStatus struct from the Go backend. */
+export interface RequiredTeam {
+    /** Team display name, or the user's own login on a personal request. */
+    name: string;
+    slug: string;
+    org: string;
+    /** "pending" | "approved" | "changes_requested" | "reviewed". */
+    status: string;
+    /** The current user is on this team (always true for a personal request). */
+    mine: boolean;
+    /** GitHub asked the current user directly rather than through a team. */
+    personal: boolean;
+}
+
+/** How a required reviewer relates to the person reading the list. */
+export type TeamRelationship = 'personal' | 'mine' | 'theirs';
+
+export interface TeamChip {
+    key: string;
+    label: string;
+    /** Drives the chip's color through the shared status palette. */
+    variant: StatusVariant;
+    relationship: TeamRelationship;
+    /** Tooltip spelling out both dimensions the color compresses. */
+    title: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+    pending: 'awaiting review',
+    approved: 'approved',
+    changes_requested: 'changes requested',
+    // The backend's fallback: GitHub cleared the request, so somebody reviewed,
+    // but the reviewer could not be tied back to the team (usually a token that
+    // can't read the org's team membership).
+    reviewed: 'reviewed',
+};
+
+export function teamRelationship(team: RequiredTeam): TeamRelationship {
+    if (team.personal) return 'personal';
+    return team.mine ? 'mine' : 'theirs';
+}
+
+/**
+ * The chip's color. Status leads — approved is green and changes-requested is
+ * red no matter whose team it is — and only a still-pending review looks at the
+ * relationship, because "waiting" is worth flagging when it is waiting on you
+ * and is just context when it is waiting on someone else.
+ */
+export function teamVariant(team: RequiredTeam): StatusVariant {
+    switch (team.status) {
+        case 'approved':
+            return 'success';
+        case 'changes_requested':
+            return 'danger';
+        case 'reviewed':
+            return 'info';
+        case 'pending':
+            return team.mine || team.personal ? 'warning' : 'neutral';
+        default:
+            return 'neutral';
+    }
+}
+
+function teamTitle(team: RequiredTeam, relationship: TeamRelationship): string {
+    const status = STATUS_LABELS[team.status] ?? team.status ?? '';
+    if (relationship === 'personal') {
+        return `Requested from you directly — ${status}`;
+    }
+    const who = relationship === 'mine' ? ' (your team)' : '';
+    return `${team.name}${who} — ${status}`;
+}
+
+/**
+ * Build the chips for one row. Entries with no name are dropped rather than
+ * rendered blank, and the backend's order is preserved: it already leads with
+ * the request that is on you.
+ */
+export function teamChips(teams: RequiredTeam[] | undefined): TeamChip[] {
+    return (teams || [])
+        .filter(team => team && team.name)
+        .map(team => {
+            const relationship = teamRelationship(team);
+            return {
+                key: team.personal ? `@${team.name}` : `${team.org}/${team.slug}` || team.name,
+                label: team.personal ? `@${team.name}` : team.name,
+                variant: teamVariant(team),
+                relationship,
+                title: teamTitle(team, relationship),
+            };
+        });
+}
+
+/** Team names on a row, for free-text search over the list. */
+export function teamSearchTerms(teams: RequiredTeam[] | undefined): string[] {
+    const terms: string[] = [];
+    for (const team of teams || []) {
+        if (team.name) terms.push(team.name);
+        if (team.slug) terms.push(team.slug);
+    }
+    return terms;
+}

--- a/database/database.go
+++ b/database/database.go
@@ -169,6 +169,14 @@ func (db *DB) initSchema() error {
 		UNIQUE(pr_number, repo)
 	);
 
+	CREATE TABLE IF NOT EXISTS PRTeamReviews (
+		pr_number INTEGER NOT NULL,
+		repo TEXT NOT NULL,
+		teams_json TEXT NOT NULL,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(pr_number, repo)
+	);
+
 	CREATE TABLE IF NOT EXISTS CIStatus (
 		pr_number INTEGER NOT NULL,
 		repo TEXT NOT NULL,
@@ -262,6 +270,7 @@ func (db *DB) initSchema() error {
 		check_runs INTEGER NOT NULL DEFAULT 0,
 		commits INTEGER NOT NULL DEFAULT 0,
 		review_threads INTEGER NOT NULL DEFAULT 0,
+		team_reviews INTEGER NOT NULL DEFAULT 0,
 		total INTEGER NOT NULL DEFAULT 0
 	);
 	`
@@ -425,6 +434,17 @@ func (db *DB) initSchema() error {
 		_, err = db.conn.Exec("ALTER TABLE APICallStats ADD COLUMN review_threads INTEGER NOT NULL DEFAULT 0")
 		if err != nil {
 			slog.Warn("Error adding review_threads column to APICallStats", "error", err)
+		}
+	}
+
+	// Migration: Add the team_reviews counter to APICallStats. Same story as
+	// review_threads — the review-request history behind the required-team
+	// chips is a GraphQL call spending the same budget.
+	err = db.conn.QueryRow("SELECT COUNT(*) FROM pragma_table_info('APICallStats') WHERE name='team_reviews'").Scan(&count)
+	if err == nil && count == 0 {
+		_, err = db.conn.Exec("ALTER TABLE APICallStats ADD COLUMN team_reviews INTEGER NOT NULL DEFAULT 0")
+		if err != nil {
+			slog.Warn("Error adding team_reviews column to APICallStats", "error", err)
 		}
 	}
 
@@ -1544,6 +1564,47 @@ func (db *DB) DeletePRReviewThreads(prNumber int, repo string) error {
 	return err
 }
 
+// GetPRTeamReviews returns the cached required-team review statuses for a PR as
+// JSON. An empty string means no row: the difference between "this PR has never
+// had its teams resolved" and "this PR has no required teams" (which caches as
+// "[]") is what stops the workflow re-asking GitHub for the request history on
+// every cycle.
+func (db *DB) GetPRTeamReviews(prNumber int, repo string) (string, error) {
+	var teamsJSON string
+	err := db.conn.QueryRow(
+		"SELECT teams_json FROM PRTeamReviews WHERE pr_number = ? AND repo = ?",
+		prNumber, repo,
+	).Scan(&teamsJSON)
+
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return teamsJSON, nil
+}
+
+func (db *DB) UpsertPRTeamReviews(prNumber int, repo, teamsJSON string) error {
+	_, err := db.conn.Exec(
+		`INSERT INTO PRTeamReviews (pr_number, repo, teams_json, updated_at)
+		 VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(pr_number, repo) DO UPDATE SET
+			teams_json = excluded.teams_json,
+			updated_at = CURRENT_TIMESTAMP`,
+		prNumber, repo, teamsJSON,
+	)
+	return err
+}
+
+func (db *DB) DeletePRTeamReviews(prNumber int, repo string) error {
+	_, err := db.conn.Exec(
+		"DELETE FROM PRTeamReviews WHERE pr_number = ? AND repo = ?",
+		prNumber, repo,
+	)
+	return err
+}
+
 func (db *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
 	return db.conn.Exec(query, args...)
 }
@@ -1558,13 +1619,13 @@ func (db *DB) QueryRow(query string, args ...interface{}) *sql.Row {
 
 // LogAPICallStats persists per-type GitHub API call counts and post-cycle rate limit
 // status for a completed workflow cycle.
-func (db *DB) LogAPICallStats(prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits, reviewThreads int64, rateLimitRemaining, rateLimitLimit int, rateLimitResetAt string) error {
-	total := prList + prSpecific + comments + issueComments + ciStatus + diff + reviews + combinedStatus + checkRuns + commits + reviewThreads
+func (db *DB) LogAPICallStats(prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits, reviewThreads, teamReviews int64, rateLimitRemaining, rateLimitLimit int, rateLimitResetAt string) error {
+	total := prList + prSpecific + comments + issueComments + ciStatus + diff + reviews + combinedStatus + checkRuns + commits + reviewThreads + teamReviews
 	_, err := db.conn.Exec(
 		`INSERT INTO APICallStats
-			(pr_list, pr_specific, comments, issue_comments, ci_status, diff, reviews, combined_status, check_runs, commits, review_threads, total, rate_limit_remaining, rate_limit_limit, rate_limit_reset_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits, reviewThreads, total,
+			(pr_list, pr_specific, comments, issue_comments, ci_status, diff, reviews, combined_status, check_runs, commits, review_threads, team_reviews, total, rate_limit_remaining, rate_limit_limit, rate_limit_reset_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		prList, prSpecific, comments, issueComments, ciStatus, diff, reviews, combinedStatus, checkRuns, commits, reviewThreads, teamReviews, total,
 		rateLimitRemaining, rateLimitLimit, rateLimitResetAt,
 	)
 	return err

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -73,6 +73,27 @@ Fetches all review sections from the local database, rendered as org-mode format
 | `release_status`   | string | Release status from the configured release check command, if any  |
 | `review_ease`      | string | LLM rating of how easy the PR is to review: `easy`, `medium`, or `hard`. Empty unless `ExperimentalLLMReviewEase` is enabled in the config and a rating has been computed |
 | `created_at`       | Time   | PR creation timestamp                                             |
+| `required_teams`   | []TeamReviewStatus | Teams asked to review the PR, with each one's standing. Empty until a workflow cycle has resolved them |
+
+#### TeamReviewStatus Object
+
+The teams a PR needs a review from, resolved by the workflow layer and served
+from its cache — `GetAllReviews` never calls GitHub for it. The list is a
+high-water mark: GitHub drops a team from a PR's requested teams as soon as one
+of its members reviews, so a team that has already approved stays listed here
+with `approved` rather than disappearing.
+
+| Field      | Type   | Description                                                            |
+|------------|--------|------------------------------------------------------------------------|
+| `name`     | string | Team display name, or the user's own login when `personal` is true      |
+| `slug`     | string | Team slug (empty for a personal request)                                |
+| `org`      | string | Organization that owns the team (empty for a personal request)          |
+| `status`   | string | `pending` (nobody has reviewed), `approved`, `changes_requested`, or `reviewed` — the last meaning GitHub cleared the request but the reviewer could not be tied to the team, typically because the token cannot read the org's team membership |
+| `mine`     | bool   | The current user is on this team; always true for a personal request    |
+| `personal` | bool   | GitHub asked the current user directly rather than through a team       |
+
+Entries are ordered with the personal request first, then the user's own teams,
+then the rest alphabetically.
 
 ---
 

--- a/docs/web_client_features.md
+++ b/docs/web_client_features.md
@@ -144,15 +144,23 @@ Laid out as a fixed sidebar of filters beside a dense, full-width list of rows.
   with its own count, plus a global collapse/expand toggle in the toolbar.
 - **Per-item row** — lifecycle pill (open / draft / merged / closed, in a fixed-width
   column so titles align), title, `review_ease` pill when the LLM rating is enabled,
-  and a meta line of repo, `#number`, author login, and a relative timestamp from
-  `created_at` (full timestamp on hover).
+  and a meta line of repo, `#number`, author login, a relative timestamp from
+  `created_at` (full timestamp on hover), and the required-team chips.
+- **Required-team chips** — one per entry in `required_teams`, showing who still owes
+  this PR a review. The color is the team's status: green approved, red changes
+  requested, blue reviewed-but-unattributable, amber still waiting when it is one of
+  your teams, grey when it is somebody else's. The weight and the italic carry the
+  relationship — your teams are bold, a request made of you directly is bold italic
+  and labelled `@login`, other teams are dimmed — and the tooltip spells out both.
+  Chips appear once a workflow cycle has resolved the PR's teams.
 - **Non-PR items** — items with `number <= 0` render as "Non-PR item" and are not
   clickable.
 - **Actions per row** — revealed on hover or keyboard focus: Plugins (open the plugin
   view) plus whichever of Review / GitHub the row click doesn't already go to, which
   depends on the Preferred Review Location preference.
-- **Text filter** — matches title, repo, owner, author, and PR number (with or
-  without a leading `#`, by prefix). A "N of M" counter sits beside it.
+- **Text filter** — matches title, repo, owner, author, required-team name or slug,
+  and PR number (with or without a leading `#`, by prefix). A "N of M" counter sits
+  beside it.
 - **GitHub URL paste** — pasting `https://github.com/{owner}/{repo}/pull/{n}` into the
   filter box opens that review directly instead of filtering.
 - **Repo / author narrowing** — a checkable list per field, each value shown with its

--- a/git_tools/graphql.go
+++ b/git_tools/graphql.go
@@ -1,0 +1,84 @@
+package git_tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Shared plumbing for the handful of GitHub GraphQL calls this package makes.
+// Everything else goes through go-github's REST client; GraphQL is reserved for
+// the questions REST cannot answer — review-thread resolution state
+// (review_threads.go) and the full review-request history (team_reviews.go).
+
+// GraphQLEndpoint is the GitHub GraphQL URL. Overridable in tests.
+var GraphQLEndpoint = "https://api.github.com/graphql"
+
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+type graphQLError struct {
+	Message string `json:"message"`
+}
+
+// runGraphQL posts one query and unmarshals the response into out. A GraphQL
+// `errors` array is returned as an error even though the HTTP status is 200,
+// because a partially-resolved response is not something callers can use.
+func runGraphQL(ctx context.Context, query string, variables map[string]any, out any) error {
+	// trackBudget=false: GraphQL is metered separately from REST, so its
+	// X-RateLimit-* headers must not overwrite the REST budget reading.
+	httpClient, err := newAuthedHTTPClient(false)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, GraphQLEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("github graphql returned %d: %s", resp.StatusCode, truncate(string(respBody), 200))
+	}
+
+	var envelope struct {
+		Errors []graphQLError `json:"errors"`
+	}
+	if err := json.Unmarshal(respBody, &envelope); err == nil && len(envelope.Errors) > 0 {
+		msgs := make([]string, 0, len(envelope.Errors))
+		for _, e := range envelope.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		return fmt.Errorf("github graphql error: %s", strings.Join(msgs, "; "))
+	}
+
+	return json.Unmarshal(respBody, out)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/git_tools/review_threads.go
+++ b/git_tools/review_threads.go
@@ -1,23 +1,14 @@
 package git_tools
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
-	"strings"
 	"time"
 )
 
 // GitHub's REST API does not report whether a review-comment thread has been
 // resolved — that lives only in GraphQL's `reviewThreads` connection. This file
 // fetches it so clients can show "resolved" alongside "outdated".
-
-// GraphQLEndpoint is the GitHub GraphQL URL. Overridable in tests.
-var GraphQLEndpoint = "https://api.github.com/graphql"
 
 // ReviewThread is the resolution state of one review-comment thread, keyed back
 // to REST by the database IDs of the comments it contains.
@@ -60,15 +51,6 @@ const reviewThreadsQuery = `query($owner:String!, $repo:String!, $number:Int!, $
   }
 }`
 
-type graphQLRequest struct {
-	Query     string         `json:"query"`
-	Variables map[string]any `json:"variables"`
-}
-
-type graphQLError struct {
-	Message string `json:"message"`
-}
-
 type reviewThreadsResponse struct {
 	Data struct {
 		Repository struct {
@@ -96,20 +78,12 @@ type reviewThreadsResponse struct {
 			} `json:"pullRequest"`
 		} `json:"repository"`
 	} `json:"data"`
-	Errors []graphQLError `json:"errors"`
 }
 
 // GetReviewThreads returns the resolution state of every review thread on a PR.
 // Errors are returned rather than swallowed; callers treat a failure as "no
 // resolution info available" and still render the PR.
 func GetReviewThreads(owner, repo string, number int) ([]ReviewThread, error) {
-	// trackBudget=false: GraphQL is metered separately from REST, so its
-	// X-RateLimit-* headers must not overwrite the REST budget reading.
-	httpClient, err := newAuthedHTTPClient(false)
-	if err != nil {
-		return nil, err
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -117,48 +91,15 @@ func GetReviewThreads(owner, repo string, number int) ([]ReviewThread, error) {
 	var after *string
 	// Bound the paging so a malformed cursor response can't spin forever.
 	for page := 0; page < 20; page++ {
-		body, err := json.Marshal(graphQLRequest{
-			Query: reviewThreadsQuery,
-			Variables: map[string]any{
-				"owner":  owner,
-				"repo":   repo,
-				"number": number,
-				"after":  after,
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, GraphQLEndpoint, bytes.NewReader(body))
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("github graphql returned %d: %s", resp.StatusCode, truncate(string(respBody), 200))
-		}
-
 		var parsed reviewThreadsResponse
-		if err := json.Unmarshal(respBody, &parsed); err != nil {
+		err := runGraphQL(ctx, reviewThreadsQuery, map[string]any{
+			"owner":  owner,
+			"repo":   repo,
+			"number": number,
+			"after":  after,
+		}, &parsed)
+		if err != nil {
 			return nil, err
-		}
-		if len(parsed.Errors) > 0 {
-			msgs := make([]string, 0, len(parsed.Errors))
-			for _, e := range parsed.Errors {
-				msgs = append(msgs, e.Message)
-			}
-			return nil, fmt.Errorf("github graphql error: %s", strings.Join(msgs, "; "))
 		}
 
 		conn := parsed.Data.Repository.PullRequest.ReviewThreads
@@ -189,11 +130,4 @@ func GetReviewThreads(owner, repo string, number int) ([]ReviewThread, error) {
 
 	slog.Warn("Stopped paging review threads at the page cap", "owner", owner, "repo", repo, "pr", number)
 	return threads, nil
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "..."
 }

--- a/git_tools/team_reviews.go
+++ b/git_tools/team_reviews.go
@@ -1,0 +1,416 @@
+package git_tools
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// Which teams a PR needs a review from is a moving target on GitHub: the moment
+// a member of a requested team submits a review, GitHub drops that team from
+// the PR's requested_teams. REST alone therefore only ever answers "which teams
+// are still waiting", which would make an approving team disappear from the
+// review list rather than turn green. The timeline's REVIEW_REQUESTED_EVENTs
+// keep the full history, so this file pairs that history with the PR's reviews
+// to say where each required team actually stands.
+
+const (
+	// teamMembersTTL caches a team's member list. Membership changes on the
+	// scale of weeks, and every PR in a cycle asks about the same handful of
+	// teams, so this keeps the per-cycle cost at roughly one call per team.
+	teamMembersTTL = 30 * time.Minute
+
+	// teamMembersErrTTL caches a failed member lookup briefly. A token without
+	// read:org can't list members at all, and retrying that per PR per cycle
+	// would burn the budget for an answer that isn't coming.
+	teamMembersErrTTL = 5 * time.Minute
+)
+
+// Review status of one required reviewer on a PR.
+const (
+	// TeamReviewPending — nobody from the team has reviewed yet.
+	TeamReviewPending = "pending"
+	// TeamReviewApproved — a member approved and nobody asked for changes.
+	TeamReviewApproved = "approved"
+	// TeamReviewChangesRequested — a member requested changes.
+	TeamReviewChangesRequested = "changes_requested"
+	// TeamReviewReviewed — GitHub has cleared the request (so somebody
+	// reviewed) but we can't attribute it to a member: usually a token that
+	// can't list the team's members, sometimes a member who has since left.
+	TeamReviewReviewed = "reviewed"
+)
+
+// TeamRef identifies one GitHub team.
+type TeamRef struct {
+	// Name is the display name, e.g. "Platform Engineering".
+	Name string `json:"name"`
+	// Slug is the API name, e.g. "platform-engineering".
+	Slug string `json:"slug"`
+	// Org is the login of the organization that owns the team.
+	Org string `json:"org"`
+}
+
+// Key is the "org/slug" form GitHub uses for team references, and the key both
+// the member cache and GetMyTeamRefs are indexed by.
+func (t TeamRef) Key() string {
+	return t.Org + "/" + t.Slug
+}
+
+// TeamReviewStatus is one required reviewer as the review list displays it: a
+// team, or the authenticated user personally, together with where its review
+// stands and how it relates to whoever is looking at the list.
+type TeamReviewStatus struct {
+	// Name is the team's display name, or the user's login for a personal
+	// request (Personal is what tells the two apart).
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+	Org  string `json:"org"`
+	// Status is one of the TeamReview* constants above.
+	Status string `json:"status"`
+	// Mine is true when the authenticated user is on this team (always true
+	// for a personal request), which is what makes a row's chip stand out.
+	Mine bool `json:"mine"`
+	// Personal marks the pseudo-entry for a review GitHub asked the
+	// authenticated user for directly rather than through a team.
+	Personal bool `json:"personal"`
+}
+
+// ReviewRequestHistory is every reviewer a PR has ever been assigned, including
+// the ones GitHub has since cleared because they reviewed.
+type ReviewRequestHistory struct {
+	Teams []TeamRef
+	Users []string
+}
+
+// reviewRequestHistoryQuery pages the PR timeline for review-request events.
+// 100 events per page is GitHub's maximum; PRs rarely have more than a handful.
+const reviewRequestHistoryQuery = `query($owner:String!, $repo:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      timelineItems(first:100, after:$after, itemTypes:[REVIEW_REQUESTED_EVENT]) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          ... on ReviewRequestedEvent {
+            requestedReviewer {
+              __typename
+              ... on User { login }
+              ... on Team { name slug organization { login } }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+type reviewRequestHistoryResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				TimelineItems struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+					Nodes []struct {
+						RequestedReviewer struct {
+							TypeName     string `json:"__typename"`
+							Login        string `json:"login"`
+							Name         string `json:"name"`
+							Slug         string `json:"slug"`
+							Organization struct {
+								Login string `json:"login"`
+							} `json:"organization"`
+						} `json:"requestedReviewer"`
+					} `json:"nodes"`
+				} `json:"timelineItems"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// GetReviewRequestHistory returns every team and user ever asked to review the
+// PR, deduplicated and in the order they were first requested. Errors are
+// returned rather than swallowed; callers fall back to the teams still listed
+// on the PR object, which is a subset of this.
+func GetReviewRequestHistory(owner, repo string, number int) (ReviewRequestHistory, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	history := ReviewRequestHistory{}
+	seenTeams := map[string]bool{}
+	seenUsers := map[string]bool{}
+
+	var after *string
+	// Bound the paging so a malformed cursor response can't spin forever.
+	for page := 0; page < 10; page++ {
+		var parsed reviewRequestHistoryResponse
+		err := runGraphQL(ctx, reviewRequestHistoryQuery, map[string]any{
+			"owner":  owner,
+			"repo":   repo,
+			"number": number,
+			"after":  after,
+		}, &parsed)
+		if err != nil {
+			return ReviewRequestHistory{}, err
+		}
+
+		conn := parsed.Data.Repository.PullRequest.TimelineItems
+		for _, node := range conn.Nodes {
+			reviewer := node.RequestedReviewer
+			switch reviewer.TypeName {
+			case "User":
+				login := strings.ToLower(reviewer.Login)
+				if login == "" || seenUsers[login] {
+					continue
+				}
+				seenUsers[login] = true
+				history.Users = append(history.Users, reviewer.Login)
+			case "Team":
+				if reviewer.Slug == "" {
+					continue
+				}
+				team := TeamRef{
+					Name: reviewer.Name,
+					Slug: reviewer.Slug,
+					Org:  reviewer.Organization.Login,
+				}
+				if team.Org == "" {
+					// The org is only missing on malformed responses; fall back
+					// to the repo's owner, which owns the team in practice.
+					team.Org = owner
+				}
+				if team.Name == "" {
+					team.Name = team.Slug
+				}
+				if seenTeams[team.Key()] {
+					continue
+				}
+				seenTeams[team.Key()] = true
+				history.Teams = append(history.Teams, team)
+			}
+		}
+
+		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == "" {
+			return history, nil
+		}
+		cursor := conn.PageInfo.EndCursor
+		after = &cursor
+	}
+
+	slog.Warn("Stopped paging review request history at the page cap", "owner", owner, "repo", repo, "pr", number)
+	return history, nil
+}
+
+// GetTeamMembers returns the logins of everyone on org/slug, cached (see
+// teamMembersTTL). The second return value reports whether the answer is known:
+// a token without read:org gets (nil, false) rather than an empty team, which
+// is the difference between "nobody is on this team" and "we can't tell".
+func GetTeamMembers(org, slug string) ([]string, bool) {
+	if org == "" || slug == "" || !HasToken() {
+		return nil, false
+	}
+
+	cacheKey := "team_members:" + org + "/" + slug
+	if val, found := GlobalCache.Get(cacheKey); found {
+		members, ok := val.([]string)
+		return members, ok && members != nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	members, err := listAllPages(func(opts *github.ListOptions) ([]*github.User, *github.Response, error) {
+		return GetGithubClient().Teams.ListTeamMembersBySlug(ctx, org, slug,
+			&github.TeamListTeamMembersOptions{ListOptions: *opts})
+	})
+	if err != nil {
+		slog.Warn("Failed to list team members; that team's review status will show as reviewed rather than approved",
+			"org", org, "team", slug, "error", err)
+		// A nil value caches the failure: Get finds it and reports "unknown".
+		GlobalCache.Set(cacheKey, []string(nil), teamMembersErrTTL)
+		return nil, false
+	}
+
+	logins := []string{}
+	for _, member := range members {
+		if login := member.GetLogin(); login != "" {
+			logins = append(logins, login)
+		}
+	}
+	GlobalCache.Set(cacheKey, logins, teamMembersTTL)
+	return logins, true
+}
+
+// GetTeamMembersForTeams resolves the member lists of several teams at once,
+// keyed by TeamRef.Key(). Teams whose membership could not be read are absent
+// from the map rather than present-and-empty, so ResolveTeamReviews can tell
+// "no members" from "not readable".
+func GetTeamMembersForTeams(teams []TeamRef) map[string][]string {
+	members := map[string][]string{}
+	for _, team := range teams {
+		if _, done := members[team.Key()]; done {
+			continue
+		}
+		if logins, known := GetTeamMembers(team.Org, team.Slug); known {
+			members[team.Key()] = logins
+		}
+	}
+	return members
+}
+
+// LatestReviewDecisions maps each reviewer's login to their standing decision:
+// "APPROVED" or "CHANGES_REQUESTED". Reviews that carry no decision (a plain
+// comment) leave an earlier decision in place — that is how GitHub itself
+// treats them — and a dismissal drops it. Logins are lowercased so lookups can
+// ignore the casing GitHub is inconsistent about.
+func LatestReviewDecisions(reviews []*github.PullRequestReview) map[string]string {
+	decisions := map[string]string{}
+	for _, review := range reviews {
+		if review == nil {
+			continue
+		}
+		login := strings.ToLower(review.User.GetLogin())
+		if login == "" {
+			continue
+		}
+		switch strings.ToUpper(review.GetState()) {
+		case "APPROVED":
+			decisions[login] = "APPROVED"
+		case "CHANGES_REQUESTED":
+			decisions[login] = "CHANGES_REQUESTED"
+		case "DISMISSED":
+			delete(decisions, login)
+		}
+	}
+	return decisions
+}
+
+// TeamReviewInput is everything ResolveTeamReviews needs to place each required
+// reviewer. It is deliberately all data — the fetching lives in the workflow
+// layer — so the placement rules can be tested without touching GitHub.
+type TeamReviewInput struct {
+	// Teams is every team ever asked to review, the union of the PR's current
+	// requested_teams and the teams a previous cycle or the timeline recorded.
+	Teams []TeamRef
+	// PendingKeys holds the TeamRef.Key() of the teams GitHub still lists as
+	// awaiting review. A team outside this set has had its request cleared.
+	PendingKeys map[string]bool
+	// Members maps TeamRef.Key() to member logins. A missing key means the
+	// membership could not be read, not that the team is empty.
+	Members map[string][]string
+	// MyTeamKeys holds the "org/slug" refs of the authenticated user's own
+	// teams (GetMyTeamRefs), so a team still counts as mine when its member
+	// list is unreadable.
+	MyTeamKeys map[string]bool
+	// MyLogin is the authenticated user. Empty means "identity unknown", which
+	// leaves every entry unhighlighted rather than guessing.
+	MyLogin string
+	// Personal is true when the user was asked to review directly rather than
+	// through a team, and PersonalPending true while that request is open.
+	Personal        bool
+	PersonalPending bool
+	// Decisions is LatestReviewDecisions over the PR's reviews.
+	Decisions map[string]string
+}
+
+// ResolveTeamReviews places every required reviewer of a PR. The personal
+// request, when there is one, leads; teams the user belongs to come next, and
+// the rest follow alphabetically, so the entries a reviewer is accountable for
+// are the ones they read first.
+func ResolveTeamReviews(in TeamReviewInput) []TeamReviewStatus {
+	statuses := []TeamReviewStatus{}
+
+	if in.Personal && in.MyLogin != "" {
+		statuses = append(statuses, TeamReviewStatus{
+			Name:     in.MyLogin,
+			Status:   decisionStatus(in.Decisions[strings.ToLower(in.MyLogin)], in.PersonalPending),
+			Mine:     true,
+			Personal: true,
+		})
+	}
+
+	teams := make([]TeamReviewStatus, 0, len(in.Teams))
+	seen := map[string]bool{}
+	for _, team := range in.Teams {
+		if team.Slug == "" || seen[team.Key()] {
+			continue
+		}
+		seen[team.Key()] = true
+
+		name := team.Name
+		if name == "" {
+			name = team.Slug
+		}
+		members, known := in.Members[team.Key()]
+		teams = append(teams, TeamReviewStatus{
+			Name:   name,
+			Slug:   team.Slug,
+			Org:    team.Org,
+			Status: teamStatus(members, known, in.Decisions, in.PendingKeys[team.Key()]),
+			Mine:   in.MyLogin != "" && (in.MyTeamKeys[team.Key()] || containsFold(members, in.MyLogin)),
+		})
+	}
+
+	sort.SliceStable(teams, func(i, j int) bool {
+		if teams[i].Mine != teams[j].Mine {
+			return teams[i].Mine
+		}
+		return strings.ToLower(teams[i].Name) < strings.ToLower(teams[j].Name)
+	})
+
+	return append(statuses, teams...)
+}
+
+// teamStatus resolves one team's standing. A member who asked for changes wins
+// over one who approved: the PR still needs work either way.
+func teamStatus(members []string, membersKnown bool, decisions map[string]string, pending bool) string {
+	if membersKnown {
+		approved := false
+		for _, member := range members {
+			switch decisions[strings.ToLower(member)] {
+			case "CHANGES_REQUESTED":
+				return TeamReviewChangesRequested
+			case "APPROVED":
+				approved = true
+			}
+		}
+		if approved {
+			return TeamReviewApproved
+		}
+	}
+	if pending {
+		return TeamReviewPending
+	}
+	// GitHub cleared the request without a review we can attribute to the team:
+	// either its membership is unreadable, or the reviewer has since left it.
+	return TeamReviewReviewed
+}
+
+// decisionStatus maps the authenticated user's own standing decision, falling
+// back to whether their review request is still open.
+func decisionStatus(decision string, pending bool) string {
+	switch decision {
+	case "APPROVED":
+		return TeamReviewApproved
+	case "CHANGES_REQUESTED":
+		return TeamReviewChangesRequested
+	}
+	if pending {
+		return TeamReviewPending
+	}
+	return TeamReviewReviewed
+}
+
+func containsFold(haystack []string, needle string) bool {
+	for _, candidate := range haystack {
+		if strings.EqualFold(candidate, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/git_tools/team_reviews_test.go
+++ b/git_tools/team_reviews_test.go
@@ -1,0 +1,288 @@
+package git_tools
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v74/github"
+)
+
+func TestGetReviewRequestHistoryCollectsTeamsAndUsers(t *testing.T) {
+	withFakeGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"data":{"repository":{"pullRequest":{"timelineItems":{
+			"pageInfo":{"hasNextPage":false,"endCursor":""},
+			"nodes":[
+				{"requestedReviewer":{"__typename":"Team","name":"Platform Eng","slug":"platform-eng","organization":{"login":"acme"}}},
+				{"requestedReviewer":{"__typename":"User","login":"alice"}},
+				{"requestedReviewer":{"__typename":"Team","name":"Platform Eng","slug":"platform-eng","organization":{"login":"acme"}}},
+				{"requestedReviewer":{"__typename":"Team","name":"","slug":"security","organization":{"login":""}}}
+			]}}}}}`)
+	})
+
+	history, err := GetReviewRequestHistory("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("GetReviewRequestHistory returned an error: %v", err)
+	}
+
+	want := []TeamRef{
+		{Name: "Platform Eng", Slug: "platform-eng", Org: "acme"},
+		// A team with no name or org falls back to its slug and the repo owner.
+		{Name: "security", Slug: "security", Org: "acme"},
+	}
+	if len(history.Teams) != len(want) {
+		t.Fatalf("got %d teams (%+v), want %d", len(history.Teams), history.Teams, len(want))
+	}
+	for i, team := range want {
+		if history.Teams[i] != team {
+			t.Errorf("team %d = %+v, want %+v", i, history.Teams[i], team)
+		}
+	}
+	if len(history.Users) != 1 || history.Users[0] != "alice" {
+		t.Errorf("users = %v, want [alice]", history.Users)
+	}
+}
+
+func TestGetReviewRequestHistoryFollowsPagination(t *testing.T) {
+	page := 0
+	withFakeGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		page++
+		w.Header().Set("Content-Type", "application/json")
+		if page == 1 {
+			if after := req.Variables["after"]; after != nil {
+				t.Errorf("first page sent after=%v, want null", after)
+			}
+			io.WriteString(w, `{"data":{"repository":{"pullRequest":{"timelineItems":{
+				"pageInfo":{"hasNextPage":true,"endCursor":"CURSOR"},
+				"nodes":[{"requestedReviewer":{"__typename":"Team","name":"A","slug":"a","organization":{"login":"acme"}}}]}}}}}`)
+			return
+		}
+		if got := req.Variables["after"]; got != "CURSOR" {
+			t.Errorf("second page sent after=%v, want CURSOR", got)
+		}
+		io.WriteString(w, `{"data":{"repository":{"pullRequest":{"timelineItems":{
+			"pageInfo":{"hasNextPage":false,"endCursor":""},
+			"nodes":[{"requestedReviewer":{"__typename":"Team","name":"B","slug":"b","organization":{"login":"acme"}}}]}}}}}`)
+	})
+
+	history, err := GetReviewRequestHistory("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("GetReviewRequestHistory returned an error: %v", err)
+	}
+	if len(history.Teams) != 2 {
+		t.Fatalf("got %d teams, want both pages", len(history.Teams))
+	}
+}
+
+func TestGetReviewRequestHistoryReturnsGraphQLErrors(t *testing.T) {
+	withFakeGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"errors":[{"message":"Resource not accessible"}]}`)
+	})
+
+	if _, err := GetReviewRequestHistory("acme", "widgets", 7); err == nil {
+		t.Fatal("expected an error when GitHub reports one")
+	} else if !strings.Contains(err.Error(), "Resource not accessible") {
+		t.Errorf("error = %v, want GitHub's message", err)
+	}
+}
+
+func review(login, state string) *github.PullRequestReview {
+	return &github.PullRequestReview{
+		User:  &github.User{Login: github.String(login)},
+		State: github.String(state),
+	}
+}
+
+func TestLatestReviewDecisions(t *testing.T) {
+	decisions := LatestReviewDecisions([]*github.PullRequestReview{
+		review("Alice", "APPROVED"),
+		// A later plain comment does not undo the approval, exactly as GitHub
+		// itself treats it.
+		review("alice", "COMMENTED"),
+		review("bob", "APPROVED"),
+		review("bob", "CHANGES_REQUESTED"),
+		review("carol", "CHANGES_REQUESTED"),
+		review("carol", "DISMISSED"),
+		review("dave", "COMMENTED"),
+	})
+
+	want := map[string]string{"alice": "APPROVED", "bob": "CHANGES_REQUESTED"}
+	if len(decisions) != len(want) {
+		t.Fatalf("decisions = %v, want %v", decisions, want)
+	}
+	for login, state := range want {
+		if decisions[login] != state {
+			t.Errorf("decision for %s = %q, want %q", login, decisions[login], state)
+		}
+	}
+}
+
+func teamRef(slug string) TeamRef {
+	return TeamRef{Name: strings.ToUpper(slug[:1]) + slug[1:], Slug: slug, Org: "acme"}
+}
+
+func TestResolveTeamReviewsStatuses(t *testing.T) {
+	in := TeamReviewInput{
+		Teams: []TeamRef{teamRef("approvers"), teamRef("blockers"), teamRef("waiters"), teamRef("unknowns")},
+		PendingKeys: map[string]bool{
+			"acme/waiters": true,
+			// blockers asked for changes, so GitHub still lists them as pending.
+			"acme/blockers": true,
+		},
+		Members: map[string][]string{
+			"acme/approvers": {"alice", "bob"},
+			"acme/blockers":  {"carol"},
+			"acme/waiters":   {"dave"},
+			// "unknowns" is absent: its membership could not be read.
+		},
+		MyLogin:   "erin",
+		Decisions: map[string]string{"alice": "APPROVED", "carol": "CHANGES_REQUESTED"},
+	}
+
+	byName := map[string]TeamReviewStatus{}
+	for _, status := range ResolveTeamReviews(in) {
+		byName[status.Name] = status
+	}
+
+	cases := map[string]string{
+		"Approvers": TeamReviewApproved,
+		"Blockers":  TeamReviewChangesRequested,
+		"Waiters":   TeamReviewPending,
+		// Nobody attributable reviewed and GitHub is no longer waiting on them:
+		// somebody satisfied the request, we just can't say who.
+		"Unknowns": TeamReviewReviewed,
+	}
+	for name, want := range cases {
+		if got := byName[name].Status; got != want {
+			t.Errorf("%s status = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestResolveTeamReviewsChangesRequestedBeatsApproval(t *testing.T) {
+	statuses := ResolveTeamReviews(TeamReviewInput{
+		Teams:       []TeamRef{teamRef("platform")},
+		PendingKeys: map[string]bool{},
+		Members:     map[string][]string{"acme/platform": {"alice", "bob"}},
+		Decisions:   map[string]string{"alice": "APPROVED", "bob": "CHANGES_REQUESTED"},
+	})
+
+	if len(statuses) != 1 || statuses[0].Status != TeamReviewChangesRequested {
+		t.Fatalf("statuses = %+v, want a single changes_requested entry", statuses)
+	}
+}
+
+func TestResolveTeamReviewsMarksMyTeams(t *testing.T) {
+	statuses := ResolveTeamReviews(TeamReviewInput{
+		Teams: []TeamRef{teamRef("byMembership"), teamRef("byRef"), teamRef("theirs")},
+		Members: map[string][]string{
+			"acme/byMembership": {"ERIN"}, // GitHub is inconsistent about casing
+			"acme/theirs":       {"alice"},
+			// byRef's membership is unreadable; GetMyTeamRefs still knows it.
+		},
+		MyTeamKeys:  map[string]bool{"acme/byRef": true},
+		PendingKeys: map[string]bool{"acme/byMembership": true, "acme/byRef": true, "acme/theirs": true},
+		MyLogin:     "erin",
+	})
+
+	mine := map[string]bool{}
+	for _, status := range statuses {
+		mine[status.Name] = status.Mine
+	}
+	if !mine["ByMembership"] || !mine["ByRef"] {
+		t.Errorf("expected both of the user's teams to be marked mine, got %v", mine)
+	}
+	if mine["Theirs"] {
+		t.Error("a team the user is not on should not be marked mine")
+	}
+}
+
+func TestResolveTeamReviewsWithoutIdentityMarksNothingMine(t *testing.T) {
+	statuses := ResolveTeamReviews(TeamReviewInput{
+		Teams:       []TeamRef{teamRef("platform")},
+		Members:     map[string][]string{"acme/platform": {"erin"}},
+		PendingKeys: map[string]bool{"acme/platform": true},
+		Personal:    true,
+	})
+
+	if len(statuses) != 1 {
+		t.Fatalf("statuses = %+v, want only the team (no personal entry without a login)", statuses)
+	}
+	if statuses[0].Mine {
+		t.Error("no configured identity should leave every entry unhighlighted")
+	}
+}
+
+func TestResolveTeamReviewsOrdersPersonalThenMineThenName(t *testing.T) {
+	statuses := ResolveTeamReviews(TeamReviewInput{
+		Teams:       []TeamRef{teamRef("zebra"), teamRef("alpha"), teamRef("mine")},
+		MyTeamKeys:  map[string]bool{"acme/mine": true},
+		PendingKeys: map[string]bool{"acme/zebra": true, "acme/alpha": true, "acme/mine": true},
+		MyLogin:     "erin",
+		Personal:    true,
+	})
+
+	var names []string
+	for _, status := range statuses {
+		names = append(names, status.Name)
+	}
+	want := []string{"erin", "Mine", "Alpha", "Zebra"}
+	if len(names) != len(want) {
+		t.Fatalf("names = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("names = %v, want %v", names, want)
+		}
+	}
+	if !statuses[0].Personal || !statuses[0].Mine {
+		t.Errorf("personal entry = %+v, want personal and mine", statuses[0])
+	}
+}
+
+func TestResolveTeamReviewsPersonalStatusFollowsMyOwnReview(t *testing.T) {
+	cases := []struct {
+		name     string
+		decision string
+		pending  bool
+		want     string
+	}{
+		{"still requested", "", true, TeamReviewPending},
+		{"approved", "APPROVED", false, TeamReviewApproved},
+		{"asked for changes", "CHANGES_REQUESTED", false, TeamReviewChangesRequested},
+		// The request is gone and no decision of ours survives: we reviewed and
+		// only commented, or somebody removed the request.
+		{"request cleared", "", false, TeamReviewReviewed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			decisions := map[string]string{}
+			if tc.decision != "" {
+				decisions["erin"] = tc.decision
+			}
+			statuses := ResolveTeamReviews(TeamReviewInput{
+				MyLogin:         "Erin",
+				Personal:        true,
+				PersonalPending: tc.pending,
+				Decisions:       decisions,
+			})
+			if len(statuses) != 1 {
+				t.Fatalf("statuses = %+v, want just the personal entry", statuses)
+			}
+			if statuses[0].Status != tc.want {
+				t.Errorf("personal status = %q, want %q", statuses[0].Status, tc.want)
+			}
+		})
+	}
+}

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -212,6 +212,12 @@ type ReviewItem struct {
 	// and a rating has been computed.
 	ReviewEase string    `json:"review_ease"`
 	CreatedAt  time.Time `json:"created_at"`
+	// RequiredTeams are the teams asked to review this PR — including ones
+	// whose request GitHub has already cleared — each with where its review
+	// stands and whether it is one of the current user's teams. Resolved by the
+	// workflow layer and read here from its cache, so the list never waits on
+	// GitHub. Empty when no cycle has resolved this PR yet.
+	RequiredTeams []git_tools.TeamReviewStatus `json:"required_teams"`
 }
 
 // GetAllReviewItems returns structured review items from all sections
@@ -291,7 +297,31 @@ func (r *OrgRenderer) parseItemToReviewItem(item *database.Item, sectionName str
 		}
 	}
 
+	if reviewItem.Repo != "" && reviewItem.Number > 0 {
+		reviewItem.RequiredTeams = r.requiredTeams(reviewItem.Number, reviewItem.Repo)
+	}
+
 	return reviewItem
+}
+
+// requiredTeams reads the team standing the workflow layer resolved for a PR.
+// A missing or unreadable row is not an error worth failing a render over — the
+// row simply shows no team chips — so everything here degrades to nil.
+func (r *OrgRenderer) requiredTeams(number int, repo string) []git_tools.TeamReviewStatus {
+	raw, err := r.db.GetPRTeamReviews(number, repo)
+	if err != nil {
+		slog.Warn("Error loading team reviews for review item", "pr", number, "repo", repo, "error", err)
+		return nil
+	}
+	if raw == "" {
+		return nil
+	}
+	var teams []git_tools.TeamReviewStatus
+	if err := json.Unmarshal([]byte(raw), &teams); err != nil {
+		slog.Warn("Error decoding cached team reviews", "pr", number, "repo", repo, "error", err)
+		return nil
+	}
+	return teams
 }
 
 func (r *OrgRenderer) RenderFile(filename, orgFileDir string) error {

--- a/server/renderer_test.go
+++ b/server/renderer_test.go
@@ -1270,6 +1270,59 @@ func TestBuildItemLinesIncludesReviewEaseTag(t *testing.T) {
 	}
 }
 
+func TestReviewItemsCarryRequiredTeams(t *testing.T) {
+	db := setupTestDB(t)
+	config.SetC(config.Config{DB: db})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+
+	section, err := db.GetOrCreateSection("Test Section", 0)
+	if err != nil {
+		t.Fatalf("failed to create section: %v", err)
+	}
+	details := []string{
+		"83",
+		"Repo: C-Hipple/code-review-server",
+		"https://github.com/C-Hipple/code-review-server/pull/83",
+	}
+	if _, err := db.UpsertItem(section.ID, "83", "TODO", "Debug PR", details, []string{"code-review-server"}, 0); err != nil {
+		t.Fatalf("failed to create item: %v", err)
+	}
+
+	r := NewOrgRenderer(db)
+
+	// Nothing resolved yet: the row renders without team chips rather than
+	// failing or waiting on GitHub.
+	items, err := r.GetAllReviewItems()
+	if err != nil {
+		t.Fatalf("GetAllReviewItems: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	if len(items[0].RequiredTeams) != 0 {
+		t.Errorf("required teams = %+v, want none before a workflow resolves them", items[0].RequiredTeams)
+	}
+
+	// The workflow layer caches under the short repo name (see the cache key
+	// convention), which is what the item's Repo field carries.
+	seed := `[{"name":"Platform","slug":"platform","org":"C-Hipple","status":"changes_requested","mine":true,"personal":false}]`
+	if err := db.UpsertPRTeamReviews(83, "code-review-server", seed); err != nil {
+		t.Fatalf("failed to seed team reviews: %v", err)
+	}
+
+	items, err = r.GetAllReviewItems()
+	if err != nil {
+		t.Fatalf("GetAllReviewItems: %v", err)
+	}
+	teams := items[0].RequiredTeams
+	if len(teams) != 1 {
+		t.Fatalf("required teams = %+v, want the cached entry", teams)
+	}
+	if teams[0].Name != "Platform" || teams[0].Status != git_tools.TeamReviewChangesRequested || !teams[0].Mine {
+		t.Errorf("required team = %+v, want Platform/changes_requested/mine", teams[0])
+	}
+}
+
 func TestDiffFileOrderingCacheRoundtrip(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/workflows/auxdata.go
+++ b/workflows/auxdata.go
@@ -68,6 +68,9 @@ func (s *AuxDataStore) MergeSet(key PRKey, data *PRAuxData) {
 		if data.ReviewThreads == nil {
 			data.ReviewThreads = old.ReviewThreads
 		}
+		if data.TeamReviews == nil {
+			data.TeamReviews = old.TeamReviews
+		}
 	}
 	s.data[key] = data
 }

--- a/workflows/cache_warm_test.go
+++ b/workflows/cache_warm_test.go
@@ -94,9 +94,10 @@ func TestApplyCacheWarmRequirements(t *testing.T) {
 		// Reviews and comments especially: a draft or closed PR gets no other
 		// chance at a PRReviews row, and that shows up as a "reviews" miss.
 		// ReviewThreads has no filter that would ever request it, so the warm is
-		// its only chance to land before someone opens the review.
+		// its only chance to land before someone opens the review. Teams is the
+		// same story for draft and closed PRs, which the open-PR rule skips.
 		want := AuxDataRequirement{
-			Diff: true, Commits: true, Reviews: true, Comments: true, ReviewThreads: true,
+			Diff: true, Commits: true, Reviews: true, Comments: true, ReviewThreads: true, Teams: true,
 		}
 		if got != want {
 			t.Errorf("got %+v, want %+v", got, want)

--- a/workflows/logic.go
+++ b/workflows/logic.go
@@ -39,6 +39,10 @@ type AuxDataRequirement struct {
 	// ReviewThreads is the GraphQL review-thread resolution state. No workflow
 	// filter needs it, but GetPRDetails does, so the cache warm asks for it.
 	ReviewThreads bool
+	// Teams resolves which teams are required to review the PR and where each
+	// one stands, for the chips on the review list's rows. It is derived from
+	// the PR's reviews, so asking for it implies Reviews.
+	Teams bool
 }
 
 // PRAuxData holds pre-fetched auxiliary data for a PR
@@ -51,8 +55,12 @@ type PRAuxData struct {
 	DiffLines         []string
 	Reviews           []*github.PullRequestReview // PR reviews (for approved_by / changes_requested_by / commented_by)
 	ReviewThreads     []git_tools.ReviewThread    // Review-thread resolution state, for the DB cache
-	HeadSHA           string                      // SHA of the PR head for DB storage
-	BaseSHA           string                      // SHA of the PR base for DB storage
+	// TeamReviews is the required-team standing shown on the review list's
+	// rows. Non-nil (possibly empty) once resolved; nil means "not resolved
+	// this pass", which leaves any cached row alone.
+	TeamReviews []git_tools.TeamReviewStatus
+	HeadSHA     string // SHA of the PR head for DB storage
+	BaseSHA     string // SHA of the PR base for DB storage
 }
 
 type Workflow interface {

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -58,13 +58,14 @@ type apiCallCounter struct {
 	CheckRuns      atomic.Int64
 	Commits        atomic.Int64
 	ReviewThreads  atomic.Int64
+	TeamReviews    atomic.Int64
 }
 
 func (c *apiCallCounter) total() int64 {
 	return c.PRList.Load() + c.PRSpecific.Load() + c.Comments.Load() +
 		c.IssueComments.Load() + c.CIStatus.Load() + c.Diff.Load() +
 		c.Reviews.Load() + c.CombinedStatus.Load() + c.CheckRuns.Load() +
-		c.Commits.Load() + c.ReviewThreads.Load()
+		c.Commits.Load() + c.ReviewThreads.Load() + c.TeamReviews.Load()
 }
 
 func (c *apiCallCounter) log() {
@@ -80,6 +81,7 @@ func (c *apiCallCounter) log() {
 		"check_runs", c.CheckRuns.Load(),
 		"commits", c.Commits.Load(),
 		"review_threads", c.ReviewThreads.Load(),
+		"team_reviews", c.TeamReviews.Load(),
 		"total", c.total(),
 	)
 }
@@ -599,6 +601,7 @@ func (ms ManagerService) RunOnce(file_change_wg *sync.WaitGroup) {
 		apiCalls.CheckRuns.Load(),
 		apiCalls.Commits.Load(),
 		apiCalls.ReviewThreads.Load(),
+		apiCalls.TeamReviews.Load(),
 		rlRemaining,
 		rlLimit,
 		rlResetAtStr,
@@ -819,10 +822,16 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 				existing.Reviews = existing.Reviews || req.AuxData.Reviews
 				existing.Commits = existing.Commits || req.AuxData.Commits
 				existing.ReviewThreads = existing.ReviewThreads || req.AuxData.ReviewThreads
+				existing.Teams = existing.Teams || req.AuxData.Teams
 				// Always fetch reviews for open non-draft PRs so Details() can
 				// display who has approved / requested changes / commented.
 				if pr.State != nil && *pr.State == "open" && (pr.Draft == nil || !*pr.Draft) {
 					existing.Reviews = true
+					// Required-team standing is derived from those same reviews
+					// and is shown on every row of the review list, so it is
+					// refreshed on the same cadence — a team that approves
+					// without anything being pushed still turns green.
+					existing.Teams = true
 				}
 				prRequirements[key] = existing
 			}
@@ -837,7 +846,7 @@ func (ms ManagerService) prefetchAuxData(client *github.Client,
 	for key, auxReq := range prRequirements {
 		// Skip if no aux data is needed
 		if !auxReq.Comments && !auxReq.CIStatus && !auxReq.Diff && !auxReq.Reviews &&
-			!auxReq.Commits && !auxReq.ReviewThreads {
+			!auxReq.Commits && !auxReq.ReviewThreads && !auxReq.Teams {
 			continue
 		}
 
@@ -909,6 +918,9 @@ func applyCacheWarmRequirements(db *database.DB,
 		// would populate it; without warming it here the first person to open the
 		// PR pays for the GraphQL call.
 		req.ReviewThreads = true
+		// A draft or closed PR is skipped by the open-PR rule in prefetchAuxData,
+		// so without this it would never get its required teams resolved at all.
+		req.Teams = true
 		prRequirements[key] = req
 		warmed = append(warmed, key)
 	}
@@ -948,6 +960,12 @@ func fetchAuxDataForPR(client *github.Client,
 	key PRKey, req AuxDataRequirement, pr *github.PullRequest) *PRAuxData {
 
 	auxData := &PRAuxData{}
+
+	// Required-team standing is computed from who has reviewed, so asking for
+	// the teams is asking for the reviews.
+	if req.Teams {
+		req.Reviews = true
+	}
 
 	headSHA := ""
 	if pr != nil && pr.Head != nil && pr.Head.SHA != nil {
@@ -1110,6 +1128,12 @@ func fetchAuxDataForPR(client *github.Client,
 	}
 
 	wg.Wait()
+
+	// Resolved after the wait rather than alongside the fetches above: it reads
+	// the reviews one of them just returned.
+	if req.Teams {
+		auxData.TeamReviews = resolvePRTeamReviews(apiCalls, key, pr, ghReviews)
+	}
 
 	// Persist all fetched data to DB so GetPRDetails finds it cached
 	persistPRCacheData(workflowName, key, pr, auxData, allCommentsForDB, ghReviews, ghCommits, combinedStatus, checkRunsResult)
@@ -1280,6 +1304,19 @@ func persistPRCacheData(workflowName string, key PRKey, pr *github.PullRequest,
 				slog.Error("Failed to cache PR review threads", "pr", key.Number, "repo", key.Repo, "error", err)
 			} else {
 				written = append(written, "review_threads")
+			}
+		}
+	}
+
+	// 6c. Required-team review status (what the review list's rows show). Nil
+	// means the resolution was not requested or could not be completed, so the
+	// previously cached row stands rather than being blanked.
+	if auxData.TeamReviews != nil {
+		if j, err := json.Marshal(auxData.TeamReviews); err == nil {
+			if err := db.UpsertPRTeamReviews(key.Number, key.Repo, string(j)); err != nil {
+				slog.Error("Failed to cache PR team reviews", "pr", key.Number, "repo", key.Repo, "error", err)
+			} else {
+				written = append(written, "team_reviews")
 			}
 		}
 	}

--- a/workflows/reprocess.go
+++ b/workflows/reprocess.go
@@ -212,12 +212,14 @@ func applyReprocessChanges(changes []FileChanges) {
 }
 
 // reprocessAuxRequirements is the union of what the targeted workflows' filters
-// need, plus comments and reviews unconditionally. Reviews are the data the
-// reprocess exists to act on — the identity filters read them out of the aux
-// store and the section display summarizes them — and comments come along
-// because Details() would otherwise fetch them one PR at a time anyway.
+// need, plus comments, reviews and team standing unconditionally. Reviews are
+// the data the reprocess exists to act on — the identity filters read them out
+// of the aux store and the section display summarizes them — team standing is
+// derived from them, so the review that triggered this reprocess is reflected
+// in the row's team chips, and comments come along because Details() would
+// otherwise fetch them one PR at a time anyway.
 func reprocessAuxRequirements(wfs []Workflow, owner, repo string) AuxDataRequirement {
-	req := AuxDataRequirement{Comments: true, Reviews: true}
+	req := AuxDataRequirement{Comments: true, Reviews: true, Teams: true}
 	for _, wf := range wfs {
 		for _, prReq := range wf.GetPRRequirements() {
 			if !strings.EqualFold(prReq.Owner, owner) || !strings.EqualFold(prReq.Repo, repo) {
@@ -244,6 +246,7 @@ func mergeAuxRequirements(a, b AuxDataRequirement) AuxDataRequirement {
 		Diff:     a.Diff || b.Diff,
 		Reviews:  a.Reviews || b.Reviews,
 		Commits:  a.Commits || b.Commits,
+		Teams:    a.Teams || b.Teams,
 	}
 }
 

--- a/workflows/reprocess_test.go
+++ b/workflows/reprocess_test.go
@@ -303,7 +303,7 @@ func TestReprocessAuxRequirementsUnionsWorkflowNeeds(t *testing.T) {
 	}
 
 	got := reprocessAuxRequirements([]Workflow{ci, interaction, elsewhere}, owner, repo)
-	want := AuxDataRequirement{Comments: true, Reviews: true, CIStatus: true, Diff: true, Commits: true}
+	want := AuxDataRequirement{Comments: true, Reviews: true, Teams: true, CIStatus: true, Diff: true, Commits: true}
 	if got != want {
 		t.Errorf("reprocessAuxRequirements = %+v, want %+v", got, want)
 	}

--- a/workflows/team_reviews.go
+++ b/workflows/team_reviews.go
@@ -1,0 +1,196 @@
+package workflows
+
+import (
+	"crs/config"
+	"crs/git_tools"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// resolvePRTeamReviews works out which teams a PR needs a review from and where
+// each of them stands, for the chips the review list shows on every row.
+//
+// The set of teams is a high-water mark, because GitHub drops a team from a
+// PR's requested_teams the moment one of its members reviews. Three sources
+// feed it, cheapest first:
+//
+//   - the teams still listed on the PR object, which cost nothing;
+//   - the teams a previous cycle already recorded for this PR, which is why a
+//     team that approved yesterday is still shown (in green) today;
+//   - the PR's full review-request history from the timeline, the only source
+//     that can recover a team whose review was already satisfied before we
+//     first saw the PR. That one is a GraphQL call, so it is made once per PR
+//     — on first sight, when there is nothing cached to build on.
+//
+// Returns a non-nil slice whenever it resolved anything, including the empty
+// slice for a PR with no required reviewers: persisting that empty answer is
+// what stops the next cycle asking GitHub for the history all over again.
+func resolvePRTeamReviews(apiCalls *apiCallCounter, key PRKey,
+	pr *github.PullRequest, reviews []*github.PullRequestReview) []git_tools.TeamReviewStatus {
+
+	if pr == nil {
+		return nil
+	}
+
+	cached, hasCachedRow := loadCachedTeamReviews(key)
+
+	teams := []git_tools.TeamRef{}
+	seen := map[string]bool{}
+	addTeam := func(team git_tools.TeamRef) {
+		if team.Slug == "" {
+			return
+		}
+		if team.Org == "" {
+			team.Org = key.Owner
+		}
+		if team.Name == "" {
+			team.Name = team.Slug
+		}
+		if seen[team.Key()] {
+			return
+		}
+		seen[team.Key()] = true
+		teams = append(teams, team)
+	}
+
+	// Teams still awaiting review, straight off the PR object.
+	pendingKeys := map[string]bool{}
+	for _, team := range pr.RequestedTeams {
+		if team == nil {
+			continue
+		}
+		ref := git_tools.TeamRef{
+			Name: team.GetName(),
+			Slug: team.GetSlug(),
+			Org:  team.GetOrganization().GetLogin(),
+		}
+		if ref.Org == "" {
+			ref.Org = key.Owner
+		}
+		if ref.Slug == "" {
+			continue
+		}
+		pendingKeys[ref.Key()] = true
+		addTeam(ref)
+	}
+
+	// Teams (and a personal request) carried over from the last cycle.
+	personal := false
+	for _, entry := range cached {
+		if entry.Personal {
+			personal = true
+			continue
+		}
+		addTeam(git_tools.TeamRef{Name: entry.Name, Slug: entry.Slug, Org: entry.Org})
+	}
+
+	myLogin := currentGitHubLogin()
+	personalPending := myLogin != "" && requestedFrom(pr, myLogin)
+	personal = personal || personalPending
+
+	// First sight of this PR: ask for the full request history, which is the
+	// only way to learn about requests GitHub has already cleared.
+	if !hasCachedRow {
+		apiCalls.TeamReviews.Add(1)
+		history, err := git_tools.GetReviewRequestHistory(key.Owner, key.Repo, key.Number)
+		if err != nil {
+			// Nothing is written for this PR, so the next cycle asks again.
+			// Storing the teams still listed on the PR instead would look like
+			// a complete answer and stop the retry, quietly leaving out every
+			// team whose review GitHub had already cleared.
+			slog.Warn("Failed to fetch review request history; leaving this PR's required teams unresolved for now",
+				"pr", key.Number, "repo", key.Repo, "error", err)
+			return nil
+		}
+		for _, team := range history.Teams {
+			addTeam(team)
+		}
+		if myLogin != "" && containsFold(history.Users, myLogin) {
+			personal = true
+		}
+	}
+
+	if len(teams) == 0 && !personal {
+		return []git_tools.TeamReviewStatus{}
+	}
+
+	return git_tools.ResolveTeamReviews(git_tools.TeamReviewInput{
+		Teams:           teams,
+		PendingKeys:     pendingKeys,
+		Members:         git_tools.GetTeamMembersForTeams(teams),
+		MyTeamKeys:      myTeamKeys(),
+		MyLogin:         myLogin,
+		Personal:        personal,
+		PersonalPending: personalPending,
+		Decisions:       git_tools.LatestReviewDecisions(reviews),
+	})
+}
+
+// loadCachedTeamReviews reads the statuses a previous cycle stored for a PR.
+// The second return value distinguishes a cached empty answer from no row at
+// all — see resolvePRTeamReviews for why that difference matters.
+func loadCachedTeamReviews(key PRKey) ([]git_tools.TeamReviewStatus, bool) {
+	db := config.C().DB
+	if db == nil {
+		return nil, false
+	}
+	raw, err := db.GetPRTeamReviews(key.Number, key.Repo)
+	if err != nil {
+		slog.Warn("Failed to read cached team reviews", "pr", key.Number, "repo", key.Repo, "error", err)
+		return nil, false
+	}
+	if raw == "" {
+		return nil, false
+	}
+	var cached []git_tools.TeamReviewStatus
+	if err := json.Unmarshal([]byte(raw), &cached); err != nil {
+		slog.Warn("Failed to decode cached team reviews", "pr", key.Number, "repo", key.Repo, "error", err)
+		return nil, false
+	}
+	return cached, true
+}
+
+// currentGitHubLogin is who the review list is being built for: the configured
+// username, or the identity behind the API token when the config leaves it
+// unset. Empty when neither is available, which leaves every chip unhighlighted
+// rather than highlighting the wrong ones.
+func currentGitHubLogin() string {
+	if login := config.C().GithubUsername; login != "" {
+		return login
+	}
+	return git_tools.GetAuthenticatedLogin()
+}
+
+// myTeamKeys is the authenticated user's own teams as "org/slug", the same key
+// TeamRef.Key() produces. It answers "is this my team" even for teams whose
+// member list the token cannot read.
+func myTeamKeys() map[string]bool {
+	keys := map[string]bool{}
+	for _, ref := range git_tools.GetMyTeamRefs() {
+		keys[ref] = true
+	}
+	return keys
+}
+
+// requestedFrom reports whether login has an open personal review request on
+// the PR (as opposed to being asked through one of their teams).
+func requestedFrom(pr *github.PullRequest, login string) bool {
+	for _, reviewer := range pr.RequestedReviewers {
+		if reviewer != nil && strings.EqualFold(reviewer.GetLogin(), login) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(haystack []string, needle string) bool {
+	for _, candidate := range haystack {
+		if strings.EqualFold(candidate, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/workflows/team_reviews_test.go
+++ b/workflows/team_reviews_test.go
@@ -1,0 +1,172 @@
+package workflows
+
+import (
+	"crs/config"
+	"crs/git_tools"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// teamReviewTestConfig points the workflow layer at a scratch DB and gives it an
+// identity, with no GitHub token: every lookup that would call GitHub (team
+// membership, the user's own teams, the request history) reports "unknown"
+// instead, which is exactly the path a cached PR takes during a cycle.
+func teamReviewTestConfig(t *testing.T) config.Config {
+	t.Helper()
+	t.Setenv("CRS_GITHUB_TOKEN", "")
+	db := warmTestDB(t)
+	config.SetC(config.Config{DB: db, GithubUsername: "erin"})
+	t.Cleanup(func() { config.SetC(config.Config{}) })
+	return config.C()
+}
+
+func teamRequest(name, slug, org string) *github.Team {
+	return &github.Team{
+		Name:         github.String(name),
+		Slug:         github.String(slug),
+		Organization: &github.Organization{Login: github.String(org)},
+	}
+}
+
+func TestResolvePRTeamReviewsUnionsCachedAndPendingTeams(t *testing.T) {
+	cfg := teamReviewTestConfig(t)
+	key := PRKey{Owner: "acme", Repo: "widgets", Number: 12}
+
+	// A previous cycle recorded two teams; one of them has since been cleared
+	// by GitHub because a member reviewed, so it is no longer pending.
+	cached := []git_tools.TeamReviewStatus{
+		{Name: "Platform", Slug: "platform", Org: "acme", Status: git_tools.TeamReviewPending},
+		{Name: "Security", Slug: "security", Org: "acme", Status: git_tools.TeamReviewPending},
+	}
+	seed, err := json.Marshal(cached)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := cfg.DB.UpsertPRTeamReviews(key.Number, key.Repo, string(seed)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	pr := &github.PullRequest{
+		RequestedTeams: []*github.Team{
+			teamRequest("Platform", "platform", "acme"),
+			// Requested since the last cycle: no history call needed to see it.
+			teamRequest("Docs", "docs", "acme"),
+		},
+	}
+
+	statuses := resolvePRTeamReviews(&apiCallCounter{}, key, pr, nil)
+
+	got := map[string]string{}
+	for _, status := range statuses {
+		got[status.Name] = status.Status
+	}
+	want := map[string]string{
+		"Platform": git_tools.TeamReviewPending,
+		"Docs":     git_tools.TeamReviewPending,
+		// Carried over from the cache and no longer awaiting review: without a
+		// readable member list we can say it was reviewed, not by whom.
+		"Security": git_tools.TeamReviewReviewed,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("statuses = %+v, want %v", statuses, want)
+	}
+	for name, status := range want {
+		if got[name] != status {
+			t.Errorf("%s = %q, want %q", name, got[name], status)
+		}
+	}
+}
+
+func TestResolvePRTeamReviewsKeepsPersonalRequestAfterItIsCleared(t *testing.T) {
+	cfg := teamReviewTestConfig(t)
+	key := PRKey{Owner: "acme", Repo: "widgets", Number: 13}
+
+	seed, err := json.Marshal([]git_tools.TeamReviewStatus{
+		{Name: "erin", Status: git_tools.TeamReviewPending, Mine: true, Personal: true},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := cfg.DB.UpsertPRTeamReviews(key.Number, key.Repo, string(seed)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// GitHub drops the reviewer from requested_reviewers once they review, so
+	// the entry only survives because the cache remembered it.
+	statuses := resolvePRTeamReviews(&apiCallCounter{}, key, &github.PullRequest{}, []*github.PullRequestReview{
+		{User: &github.User{Login: github.String("erin")}, State: github.String("APPROVED")},
+	})
+
+	if len(statuses) != 1 {
+		t.Fatalf("statuses = %+v, want the personal entry", statuses)
+	}
+	if !statuses[0].Personal || statuses[0].Status != git_tools.TeamReviewApproved {
+		t.Errorf("personal entry = %+v, want an approved personal entry", statuses[0])
+	}
+}
+
+func TestResolvePRTeamReviewsKeepsAnEmptyAnswerEmpty(t *testing.T) {
+	cfg := teamReviewTestConfig(t)
+	key := PRKey{Owner: "acme", Repo: "widgets", Number: 14}
+
+	// A previous cycle already established this PR needs no team review. The
+	// answer must come back as an empty non-nil slice: persisting "[]" is what
+	// stops every later cycle asking GitHub for the history all over again.
+	if err := cfg.DB.UpsertPRTeamReviews(key.Number, key.Repo, "[]"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	statuses := resolvePRTeamReviews(&apiCallCounter{}, key, &github.PullRequest{}, nil)
+	if statuses == nil || len(statuses) != 0 {
+		t.Fatalf("statuses = %+v, want an empty non-nil slice", statuses)
+	}
+}
+
+func TestResolvePRTeamReviewsLeavesNothingCachedWhenTheHistoryFails(t *testing.T) {
+	teamReviewTestConfig(t)
+	key := PRKey{Owner: "acme", Repo: "widgets", Number: 17}
+
+	// No token, so the first-sight history call fails. Storing the teams still
+	// listed on the PR would look like a complete answer and stop the retry,
+	// leaving out every team whose review GitHub had already cleared.
+	pr := &github.PullRequest{RequestedTeams: []*github.Team{teamRequest("Platform", "platform", "acme")}}
+	if statuses := resolvePRTeamReviews(&apiCallCounter{}, key, pr, nil); statuses != nil {
+		t.Fatalf("statuses = %+v, want nil so the next cycle tries again", statuses)
+	}
+}
+
+func TestResolvePRTeamReviewsSkipsPRsItCannotRead(t *testing.T) {
+	teamReviewTestConfig(t)
+	key := PRKey{Owner: "acme", Repo: "widgets", Number: 15}
+
+	if statuses := resolvePRTeamReviews(&apiCallCounter{}, key, nil, nil); statuses != nil {
+		t.Fatalf("statuses = %+v, want nil so the cached row is left alone", statuses)
+	}
+}
+
+func TestPersistPRCacheDataStoresTeamReviews(t *testing.T) {
+	cfg := teamReviewTestConfig(t)
+	key := PRKey{Owner: "acme", Repo: "widgets", Number: 16}
+
+	auxData := &PRAuxData{
+		HeadSHA: "abc123",
+		TeamReviews: []git_tools.TeamReviewStatus{
+			{Name: "Platform", Slug: "platform", Org: "acme", Status: git_tools.TeamReviewApproved, Mine: true},
+		},
+	}
+	persistPRCacheData("test-workflow", key, nil, auxData, nil, nil, nil, nil, nil)
+
+	raw, err := cfg.DB.GetPRTeamReviews(key.Number, key.Repo)
+	if err != nil {
+		t.Fatalf("GetPRTeamReviews: %v", err)
+	}
+	var stored []git_tools.TeamReviewStatus
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		t.Fatalf("stored row is not decodable: %v (%q)", err, raw)
+	}
+	if len(stored) != 1 || stored[0].Slug != "platform" || !stored[0].Mine {
+		t.Errorf("stored = %+v, want the resolved platform entry", stored)
+	}
+}


### PR DESCRIPTION
Ports prism's via-teams column to the web client: every row now carries a
chip per team the PR needs a review from, colored by where that review
stands and weighted by whether it is one of your teams.

The teams are a high-water mark, because GitHub drops a team from a PR's
requested_teams as soon as one of its members reviews — REST alone can
only answer "who is still waiting", which would make an approving team
vanish instead of turning green. Three sources feed the set, cheapest
first: the teams still on the PR object, the teams a previous cycle
recorded, and the PR's full review-request history from the timeline
(GraphQL, fetched once per PR on first sight, since that is the only way
to recover a request GitHub had already cleared).

Resolution happens in the workflow layer, alongside the reviews it is
derived from, and lands in a new PRTeamReviews cache. GetAllReviews reads
that cache, so the list never waits on GitHub and the client never talks
to it. Status refreshes on the same cadence as reviews, so a team that
approves without anything being pushed turns green on the next cycle, and
a review submitted from the web client updates its chip through the
reprocess path.

Where the token cannot read a team's membership, a cleared request
reports "reviewed" rather than claiming an approval it cannot attribute.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HhRyaEs4ndxu8AETvEzw6v