### PR TITLE
Paginate every PR data fetch on the read path

### DIFF
--- a/cmd/debug_comments/main.go
+++ b/cmd/debug_comments/main.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-
-	"github.com/google/go-github/v74/github"
 )
 
 func main() {
@@ -24,9 +22,8 @@ func main() {
 
 	client := git_tools.GetGithubClient()
 	ctx := context.Background()
-	opts := &github.PullRequestListCommentsOptions{}
 
-	comments, _, err := client.PullRequests.ListComments(ctx, owner, repo, number, opts)
+	comments, err := git_tools.ListAllPRComments(ctx, client, owner, repo, number)
 	if err != nil {
 		fmt.Printf("Error processing PR: %v\n", err)
 		os.Exit(1)

--- a/git_tools/git_tools.go
+++ b/git_tools/git_tools.go
@@ -121,8 +121,7 @@ func GetPRDiff(client *github.Client, owner string, repo string, pr_number int) 
 }
 
 func GetPRComments(client *github.Client, owner string, repo string, number int) ([]*github.PullRequestComment, error) {
-	opts := github.PullRequestListCommentsOptions{}
-	comments, _, err := client.PullRequests.ListComments(context.Background(), owner, repo, number, &opts)
+	comments, err := ListAllPRComments(context.Background(), client, owner, repo, number)
 	if err != nil {
 		// TODO: wump
 		// unwrap in production
@@ -635,16 +634,59 @@ func SubmitReply(client *github.Client, owner string, repo string, number int, b
 	return err
 }
 
+// GetCombinedStatus returns every commit status on a ref. The response is a
+// struct wrapping a paginated Statuses list, so a repo with more contexts than
+// one page would otherwise report CI as incomplete. Only Statuses accumulates;
+// the summary fields come from the first page.
 func GetCombinedStatus(client *github.Client, owner, repo, ref string) (*github.CombinedStatus, error) {
 	ctx := context.Background()
-	status, _, err := client.Repositories.GetCombinedStatus(ctx, owner, repo, ref, nil)
-	return status, err
+	var combined *github.CombinedStatus
+	opts := &github.ListOptions{PerPage: githubPageSize, Page: 1}
+	for i := 0; i < githubMaxPages; i++ {
+		status, resp, err := client.Repositories.GetCombinedStatus(ctx, owner, repo, ref, opts)
+		if err != nil {
+			return combined, err
+		}
+		if combined == nil {
+			combined = status
+		} else if status != nil {
+			combined.Statuses = append(combined.Statuses, status.Statuses...)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return combined, nil
+		}
+		opts.Page = resp.NextPage
+	}
+	slog.Warn("Paginated fetch hit the page cap; results are truncated",
+		"endpoint", "commits/status", "max_pages", githubMaxPages, "ref", ref)
+	return combined, nil
 }
 
+// GetCheckRuns returns every check run on a ref, for the same reason as
+// GetCombinedStatus: a busy repo has more than one page of checks, and a
+// truncated list silently misreports the PR's CI state.
 func GetCheckRuns(client *github.Client, owner, repo, ref string) (*github.ListCheckRunsResults, error) {
 	ctx := context.Background()
-	checkRuns, _, err := client.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, nil)
-	return checkRuns, err
+	var all *github.ListCheckRunsResults
+	opts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: githubPageSize, Page: 1}}
+	for i := 0; i < githubMaxPages; i++ {
+		checkRuns, resp, err := client.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, opts)
+		if err != nil {
+			return all, err
+		}
+		if all == nil {
+			all = checkRuns
+		} else if checkRuns != nil {
+			all.CheckRuns = append(all.CheckRuns, checkRuns.CheckRuns...)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return all, nil
+		}
+		opts.Page = resp.NextPage
+	}
+	slog.Warn("Paginated fetch hit the page cap; results are truncated",
+		"endpoint", "commits/check-runs", "max_pages", githubMaxPages, "ref", ref)
+	return all, nil
 }
 
 func CreateWorktree(repoDir, branch, worktreePath string) error {
@@ -1031,13 +1073,13 @@ func CalculateInteractionState(myLogin string, pr *github.PullRequest, reviews [
 	return state
 }
 
-// interactionPageSize / interactionMaxPages bound the paginated fetches behind
-// GetInteractionState. GitHub caps a PR's commit list at 250 entries, and a PR
-// with more than 500 comments is far past the point where any of this matters,
-// so five pages is plenty while keeping the worst case at five calls per list.
+// githubPageSize / githubMaxPages bound every paginated fetch in this package.
+// GitHub caps a PR's commit list at 250 entries, and a PR with more than 500
+// comments is far past the point where any of this matters, so five pages is
+// plenty while keeping the worst case at five calls per list.
 const (
-	interactionPageSize = 100
-	interactionMaxPages = 5
+	githubPageSize = 100
+	githubMaxPages = 5
 
 	// interactionStateConcurrency bounds how many candidate PRs have their
 	// interaction state fetched at once. Each GetInteractionState call fans
@@ -1047,24 +1089,92 @@ const (
 	interactionStateConcurrency = 8
 )
 
-// listAllPages walks the paginated endpoint fetch until it runs out of pages
-// (or hits interactionMaxPages), returning everything it collected. On error it
-// returns the pages gathered so far alongside the error, so callers can still
-// work with a partial history rather than falling back to nothing.
-func listAllPages[T any](fetch func(opts *github.ListOptions) ([]T, *github.Response, error)) ([]T, error) {
+// ListAllPages walks the paginated endpoint fetch until it runs out of pages (or
+// hits githubMaxPages), returning everything it collected. On error it returns
+// the pages gathered so far alongside the error, so callers can still work with
+// a partial history rather than falling back to nothing.
+//
+// Every GitHub list endpoint is paginated, defaults to 30 items per page, and
+// returns oldest-first. A caller that passes nil options therefore gets the
+// *start* of a PR's history and silently loses the newest entries — the newest
+// review, the latest push — which is the opposite of what any caller wants.
+// Route every list call through here rather than calling the client directly.
+//
+// label names the endpoint for the page-cap warning; truncating at githubMaxPages
+// is the same silent-data-loss failure this helper exists to prevent, so it is
+// logged rather than swallowed.
+func ListAllPages[T any](label string, fetch func(opts *github.ListOptions) ([]T, *github.Response, error)) ([]T, error) {
 	var all []T
-	opts := &github.ListOptions{PerPage: interactionPageSize, Page: 1}
-	for i := 0; i < interactionMaxPages; i++ {
+	opts := &github.ListOptions{PerPage: githubPageSize, Page: 1}
+	for i := 0; i < githubMaxPages; i++ {
 		page, resp, err := fetch(opts)
 		if err != nil {
 			return all, err
 		}
 		all = append(all, page...)
 		if resp == nil || resp.NextPage == 0 {
-			break
+			return all, nil
 		}
 		opts.Page = resp.NextPage
 	}
+	slog.Warn("Paginated fetch hit the page cap; results are truncated",
+		"endpoint", label, "max_pages", githubMaxPages, "per_page", githubPageSize, "collected", len(all))
+	return all, nil
+}
+
+// ListAllPRReviews returns every review on a PR, not just the first page.
+func ListAllPRReviews(ctx context.Context, client *github.Client, owner, repo string, number int) ([]*github.PullRequestReview, error) {
+	return ListAllPages("pulls/reviews", func(opts *github.ListOptions) ([]*github.PullRequestReview, *github.Response, error) {
+		return client.PullRequests.ListReviews(ctx, owner, repo, number, opts)
+	})
+}
+
+// ListAllPRComments returns every review comment (comment on code) on a PR.
+func ListAllPRComments(ctx context.Context, client *github.Client, owner, repo string, number int) ([]*github.PullRequestComment, error) {
+	return ListAllPages("pulls/comments", func(opts *github.ListOptions) ([]*github.PullRequestComment, *github.Response, error) {
+		return client.PullRequests.ListComments(ctx, owner, repo, number,
+			&github.PullRequestListCommentsOptions{ListOptions: *opts})
+	})
+}
+
+// ListAllIssueComments returns every conversation comment on a PR.
+func ListAllIssueComments(ctx context.Context, client *github.Client, owner, repo string, number int) ([]*github.IssueComment, error) {
+	return ListAllPages("issues/comments", func(opts *github.ListOptions) ([]*github.IssueComment, *github.Response, error) {
+		return client.Issues.ListComments(ctx, owner, repo, number,
+			&github.IssueListCommentsOptions{ListOptions: *opts})
+	})
+}
+
+// ListAllPRCommits returns every commit on a PR, up to GitHub's own 250 cap.
+func ListAllPRCommits(ctx context.Context, client *github.Client, owner, repo string, number int) ([]*github.RepositoryCommit, error) {
+	return ListAllPages("pulls/commits", func(opts *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
+		return client.PullRequests.ListCommits(ctx, owner, repo, number, opts)
+	})
+}
+
+// ListAllRequestedReviewers returns every pending reviewer on a PR. The endpoint
+// returns a struct holding two slices rather than a single list, so it needs its
+// own accumulation loop instead of ListAllPages.
+func ListAllRequestedReviewers(ctx context.Context, client *github.Client, owner, repo string, number int) (*github.Reviewers, error) {
+	all := &github.Reviewers{}
+	opts := &github.ListOptions{PerPage: githubPageSize, Page: 1}
+	for i := 0; i < githubMaxPages; i++ {
+		page, resp, err := client.PullRequests.ListReviewers(ctx, owner, repo, number, opts)
+		if err != nil {
+			return all, err
+		}
+		if page != nil {
+			all.Users = append(all.Users, page.Users...)
+			all.Teams = append(all.Teams, page.Teams...)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return all, nil
+		}
+		opts.Page = resp.NextPage
+	}
+	slog.Warn("Paginated fetch hit the page cap; results are truncated",
+		"endpoint", "pulls/requested_reviewers", "max_pages", githubMaxPages,
+		"users", len(all.Users), "teams", len(all.Teams))
 	return all, nil
 }
 
@@ -1115,15 +1225,13 @@ func GetInteractionState(owner, repo string, pr *github.PullRequest) Interaction
 
 	resultChan := make(chan result, 4)
 
-	// Every list below is paginated. GitHub's default page size is 30, and all of
-	// these endpoints return oldest-first, so a single unpaginated call on an
-	// active PR hands back only the *start* of its history: my latest review, the
-	// reply that is waiting on me, and the newest commit all fall off the end.
-	// That silently skews every timestamp this state is built from.
+	// Every list below is paginated; see ListAllPages for why calling the client
+	// directly loses the newest entries. These fetches share the timeout ctx above
+	// rather than using the ListAll* helpers, which fetch on context.Background().
 
 	// Fetch Reviews
 	go func() {
-		reviews, err := listAllPages(func(opts *github.ListOptions) ([]*github.PullRequestReview, *github.Response, error) {
+		reviews, err := ListAllPages("pulls/reviews", func(opts *github.ListOptions) ([]*github.PullRequestReview, *github.Response, error) {
 			return client.PullRequests.ListReviews(ctx, owner, repo, *pr.Number, opts)
 		})
 		if err != nil {
@@ -1134,7 +1242,7 @@ func GetInteractionState(owner, repo string, pr *github.PullRequest) Interaction
 
 	// Fetch Review Comments
 	go func() {
-		reviewComments, err := listAllPages(func(opts *github.ListOptions) ([]*github.PullRequestComment, *github.Response, error) {
+		reviewComments, err := ListAllPages("pulls/comments", func(opts *github.ListOptions) ([]*github.PullRequestComment, *github.Response, error) {
 			return client.PullRequests.ListComments(ctx, owner, repo, *pr.Number,
 				&github.PullRequestListCommentsOptions{ListOptions: *opts})
 		})
@@ -1146,7 +1254,7 @@ func GetInteractionState(owner, repo string, pr *github.PullRequest) Interaction
 
 	// Fetch Issue Comments
 	go func() {
-		issueComments, err := listAllPages(func(opts *github.ListOptions) ([]*github.IssueComment, *github.Response, error) {
+		issueComments, err := ListAllPages("issues/comments", func(opts *github.ListOptions) ([]*github.IssueComment, *github.Response, error) {
 			return client.Issues.ListComments(ctx, owner, repo, *pr.Number,
 				&github.IssueListCommentsOptions{ListOptions: *opts})
 		})
@@ -1158,7 +1266,7 @@ func GetInteractionState(owner, repo string, pr *github.PullRequest) Interaction
 
 	// Fetch Commits
 	go func() {
-		commits, err := listAllPages(func(opts *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
+		commits, err := ListAllPages("pulls/commits", func(opts *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
 			return client.PullRequests.ListCommits(ctx, owner, repo, *pr.Number, opts)
 		})
 		if err != nil {

--- a/git_tools/identity.go
+++ b/git_tools/identity.go
@@ -85,7 +85,7 @@ func GetMyTeamRefs() []string {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	teams, err := listAllPages(func(opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
+	teams, err := ListAllPages("user/teams", func(opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
 		return GetGithubClient().Teams.ListUserTeams(ctx, opts)
 	})
 	if err != nil {

--- a/git_tools/pagination_test.go
+++ b/git_tools/pagination_test.go
@@ -1,0 +1,232 @@
+package git_tools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// pagedServer serves `total` items from a GitHub-style list endpoint, honoring the
+// per_page and page query params and emitting the Link headers go-github reads to
+// discover the next page. Each item is rendered by item(i) for a 1-based index.
+//
+// It records every per_page value it was asked for so tests can assert the caller
+// actually requested a full page instead of silently accepting GitHub's default of
+// 30 — passing nil options is exactly the bug these tests guard against.
+type pagedServer struct {
+	server   *httptest.Server
+	perPages []string
+	pageHits int
+}
+
+func newPagedServer(t *testing.T, path string, total int, item func(i int) string) *pagedServer {
+	t.Helper()
+	ps := &pagedServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		ps.perPages = append(ps.perPages, q.Get("per_page"))
+		ps.pageHits++
+
+		// Mirror GitHub: absent per_page means 30.
+		perPage := 30
+		if v := q.Get("per_page"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				perPage = n
+			}
+		}
+		page := 1
+		if v := q.Get("page"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				page = n
+			}
+		}
+
+		start := (page-1)*perPage + 1
+		end := start + perPage - 1
+		if end > total {
+			end = total
+		}
+		items := []string{}
+		for i := start; i <= end; i++ {
+			items = append(items, item(i))
+		}
+
+		if end < total {
+			next := fmt.Sprintf("%s%s?page=%d&per_page=%d", ps.server.URL, path, page+1, perPage)
+			w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, next))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, "[%s]", strings.Join(items, ","))
+	})
+	ps.server = httptest.NewServer(mux)
+	t.Cleanup(ps.server.Close)
+	return ps
+}
+
+func (ps *pagedServer) client(t *testing.T) *github.Client {
+	t.Helper()
+	base, err := url.Parse(ps.server.URL + "/")
+	if err != nil {
+		t.Fatalf("parsing base URL: %v", err)
+	}
+	c := github.NewClient(nil)
+	c.BaseURL = base
+	return c
+}
+
+// TestListAllPRReviewsFetchesEveryPage is the regression guard for the bug where
+// a PR with more than 30 reviews had its newest reviews silently dropped. The
+// reviews endpoint returns oldest-first, so a single unpaginated call kept only
+// the oldest 30 — hiding the most recent CHANGES_REQUESTED from the client.
+func TestListAllPRReviewsFetchesEveryPage(t *testing.T) {
+	const total = 37
+	ps := newPagedServer(t, "/repos/owner/repo/pulls/30195/reviews", total, func(i int) string {
+		state := "COMMENTED"
+		if i == total {
+			state = "CHANGES_REQUESTED"
+		}
+		return fmt.Sprintf(`{"id":%d,"state":%q,"user":{"login":"reviewer%d"}}`, i, state, i)
+	})
+
+	reviews, err := ListAllPRReviews(context.Background(), ps.client(t), "owner", "repo", 30195)
+	if err != nil {
+		t.Fatalf("ListAllPRReviews returned error: %v", err)
+	}
+
+	if len(reviews) != total {
+		t.Errorf("got %d reviews, want %d — pagination dropped %d", len(reviews), total, total-len(reviews))
+	}
+
+	// The newest review is the one that matters and the one truncation loses first.
+	var newest *github.PullRequestReview
+	for _, r := range reviews {
+		if r.GetID() == int64(total) {
+			newest = r
+		}
+	}
+	if newest == nil {
+		t.Fatalf("newest review (id %d) missing; the last page was never fetched", total)
+	}
+	if got := newest.GetState(); got != "CHANGES_REQUESTED" {
+		t.Errorf("newest review state = %q, want CHANGES_REQUESTED", got)
+	}
+
+	// Guard the root cause directly: a nil-options call sends no per_page and
+	// silently caps at 30. Every request must ask for a full page.
+	for i, pp := range ps.perPages {
+		if pp != strconv.Itoa(githubPageSize) {
+			t.Errorf("request %d sent per_page=%q, want %d (nil options would send none)", i, pp, githubPageSize)
+		}
+	}
+}
+
+func TestListAllPRReviewsSinglePage(t *testing.T) {
+	ps := newPagedServer(t, "/repos/owner/repo/pulls/1/reviews", 3, func(i int) string {
+		return fmt.Sprintf(`{"id":%d,"state":"APPROVED"}`, i)
+	})
+
+	reviews, err := ListAllPRReviews(context.Background(), ps.client(t), "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("ListAllPRReviews returned error: %v", err)
+	}
+	if len(reviews) != 3 {
+		t.Errorf("got %d reviews, want 3", len(reviews))
+	}
+	// A PR that fits in one page must not cost a second call.
+	if ps.pageHits != 1 {
+		t.Errorf("made %d requests for a single-page result, want 1", ps.pageHits)
+	}
+}
+
+func TestListAllPagesStopsAtPageCap(t *testing.T) {
+	// More data than the cap allows: the helper must return the bounded prefix
+	// rather than looping forever.
+	total := githubPageSize*githubMaxPages + 50
+	ps := newPagedServer(t, "/repos/owner/repo/pulls/2/commits", total, func(i int) string {
+		return fmt.Sprintf(`{"sha":"sha%d"}`, i)
+	})
+
+	commits, err := ListAllPRCommits(context.Background(), ps.client(t), "owner", "repo", 2)
+	if err != nil {
+		t.Fatalf("ListAllPRCommits returned error: %v", err)
+	}
+	if want := githubPageSize * githubMaxPages; len(commits) != want {
+		t.Errorf("got %d commits, want %d (the page cap)", len(commits), want)
+	}
+	if ps.pageHits != githubMaxPages {
+		t.Errorf("made %d requests, want %d", ps.pageHits, githubMaxPages)
+	}
+}
+
+func TestListAllPagesReturnsPartialResultsOnError(t *testing.T) {
+	// Page 1 succeeds, page 2 fails. Callers prefer a partial history to nothing,
+	// but the error must still surface so the failure is not mistaken for "no data".
+	var hits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls/3/reviews", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if hits > 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		next := fmt.Sprintf("%s?page=2&per_page=%d", r.URL.Path, githubPageSize)
+		w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, next))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"id":1,"state":"COMMENTED"}]`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	base, _ := url.Parse(srv.URL + "/")
+	c := github.NewClient(nil)
+	c.BaseURL = base
+
+	reviews, err := ListAllPRReviews(context.Background(), c, "owner", "repo", 3)
+	if err == nil {
+		t.Fatal("expected an error when a page fetch fails")
+	}
+	if len(reviews) != 1 {
+		t.Errorf("got %d reviews alongside the error, want the 1 already collected", len(reviews))
+	}
+}
+
+func TestListAllRequestedReviewersAccumulatesPages(t *testing.T) {
+	// This endpoint returns a struct of two slices rather than a list, so it has
+	// its own loop; assert both slices accumulate across pages.
+	var hits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls/4/requested_reviewers", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		if hits == 1 {
+			next := fmt.Sprintf("%s?page=2&per_page=%d", r.URL.Path, githubPageSize)
+			w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, next))
+			fmt.Fprint(w, `{"users":[{"login":"alice"}],"teams":[{"slug":"team-a"}]}`)
+			return
+		}
+		fmt.Fprint(w, `{"users":[{"login":"bob"}],"teams":[{"slug":"team-b"}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	base, _ := url.Parse(srv.URL + "/")
+	c := github.NewClient(nil)
+	c.BaseURL = base
+
+	reviewers, err := ListAllRequestedReviewers(context.Background(), c, "owner", "repo", 4)
+	if err != nil {
+		t.Fatalf("ListAllRequestedReviewers returned error: %v", err)
+	}
+	if len(reviewers.Users) != 2 {
+		t.Errorf("got %d users, want 2 (pages did not accumulate)", len(reviewers.Users))
+	}
+	if len(reviewers.Teams) != 2 {
+		t.Errorf("got %d teams, want 2 (pages did not accumulate)", len(reviewers.Teams))
+	}
+}

--- a/server/renderer.go
+++ b/server/renderer.go
@@ -1233,14 +1233,13 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 	}
 	if githubComments == nil {
 		missState.missedFields = append(missState.missedFields, "comments")
-		opts := github.PullRequestListCommentsOptions{}
 		var err error
-		githubComments, _, err = client.PullRequests.ListComments(ctx, owner, repo, number, &opts)
+		githubComments, err = git_tools.ListAllPRComments(ctx, client, owner, repo, number)
 		if err != nil {
 			slog.Error("Error fetching PR review comments", "pr", number, "repo", repo, "error", err)
 		}
 
-		issueComments, _, err := client.Issues.ListComments(ctx, owner, repo, number, nil)
+		issueComments, err := git_tools.ListAllIssueComments(ctx, client, owner, repo, number)
 		if err != nil {
 			slog.Error("Error fetching PR issue comments", "pr", number, "repo", repo, "error", err)
 		}
@@ -1298,7 +1297,7 @@ func GetPRDetails(owner string, repo string, number int, skipCache bool) (*PRDet
 	}
 	if commits == nil {
 		missState.missedFields = append(missState.missedFields, "commits")
-		ghCommits, _, err := client.PullRequests.ListCommits(ctx, owner, repo, number, nil)
+		ghCommits, err := git_tools.ListAllPRCommits(ctx, client, owner, repo, number)
 		if err != nil {
 			slog.Error("Error fetching commits", "error", err)
 		} else {
@@ -1798,9 +1797,8 @@ func processPRDiffWithComments(client *github.Client, owner string, repo string,
 
 	// Not in cache or error occurred, fetch from API
 	if comments == nil {
-		opts := github.PullRequestListCommentsOptions{}
 		var apiErr error
-		githubComments, _, apiErr = client.PullRequests.ListComments(context.Background(), owner, repo, number, &opts)
+		githubComments, apiErr = git_tools.ListAllPRComments(context.Background(), client, owner, repo, number)
 		if apiErr != nil {
 			slog.Error("Error getting Comments", "pr", number, "repo", repo, "error", apiErr)
 			return diff, 0
@@ -2277,7 +2275,7 @@ func GetRequestedReviewers(owner, repo string, number int, skipCache bool) (*git
 		}
 	}
 
-	reviewers, _, err := client.PullRequests.ListReviewers(context.Background(), owner, repo, number, nil)
+	reviewers, err := git_tools.ListAllRequestedReviewers(context.Background(), client, owner, repo, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2314,7 +2312,7 @@ func GetPRReviews(owner, repo string, number int, skipCache bool) ([]ReviewJSON,
 	}
 
 	client := git_tools.GetGithubClient()
-	ghReviews, _, err := client.PullRequests.ListReviews(context.Background(), owner, repo, number, nil)
+	ghReviews, err := git_tools.ListAllPRReviews(context.Background(), client, owner, repo, number)
 	if err != nil {
 		return nil, err
 	}

--- a/workflows/manager.go
+++ b/workflows/manager.go
@@ -990,8 +990,7 @@ func fetchAuxDataForPR(client *github.Client,
 			combined := make([]*github.PullRequestComment, len(prComments))
 			copy(combined, prComments)
 			apiCalls.IssueComments.Add(1)
-			issueComments, _, err := client.Issues.ListComments(
-				context.Background(), key.Owner, key.Repo, key.Number, nil)
+			issueComments, err := git_tools.ListAllIssueComments(context.Background(), client, key.Owner, key.Repo, key.Number)
 			if err == nil {
 				for _, ic := range issueComments {
 					combined = append(combined, convertIssueToPRComment(ic))
@@ -1044,8 +1043,7 @@ func fetchAuxDataForPR(client *github.Client,
 		go func() {
 			defer wg.Done()
 			apiCalls.Reviews.Add(1)
-			reviews, _, err := client.PullRequests.ListReviews(
-				context.Background(), key.Owner, key.Repo, key.Number, nil)
+			reviews, err := git_tools.ListAllPRReviews(context.Background(), client, key.Owner, key.Repo, key.Number)
 			if err != nil {
 				// Nothing gets written to PRReviews when this fails, so the next
 				// time the UI opens this PR it logs a "reviews" cache miss.
@@ -1082,8 +1080,7 @@ func fetchAuxDataForPR(client *github.Client,
 		go func() {
 			defer wg.Done()
 			apiCalls.Commits.Add(1)
-			commits, _, err := client.PullRequests.ListCommits(
-				context.Background(), key.Owner, key.Repo, key.Number, nil)
+			commits, err := git_tools.ListAllPRCommits(context.Background(), client, key.Owner, key.Repo, key.Number)
 			if err != nil {
 				slog.Warn("Failed to fetch commits for pre-fetch", "pr", key.Number, "error", err)
 				return


### PR DESCRIPTION
## The bug

GitHub's list endpoints are paginated, default to **30 items per page**, and return **oldest-first**. Every fetch behind `GetPRDetails` passed `nil` or an empty options struct and discarded the `*github.Response`, so an active PR was served the *start* of its history and silently lost the newest entries.

Reproduced against `multimediallc/chaturbate#29187`:

| data | server saw | GitHub actually has |
|---|---|---|
| reviews | **30** (newest: Aug 21 13:58) | **37** (newest: Aug 24 22:28) |
| review comments | **30** (newest: **Jul 31** 13:32) | **48** (newest: Aug 24 22:27) |

Two `APPROVED` reviews submitted on Aug 24 were invisible to the app.

## Why Sync said "already up to date"

The same truncation also defeats the change detector. `SyncPR` reports `updated` via `syncDetectedChanges`, which compares the head SHA and the set of cached comment IDs. On that PR:

- the head SHA hasn't moved since Aug 21, and
- the cached comment set is frozen at the same oldest 30 on every sync, so no new IDs ever appear.

So `updated` was always `false` and the client showed `Synced — already up to date` while the PR was three days stale.

## What this changes

PR #196 fixed this for the interaction-state fetches behind the WaitingOnMe filter, but the read path that actually renders a review was never converted. This promotes that helper to an exported `ListAllPages` and routes every list call through a named `ListAll*` wrapper:

- `ListAllPRReviews`, `ListAllPRComments`, `ListAllIssueComments`, `ListAllPRCommits`, `ListAllRequestedReviewers`
- `GetCombinedStatus` and `GetCheckRuns` wrap a paginated list inside a struct, so they accumulate in their own loops
- callers updated in `server/renderer.go` (`GetPRDetails`, `GetPRReviews`, `GetRequestedReviewers`, `processPRDiffWithComments`), `workflows/manager.go` (`fetchAuxDataForPR`), `git_tools.GetPRComments`, and `cmd/debug_comments`

Hitting the page cap is now logged rather than swallowed — silent data loss is the exact failure this helper exists to prevent.

## Tests

`git_tools/pagination_test.go` stands up a GitHub-style paged `httptest` server that honors `per_page`/`page` and emits `Link` headers. It asserts both that all items are collected across pages and that callers actually request a full page — passing `nil` options is precisely the bug being guarded against.

`go build ./...` clean; `go test ./...` passes across all 13 packages.

## Also fixed here

**`GetCIStatus`** (`git_tools/git_tools.go`) passed `ListWorkflowRunsOptions` with no embedded `ListOptions` and got GitHub's default 30 runs. This endpoint is newest-first, so unlike the lists above truncation drops the *oldest* runs — but it still loses a whole workflow, because `ProcessWorkflowRuns` keeps the latest run per name: a workflow whose most recent run has been pushed past the window by newer runs of other workflows vanishes from the status list and stops counting toward `hasFailure`/`allSuccess`.

It now asks for a full 100-run page, but **deliberately stays at one page** rather than using `ListAllPages`. Latest-per-name over a branch's full history would resurrect workflows since deleted from the repo and let their last, possibly failed, run drive the overall status forever. A wider single window avoids both failure modes at the same one API call as before.

## Not covered here — one follow-up

**`syncDetectedChanges` never looks at reviews** (`server/server.go`). Even with this fix, a bare approval still reports "up to date": both Aug-24 approvals on #29187 have `body_len=0` and `inline_comments=0`, so they produce no comment ID and no SHA change. Tracked separately.
