### PR TITLE
Take the workflow reprocess off the review-submission path

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -555,7 +555,11 @@ export default function Review({
     const handleSubmitReview = async () => {
         setIsSubmittingReview(true);
         try {
-            await rpcCall<PRResponse>('RPCHandler.SubmitReview', [
+            // The reply is the post-submission PR, fetched fresh from GitHub
+            // by the server. Applying it directly is the refresh — calling
+            // handleSync() here would throw this payload away and pay for the
+            // identical forced refetch a second time.
+            const res = await rpcCall<PRResponse>('RPCHandler.SubmitReview', [
                 {
                     Owner: owner,
                     Repo: repo,
@@ -566,8 +570,8 @@ export default function Review({
             ]);
             setSubmitting(false);
             setReviewBody('');
-            // Refresh everything after submission
-            await handleSync();
+            applyPRResponse(res);
+            loadPluginOutputs();
         } catch (e) {
             console.error(e);
             alert('Error submitting review');

--- a/server/server.go
+++ b/server/server.go
@@ -586,20 +586,26 @@ func (h *RPCHandler) SubmitReview(args *SubmitReviewArgs, reply *SubmitReviewRep
 	}
 
 	// 5. Re-run the PR through the workflows that target its repo so the
-	// dashboard reflects the review immediately instead of at the next cycle.
-	// Every targeting workflow is consulted, not just the ones holding the PR:
-	// a review can move a PR into a section ("waiting on author") as easily as
-	// out of one ("needs review"). Failures are logged rather than returned —
-	// the review itself already succeeded, and the next cycle re-syncs anyway.
-	if err := workflows.ReprocessPR(args.Owner, args.Repo, args.Number); err != nil {
-		slog.Error("Error reprocessing PR through workflows after review",
-			"owner", args.Owner, "repo", args.Repo, "pr", args.Number, "error", err)
-	}
+	// dashboard reflects the review well before the next cycle, up to ten
+	// minutes away. Every targeting workflow is consulted, not just the ones
+	// holding the PR: a review can move a PR into a section ("waiting on
+	// author") as easily as out of one ("needs review").
+	//
+	// Dispatched, not awaited. It is a second GitHub fan-out over the same PR,
+	// and the reply below is built from a fresh fetch of its own rather than
+	// from anything the reprocess writes, so waiting for it only adds a round
+	// trip to the submit the reviewer is sitting in front of. The sections it
+	// rewrites are read by the dashboard, which refetches when it is opened.
+	workflows.ReprocessPRAsync(args.Owner, args.Repo, args.Number)
 
 	details, content, err := h.fetchPR(args.Owner, args.Repo, args.Number, true)
 	if err != nil {
 		return err
 	}
+	// Kept from the sync the client used to run after submitting: the hooks
+	// dispatch in goroutines and are debounced per head SHA, so on the usual
+	// path — a review that changes no commits — this costs nothing.
+	ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
 	reply.populate(details, content, args.Owner, args.Repo, args.Number)
 	return nil
 }

--- a/workflows/reprocess.go
+++ b/workflows/reprocess.go
@@ -329,3 +329,38 @@ func (w ProjectListWorkflow) MatchesPR(pr *github.PullRequest, ownedByWorkflow b
 	}
 	return len(git_tools.ApplyPRFilters([]*github.PullRequest{pr}, w.Filters)) > 0
 }
+
+// reprocessInFlight tracks the PRs a background reprocess is currently running
+// for, keyed "owner/repo#number".
+var reprocessInFlight sync.Map
+
+// ReprocessPRAsync runs ReprocessPR in the background and returns immediately.
+//
+// The work is a GitHub fan-out — the PR itself plus its comments, reviews,
+// commits, CI status and review threads — and nothing the caller returns to the
+// client reads its result: an RPC that reprocesses serves its own response from
+// its own fresh fetch, and the dashboard re-reads the sections the next time it
+// is loaded. Running it inline only makes the caller wait out a second round
+// trip to GitHub before answering.
+//
+// A reprocess already in flight for the same PR wins: a second one started
+// behind it would fetch the same post-action state the first is already
+// fetching, so dropping it costs nothing.
+//
+// Errors are logged rather than returned — the caller has already finished by
+// the time they happen, and the next workflow cycle re-syncs the PR anyway.
+func ReprocessPRAsync(owner, repo string, number int) {
+	key := fmt.Sprintf("%s/%s#%d", owner, repo, number)
+	if _, loaded := reprocessInFlight.LoadOrStore(key, struct{}{}); loaded {
+		slog.Debug("Reprocess already in flight for this PR; skipping duplicate",
+			"owner", owner, "repo", repo, "pr", number)
+		return
+	}
+	go func() {
+		defer reprocessInFlight.Delete(key)
+		if err := ReprocessPR(owner, repo, number); err != nil {
+			slog.Error("Error reprocessing PR through workflows",
+				"owner", owner, "repo", repo, "pr", number, "error", err)
+		}
+	}()
+}


### PR DESCRIPTION
Submitting a review from the web client waited on three separate
round-trip sets to GitHub before the button stopped spinning:

1. ReprocessPR, called inline, fetched the PR again and fanned out over
   its comments, issue comments, reviews, commits, CI status, check runs
   and review threads before returning.
2. SubmitReview then served its reply from fetchPR with skipCache set,
   which is that same fan-out a second time.
3. The client discarded that reply and called handleSync(), whose SyncPR
   handler runs the identical forced refetch a third time.

Only the second one is work the reviewer is actually waiting for.

ReprocessPR now dispatches through ReprocessPRAsync: the sections it
rewrites are read by the dashboard, which refetches when it is opened,
and the reply the client renders comes from its own fresh fetch, so
nothing on the response path reads what the reprocess writes. A
reprocess already in flight for the same PR wins, since a second one
would fetch the same post-review state.

The client applies the SubmitReview reply directly instead of throwing
it away and re-syncing. SubmitReview picks up the ensurePostUpdateHooks
call that came with the sync it replaces; the hooks dispatch in
goroutines and are debounced per head SHA, so a review that changes no
commits pays nothing for it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RB8epegqq3uZu9x6QKoK8a