### PR TITLE
Count new and dismissed reviews as sync changes

### DIFF
--- a/bun_client/frontend/src/components/Review.tsx
+++ b/bun_client/frontend/src/components/Review.tsx
@@ -310,7 +310,7 @@ export default function Review({
             applyPRResponse(res);
             loadPluginOutputs();
             if (res.updated) {
-                showToast('Synced — new commits or comments pulled in', 'success');
+                showToast('Synced — new commits, comments, or reviews pulled in', 'success');
             } else {
                 showToast('Synced — already up to date', 'info');
             }

--- a/server/server.go
+++ b/server/server.go
@@ -666,8 +666,7 @@ func (h *RPCHandler) SyncPR(args *SyncPRArgs, reply *SyncPRReply) error {
 	// Snapshot the cached state so we can tell the client whether the sync
 	// actually pulled in anything new. The fresh fetch below overwrites these
 	// cache entries.
-	_, oldSHA, _ := config.C().DB.GetPullRequest(args.Number, args.Repo)
-	oldCommentsJSON, _ := config.C().DB.GetPRComments(args.Number, args.Repo)
+	before := readSyncSnapshot(args.Repo, args.Number)
 
 	details, content, err := h.fetchPR(args.Owner, args.Repo, args.Number, true)
 	if err != nil {
@@ -675,27 +674,74 @@ func (h *RPCHandler) SyncPR(args *SyncPRArgs, reply *SyncPRReply) error {
 	}
 	ensurePostUpdateHooks(args.Owner, args.Repo, args.Number, details)
 
-	_, newSHA, _ := config.C().DB.GetPullRequest(args.Number, args.Repo)
-	newCommentsJSON, _ := config.C().DB.GetPRComments(args.Number, args.Repo)
-	reply.Updated = syncDetectedChanges(oldSHA, newSHA, oldCommentsJSON, newCommentsJSON)
+	reply.Updated = syncDetectedChanges(before, readSyncSnapshot(args.Repo, args.Number))
 
 	reply.populate(details, content, args.Owner, args.Repo, args.Number)
 	return nil
 }
 
-// syncDetectedChanges reports whether a sync brought in a new head SHA or new
-// comments compared to the previously cached state.
-func syncDetectedChanges(oldSHA, newSHA, oldCommentsJSON, newCommentsJSON string) bool {
-	if oldSHA != newSHA {
+// syncSnapshot is the cached state of a PR at a single moment. Grouping the
+// fields keeps the before/after pair from becoming a run of same-typed string
+// arguments that is easy to transpose at the call site.
+type syncSnapshot struct {
+	sha          string
+	commentsJSON string
+	reviewsJSON  string
+}
+
+func readSyncSnapshot(repo string, number int) syncSnapshot {
+	_, sha, _ := config.C().DB.GetPullRequest(number, repo)
+	commentsJSON, _ := config.C().DB.GetPRComments(number, repo)
+	reviewsJSON, _ := config.C().DB.GetPRReviews(number, repo)
+	return syncSnapshot{sha: sha, commentsJSON: commentsJSON, reviewsJSON: reviewsJSON}
+}
+
+// syncDetectedChanges reports whether a sync brought in a new head SHA, a new
+// comment, or a new or changed review.
+//
+// Reviews have to be checked in their own right. A review is not a comment: an
+// approval carries no inline comment and usually no body at all, so it adds no
+// entry to the PRComments cache and, on a PR whose head has not moved, leaves
+// every other input to this function identical. Checking only the SHA and the
+// comment IDs meant the two approvals that landed on an active PR were reported
+// to the client as "already up to date".
+func syncDetectedChanges(before, after syncSnapshot) bool {
+	if before.sha != after.sha {
 		return true
 	}
-	oldIDs := cachedCommentIDs(oldCommentsJSON)
-	for id := range cachedCommentIDs(newCommentsJSON) {
+	oldIDs := cachedCommentIDs(before.commentsJSON)
+	for id := range cachedCommentIDs(after.commentsJSON) {
 		if _, ok := oldIDs[id]; !ok {
 			return true
 		}
 	}
+	// Compare state as well as identity. A dismissal rewrites a review in
+	// place, keeping its ID, and that is exactly the case where the PR is
+	// waiting on the reviewer again — an ID-only check would call it unchanged.
+	oldReviews := cachedReviewStates(before.reviewsJSON)
+	for id, state := range cachedReviewStates(after.reviewsJSON) {
+		if prev, ok := oldReviews[id]; !ok || prev != state {
+			return true
+		}
+	}
 	return false
+}
+
+// cachedReviewStates maps review ID to state from a raw PRReviews cache entry.
+// Returns an empty set for empty or malformed JSON.
+func cachedReviewStates(reviewsJSON string) map[int64]string {
+	states := make(map[int64]string)
+	if reviewsJSON == "" {
+		return states
+	}
+	var reviews []ReviewJSON
+	if err := json.Unmarshal([]byte(reviewsJSON), &reviews); err != nil {
+		return states
+	}
+	for _, r := range reviews {
+		states[r.ID] = r.State
+	}
+	return states
 }
 
 // cachedCommentIDs extracts the GitHub comment IDs from a raw PRComments cache

--- a/server/sync_test.go
+++ b/server/sync_test.go
@@ -25,6 +25,21 @@ func commentsJSONWithIDs(t *testing.T, ids ...int64) string {
 	return string(raw)
 }
 
+// reviewsJSONWith builds a PRReviews cache entry from id/state pairs, matching
+// the format UpsertPRReviews stores.
+func reviewsJSONWith(t *testing.T, idStates map[int64]string) string {
+	t.Helper()
+	reviews := []ReviewJSON{}
+	for id, state := range idStates {
+		reviews = append(reviews, ReviewJSON{ID: id, State: state, User: "reviewer"})
+	}
+	raw, err := json.Marshal(reviews)
+	if err != nil {
+		t.Fatalf("failed to marshal reviews: %v", err)
+	}
+	return string(raw)
+}
+
 func TestSyncDetectedChanges(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -32,6 +47,8 @@ func TestSyncDetectedChanges(t *testing.T) {
 		newSHA          string
 		oldCommentsJSON string
 		newCommentsJSON string
+		oldReviewsJSON  string
+		newReviewsJSON  string
 		expected        bool
 	}{
 		{
@@ -92,13 +109,69 @@ func TestSyncDetectedChanges(t *testing.T) {
 			newCommentsJSON: commentsJSONWithIDs(t, 1, 2),
 			expected:        true,
 		},
+		{
+			// The reported bug: an approval carries no body and no inline
+			// comment, so nothing but the reviews cache changes.
+			name:           "bare approval with no comment and no push",
+			oldSHA:         "abc123",
+			newSHA:         "abc123",
+			oldReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "COMMENTED"}),
+			newReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "COMMENTED", 2: "APPROVED"}),
+			expected:       true,
+		},
+		{
+			name:           "first review on PR with empty cache entry",
+			oldSHA:         "abc123",
+			newSHA:         "abc123",
+			oldReviewsJSON: "",
+			newReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "APPROVED"}),
+			expected:       true,
+		},
+		{
+			// A dismissal keeps the review's ID and rewrites its state, and it
+			// puts the PR back on the reviewer's plate.
+			name:           "existing review dismissed in place",
+			oldSHA:         "abc123",
+			newSHA:         "abc123",
+			oldReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "APPROVED"}),
+			newReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "DISMISSED"}),
+			expected:       true,
+		},
+		{
+			name:           "unchanged reviews",
+			oldSHA:         "abc123",
+			newSHA:         "abc123",
+			oldReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "APPROVED", 2: "COMMENTED"}),
+			newReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "APPROVED", 2: "COMMENTED"}),
+			expected:       false,
+		},
+		{
+			name:           "review deleted is not an update",
+			oldSHA:         "abc123",
+			newSHA:         "abc123",
+			oldReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "APPROVED", 2: "COMMENTED"}),
+			newReviewsJSON: reviewsJSONWith(t, map[int64]string{1: "APPROVED"}),
+			expected:       false,
+		},
+		{
+			name:            "comments and reviews both unchanged",
+			oldSHA:          "abc123",
+			newSHA:          "abc123",
+			oldCommentsJSON: commentsJSONWithIDs(t, 1, 2),
+			newCommentsJSON: commentsJSONWithIDs(t, 1, 2),
+			oldReviewsJSON:  reviewsJSONWith(t, map[int64]string{1: "APPROVED"}),
+			newReviewsJSON:  reviewsJSONWith(t, map[int64]string{1: "APPROVED"}),
+			expected:        false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := syncDetectedChanges(tt.oldSHA, tt.newSHA, tt.oldCommentsJSON, tt.newCommentsJSON)
+			before := syncSnapshot{sha: tt.oldSHA, commentsJSON: tt.oldCommentsJSON, reviewsJSON: tt.oldReviewsJSON}
+			after := syncSnapshot{sha: tt.newSHA, commentsJSON: tt.newCommentsJSON, reviewsJSON: tt.newReviewsJSON}
+			got := syncDetectedChanges(before, after)
 			if got != tt.expected {
-				t.Errorf("syncDetectedChanges(%q, %q, ...) = %v, want %v", tt.oldSHA, tt.newSHA, got, tt.expected)
+				t.Errorf("syncDetectedChanges(%q -> %q, ...) = %v, want %v", tt.oldSHA, tt.newSHA, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up to #223. That PR fixes the *truncation* that hid new reviews; this one fixes the *change detection* that reported them as nothing new.

## The bug

`SyncPR` decides whether the sync brought anything in via `syncDetectedChanges`, which compared exactly two things: the head SHA, and the set of cached comment IDs. Reviews were never part of the check.

A review is not a comment. An approval carries no inline comment and usually no body at all, so it adds nothing to the `PRComments` cache. On a PR whose head hasn't moved, every input to the check is identical and the client is told `Synced — already up to date`.

That is exactly what happened on `multimediallc/chaturbate#29187`:

```
review 5010965036: mikhail-mmlc  body_len=0  inline_comments=0
review 5011305009: jkim-mm       body_len=0  inline_comments=0
```

Two approvals, both invisible to a comment-ID comparison, on a branch whose head SHA hadn't moved in three days.

This is independent of #223 — even with pagination fixed, a bare approval still produces no comment ID and no SHA change, so Sync would keep saying "up to date".

## The fix

Compare the `PRReviews` cache as well, on **state as well as identity**. The state term matters on its own: a dismissal rewrites a review in place and keeps its ID, and that is precisely the case where the PR is waiting on the reviewer again — `MyReviewDismissed` in `git_tools.InteractionState` already models this. An ID-only check would call it unchanged.

The before/after fields are grouped into a `syncSnapshot` rather than growing the signature to six same-typed strings that would be easy to transpose at the call site.

The client toast now names reviews alongside commits and comments, so the success message matches what is actually detected.

## Tests

`TestSyncDetectedChanges` gains six cases covering the reported bug directly (bare approval, no comment, no push), a first review against an empty cache, in-place dismissal, unchanged reviews, review deletion, and comments-and-reviews-both-unchanged. The existing comment and SHA cases are preserved.

`go build ./...` clean, `go test ./...` passes across all 13 packages, and `bun run lint` / `format:check` / `type-check` all pass.

## Deliberately not treated as changes

Comment deletion and review deletion both stay `false`, matching the existing behavior for comments — a sync that removes something has not brought anything in for you to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)