### PR TITLE
Widen the workflow-run window behind GetCIStatus

### DIFF
--- a/git_tools/git_tools.go
+++ b/git_tools/git_tools.go
@@ -791,7 +791,14 @@ func GetCIStatus(owner string, repo string, branch string) CIStatusInfo {
 		return val.(CIStatusInfo)
 	}
 
-	client := GetGithubClient()
+	info := ciStatusWithClient(GetGithubClient(), owner, repo, branch)
+	GlobalCache.Set(cacheKey, info, 5*time.Minute)
+	return info
+}
+
+// ciStatusWithClient holds the fetch itself, split out from the cache lookup so
+// tests can point it at a stub server without reaching for a real token.
+func ciStatusWithClient(client *github.Client, owner string, repo string, branch string) CIStatusInfo {
 	// branch typically comes as "username:branch_name" from GitHub API
 	branchParts := strings.Split(branch, ":")
 	apiBranch := branch
@@ -799,7 +806,23 @@ func GetCIStatus(owner string, repo string, branch string) CIStatusInfo {
 		apiBranch = branchParts[1]
 	}
 
-	opts := github.ListWorkflowRunsOptions{Branch: apiBranch}
+	// Ask for a full page. This endpoint returns runs newest-first, so the
+	// default of 30 is a window over roughly the last handful of pushes: a
+	// workflow that ran early on the branch and has not re-run since falls out
+	// of it and vanishes from the status list entirely, taking its conclusion
+	// out of the hasFailure/allSuccess tally below.
+	//
+	// Deliberately one page rather than a ListAllPages walk. ProcessWorkflowRuns
+	// keeps the latest run per workflow *name* over whatever it is handed, so
+	// walking the branch's full history would resurrect workflows that have
+	// since been deleted from the repo and let their last, possibly failed, run
+	// drive the overall status forever. A single 100-run window is the wider
+	// net that does not reach back that far, and it costs the same one API call
+	// as today.
+	opts := github.ListWorkflowRunsOptions{
+		Branch:      apiBranch,
+		ListOptions: github.ListOptions{PerPage: githubPageSize},
+	}
 	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(context.Background(), owner, repo, &opts)
 
 	if err != nil {
@@ -863,9 +886,7 @@ func GetCIStatus(owner string, repo string, branch string) CIStatusInfo {
 		overallStatus = "DONE"
 	}
 
-	info := CIStatusInfo{Statuses: statuses, OverallStatus: overallStatus}
-	GlobalCache.Set(cacheKey, info, 5*time.Minute)
-	return info
+	return CIStatusInfo{Statuses: statuses, OverallStatus: overallStatus}
 }
 
 func ProcessWorkflowRuns(runs []*github.WorkflowRun) []*github.WorkflowRun {

--- a/git_tools/pagination_test.go
+++ b/git_tools/pagination_test.go
@@ -230,3 +230,80 @@ func TestListAllRequestedReviewersAccumulatesPages(t *testing.T) {
 		t.Errorf("got %d teams, want 2 (pages did not accumulate)", len(reviewers.Teams))
 	}
 }
+
+// TestCIStatusRequestsFullPageOfRuns guards the workflow-runs window. This
+// endpoint returns runs newest-first, so unlike the reviews and comments lists
+// the default page size does not drop the *newest* data — it drops the oldest.
+// That still loses a whole workflow: ProcessWorkflowRuns keeps the latest run
+// per name, so a workflow whose most recent run has been pushed past the window
+// by newer runs of other workflows disappears from the status list, and its
+// conclusion stops counting toward the overall status.
+func TestCIStatusRequestsFullPageOfRuns(t *testing.T) {
+	const total = 40
+	// nightlyAt is inside a 100-run page but outside the default 30-run one.
+	const nightlyAt = 35
+
+	var perPages []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		perPages = append(perPages, q.Get("per_page"))
+		if got := q.Get("branch"); got != "feature" {
+			t.Errorf("branch = %q, want %q (the user: prefix must be stripped)", got, "feature")
+		}
+
+		perPage := 30
+		if v := q.Get("per_page"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				perPage = n
+			}
+		}
+		if perPage > total {
+			perPage = total
+		}
+
+		// Index 1 is the newest run, matching GitHub's ordering.
+		runs := []string{}
+		for i := 1; i <= perPage; i++ {
+			name := "CI"
+			if i == nightlyAt {
+				name = "Nightly"
+			}
+			runs = append(runs, fmt.Sprintf(
+				`{"id":%d,"name":%q,"status":"completed","conclusion":"success","created_at":%q}`,
+				i, name, fmt.Sprintf("2026-08-%02dT00:00:00Z", 1+(total-i)%28)))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"total_count":%d,"workflow_runs":[%s]}`, total, strings.Join(runs, ","))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	base, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("parsing base URL: %v", err)
+	}
+	client := github.NewClient(nil)
+	client.BaseURL = base
+
+	info := ciStatusWithClient(client, "owner", "repo", "someuser:feature")
+
+	for i, pp := range perPages {
+		if pp != strconv.Itoa(githubPageSize) {
+			t.Errorf("request %d sent per_page=%q, want %d (nil ListOptions would send none)", i, pp, githubPageSize)
+		}
+	}
+
+	var sawNightly bool
+	for _, s := range info.Statuses {
+		if strings.Contains(s, "Nightly") {
+			sawNightly = true
+		}
+	}
+	if !sawNightly {
+		t.Errorf("Nightly missing from statuses %v; run %d fell outside the requested page", info.Statuses, nightlyAt)
+	}
+	if info.OverallStatus != "DONE" {
+		t.Errorf("OverallStatus = %q, want DONE (every run succeeded)", info.OverallStatus)
+	}
+}


### PR DESCRIPTION
Split out of #223 — this commit was pushed to that branch shortly after it was merged, so it did not land.

> **Stacked on #225** (which unbreaks a red `main`). Base will retarget to `main` once #225 merges.

## The bug

`ListRepositoryWorkflowRuns` was called with no embedded `ListOptions`, so it returned GitHub's default 30 runs.

Unlike the reviews and comments lists, this endpoint is **newest-first**, so truncation drops the *oldest* runs rather than the newest. It still loses a whole workflow: `ProcessWorkflowRuns` keeps the latest run per workflow *name*, so a workflow whose most recent run has been pushed past the window by newer runs of other workflows disappears from the status list entirely — and its conclusion stops counting toward `hasFailure`/`allSuccess`.

Measured on `chaturbate` branch `feature/block_non_falcon`: 183 runs across 6 workflows on that branch alone, against a 30-run window.

## Why one page and not `ListAllPages`

Deliberate. `ProcessWorkflowRuns` takes latest-per-name over whatever it is handed, so walking a branch's full history would resurrect workflows that have since been **deleted from the repo** and let their last, possibly failed, run drive the overall status forever — turning a truncation bug into a permanent false `TODO` for the CI filters.

A single 100-run page is the wider net that does not reach back that far, and it costs the same one API call as today.

## Testable seam

The fetch is split into `ciStatusWithClient` so the window can be tested against a stub server instead of requiring a real token. `GetCIStatus` keeps its signature and its cache behavior; no caller changes.

The test verifies against the previous code — reverting the `PerPage` line produces:

```
pagination_test.go:293: request 0 sent per_page="", want 100 (nil ListOptions would send none)
pagination_test.go:304: Nightly missing from statuses [[✅]  CI]; run 35 fell outside the requested page
```

`go build ./...` clean; `go test ./...` passes across all 14 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)